### PR TITLE
fix fd leak after readdirplus

### DIFF
--- a/src/api/vfs.rs
+++ b/src/api/vfs.rs
@@ -293,7 +293,7 @@ impl Vfs {
         }
         let ino: u64 = ((index as u64) << VFS_SUPER_INDEX_SHIFT) | inode;
         trace!(
-            "vfs hash inode index {:x} inode {:x} fuse ino {:x}",
+            "vfs hash inode index {} inode {} fuse ino {:#x}",
             index,
             inode,
             ino


### PR DESCRIPTION
This PR fixes a bug which has been there for a long time way back to crosvm's passthrough version.

It's led to fd leak after readdirplus fuse request is processed, so if the directory accessed by fuse/virtiofs is a mount point, those leaked fds will keep the mount point from being umount.