### PR TITLE
vfs: add forget support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libc = ">=0.2.68"
 log = ">=0.4.6"
 nix = ">=0.17"
 vm-memory = ">=0.2.0"
-vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio.git", optional = true }
+vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio.git", branch = "dragonball", optional = true }
 vhost-rs = { git = "https://github.com/cloud-hypervisor/vhost.git", branch = "dragonball", package = "vhost", optional = true }
 
 [dev-dependencies.vm-memory]

--- a/src/api/vfs.rs
+++ b/src/api/vfs.rs
@@ -859,6 +859,18 @@ impl FileSystem for Vfs {
             (Right(fs), idata) => fs.access(ctx, idata.ino, mask),
         }
     }
+
+    fn forget(&self, ctx: Context, inode: Inode, count: u64) {
+        match self.get_real_rootfs(inode) {
+            Ok(real_rootfs) => match real_rootfs {
+                (Left(fs), idata) => fs.forget(ctx, idata.ino, count),
+                (Right(fs), idata) => fs.forget(ctx, idata.ino, count),
+            },
+            Err(e) => {
+                error!("vfs::forget: failed to get_real_rootfs {:?}", e);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/passthrough/fs.rs
+++ b/src/passthrough/fs.rs
@@ -735,6 +735,13 @@ fn forget_one(
             // we don't want misbehaving clients to cause integer overflow.
             let new_count = refcount.saturating_sub(count);
 
+            trace!(
+                "passthrough::forget: inode {} refcount {}, count {}, new_count {}",
+                inode,
+                refcount,
+                count,
+                new_count
+            );
             // Synchronizes with the acquire load in `do_lookup`.
             if data
                 .refcount

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -96,10 +96,10 @@ impl<'a> Reader<'a> {
                 // This can happen if a driver tricks a device into reading more data than
                 // fits in a `usize`.
                 total_len = total_len
-                    .checked_add(desc.len as usize)
+                    .checked_add(desc.len() as usize)
                     .ok_or(Error::DescriptorChainOverflow)?;
 
-                mem.get_slice(desc.addr, desc.len as usize)
+                mem.get_slice(desc.addr(), desc.len() as usize)
                     .map_err(Error::GuestMemoryError)
             })
             .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;
@@ -146,10 +146,10 @@ impl<'a> Writer<'a> {
                 // This can happen if a driver tricks a device into writing more data than
                 // fits in a `usize`.
                 total_len = total_len
-                    .checked_add(desc.len as usize)
+                    .checked_add(desc.len() as usize)
                     .ok_or(Error::DescriptorChainOverflow)?;
 
-                mem.get_slice(desc.addr, desc.len as usize)
+                mem.get_slice(desc.addr(), desc.len() as usize)
                     .map_err(Error::GuestMemoryError)
             })
             .collect::<Result<VecDeque<VolatileSlice<'a>>>>()?;


### PR DESCRIPTION
In some situations, we need to close the fds opened by passthorughfs
on fuse server end, and that requires the help of FUSE_FORGET
requests, a typcial use case is that

# on server end
1) a passthroughfs at /path_to_passthru
2) create a bind mount point at /path_to_passthru/mybind

# on client end
3) ls /pass_to_passthru/mybind
4) echo 2 > /proc/sys/vm/drop_caches # drop dentry reference on inodes
   and send FORGET request

# on server end
5) umount the bind mnt point.

Now in fuse-rs, forget() method is missing in vfs, and that leads to
step 5) to fail because of EBUSY.

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>