### PR TITLE
passthroughfs: do not forget ROOT_ID

### DIFF
--- a/src/passthrough/fs.rs
+++ b/src/passthrough/fs.rs
@@ -724,6 +724,12 @@ fn forget_one(
     inode: Inode,
     count: u64,
 ) {
+    // ROOT_ID should not be forgotten, or we're not able to access to files any
+    // more.
+    if inode == fuse::ROOT_ID {
+        return;
+    }
+
     if let Some(data) = inodes.get(&inode) {
         // Acquiring the write lock on the inode map prevents new lookups from incrementing the
         // refcount but there is the possibility that a previous lookup already acquired a


### PR DESCRIPTION
Typically passthroughfs's fuse client won't send a FORGET fuse request
for ROOT_ID because ROOT_ID is associated with the fuse mount point on
client end, however that is not the case anymore if passthroughfs is
used as a backend fs because the mount point is not the passthroughfs
itself.

So the end result is that EBADF will be returned when accessing any
files in the passthroughfs if the inode of ROOT_ID is forgotten via
FUSE_FORGET request.

This fixes the issue by filtering ROOT_ID inode.

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>