### PR TITLE
various fixes and improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ homepage = "https://github.com/cloud-hypervisor/"
 arc-swap = ">=0.4.6"
 #async-trait = { version = "0.1.42", optional = true }
 bitflags = ">=1.1.0"
-epoll = { version = "4.0", optional = true }
 #futures = { version = "0.3", optional = true }
 #iou = { version = "0.3.3", optional = true }
 libc = ">=0.2.68"
@@ -43,7 +42,7 @@ features = ["backend-mmap"]
 [features]
 default = ["fusedev"]
 #async-io = ["async-trait", "futures", "iou", "ringbahn"]
-fusedev = ["vmm-sys-util", "epoll"]
+fusedev = ["vmm-sys-util"]
 #virtiofs = ["vm-virtio"]
 #vhost-user-fs = ["virtiofs", "vhost-rs/vhost-user-slave"]
 

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -318,10 +318,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
         // Split the writer into 2 pieces: one for the `OutHeader` and the rest for the data.
         let w2 = match w.split_at(size_of::<OutHeader>()) {
             Ok(v) => v,
-            Err(e) => {
-                debug!("output buffer is too small, {}", e);
-                return Err(Error::InvalidHeaderLength);
-            }
+            Err(_e) => return Err(Error::InvalidHeaderLength),
         };
         let mut data_writer = AsyncZCWriter(w2);
         let result = self

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -183,8 +183,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
             #[cfg(feature = "virtiofs")]
             x if x == Opcode::RemoveMapping as u32 => self.removemapping(in_header, r, w, vu_req),
             _ => {
-                return ctx
-                    .reply_error(io::Error::from_raw_os_error(libc::ENOSYS), w)
+                ctx.reply_error(io::Error::from_raw_os_error(libc::ENOSYS), w)
                     .await
             }
         }

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -680,7 +680,12 @@ mod tests {
         let mut r_buf = [0u8];
         let r = Reader::new(FuseBuf::new(&mut r_buf)).unwrap();
         let file = vmm_sys_util::tempfile::TempFile::new().unwrap();
+        #[cfg(feature = "virtiofs")]
         let w = Writer::new(file.as_file().as_raw_fd(), 0x1000).unwrap();
+        #[cfg(feature = "fusedev")]
+        let mut buf = vec![0x0u8; 1000];
+        #[cfg(feature = "fusedev")]
+        let w = Writer::new(file.as_file().as_raw_fd(), &mut buf).unwrap();
 
         let executor = AsyncExecutor::new(32);
         executor.setup().unwrap();

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -348,7 +348,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
                 w.async_write_all(ctx.drive(), out.as_slice())
                     .await
                     .map_err(Error::EncodeMessage)?;
-                w.async_commit(ctx.drive(), &[&data_writer.0])
+                w.async_commit(ctx.drive(), Some(&data_writer.0))
                     .await
                     .map_err(Error::EncodeMessage)?;
                 Ok(out.len as usize)
@@ -627,7 +627,7 @@ impl<D: AsyncDrive, F: AsyncFileSystem> AsyncContext<D, F> {
             .map_err(Error::EncodeMessage)?;
 
         // Commit header if it is buffered otherwise kernel gets nothing back.
-        w.async_commit(self.drive(), &[])
+        w.async_commit(self.drive(), None)
             .await
             .map(|_| {
                 debug_assert_eq!(header.len as usize, w.bytes_written());

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -416,7 +416,8 @@ impl<F: FileSystem + Sync> Server<F> {
                 };
 
                 w.write_all(out.as_slice()).map_err(Error::EncodeMessage)?;
-                w.commit(&[&data_writer.0]).map_err(Error::EncodeMessage)?;
+                w.commit(Some(&data_writer.0))
+                    .map_err(Error::EncodeMessage)?;
                 Ok(out.len as usize)
             }
             Err(e) => reply_error_explicit(e, in_header.unique, w),
@@ -833,7 +834,7 @@ impl<F: FileSystem + Sync> Server<F> {
             };
 
             w.write_all(out.as_slice()).map_err(Error::EncodeMessage)?;
-            w.commit(&[&cursor]).map_err(Error::EncodeMessage)?;
+            w.commit(Some(&cursor)).map_err(Error::EncodeMessage)?;
             Ok(out.len as usize)
         }
     }
@@ -1246,7 +1247,7 @@ fn do_reply_error(err: io::Error, unique: u64, mut w: Writer, explicit: bool) ->
         .map_err(Error::EncodeMessage)?;
 
     // Commit header if it is buffered otherwise kernel gets nothing back.
-    w.commit(&[])
+    w.commit(None)
         .map(|_| {
             debug_assert_eq!(header.len as usize, w.bytes_written());
             w.bytes_written()

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -724,7 +724,10 @@ impl<F: FileSystem + Sync> Server<F> {
                 if minor < KERNEL_MINOR_VERSION_INIT_OUT_SIZE {
                     reply_ok(
                         Some(
-                            *<[u8; FUSE_COMPAT_INIT_OUT_SIZE]>::from_slice(out.as_slice()).unwrap(),
+                            *<[u8; FUSE_COMPAT_INIT_OUT_SIZE]>::from_slice(
+                                out.as_slice().split_at(FUSE_COMPAT_INIT_OUT_SIZE).0,
+                            )
+                            .unwrap(),
                         ),
                         None,
                         in_header.unique,
@@ -733,8 +736,10 @@ impl<F: FileSystem + Sync> Server<F> {
                 } else if minor < KERNEL_MINOR_VERSION_INIT_22_OUT_SIZE {
                     reply_ok(
                         Some(
-                            *<[u8; FUSE_COMPAT_22_INIT_OUT_SIZE]>::from_slice(out.as_slice())
-                                .unwrap(),
+                            *<[u8; FUSE_COMPAT_22_INIT_OUT_SIZE]>::from_slice(
+                                out.as_slice().split_at(FUSE_COMPAT_22_INIT_OUT_SIZE).0,
+                            )
+                            .unwrap(),
                         ),
                         None,
                         in_header.unique,

--- a/src/async_util.rs
+++ b/src/async_util.rs
@@ -466,7 +466,9 @@ impl AsyncExecutorState {
 
     /// Start to quiesce the executor/tasks.
     pub fn quiesce(&self) {
-        self.0.compare_and_swap(0, 1, Ordering::SeqCst);
+        let _ = self
+            .0
+            .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst);
     }
 
     /// Check whether the executor is in quiescing state.

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -215,7 +215,11 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
                     let new = curr.saturating_add(1);
 
                     // Synchronizes with the forgot_one()
-                    if data.refcount.compare_and_swap(curr, new, Ordering::AcqRel) == curr {
+                    if data
+                        .refcount
+                        .compare_exchange(curr, new, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
                         found = Some(data.inode);
                         break;
                     }

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -503,7 +503,11 @@ impl<D: AsyncDrive> PassthroughFs<D> {
                     let new = curr.saturating_add(1);
 
                     // Synchronizes with the forgot_one()
-                    if data.refcount.compare_and_swap(curr, new, Ordering::AcqRel) == curr {
+                    if data
+                        .refcount
+                        .compare_exchange(curr, new, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
                         found = Some(data.inode);
                         break;
                     }
@@ -589,7 +593,11 @@ impl<D: AsyncDrive> PassthroughFs<D> {
                 );
 
                 // Synchronizes with the acquire load in `do_lookup`.
-                if data.refcount.compare_and_swap(curr, new, Ordering::AcqRel) == curr {
+                if data
+                    .refcount
+                    .compare_exchange(curr, new, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
                     if new == 0 {
                         // We just removed the last refcount for this inode.
                         inodes.remove(&inode);

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -182,7 +182,7 @@ impl<'a> Writer<'a> {
 
     /// Returns number of bytes already written to the internal buffer.
     pub fn bytes_written(&self) -> usize {
-        return self.buf.len();
+        self.buf.len()
     }
 
     /// Returns number of bytes available for writing.

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -8,12 +8,9 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::io::{self, IoSlice, Write};
 use std::marker::PhantomData;
-#[cfg(feature = "async-io")]
 use std::os::unix::io::RawFd;
 
-use libc::c_int;
 use nix::sys::uio::{pwrite, writev, IoVec};
-
 use vm_memory::{ByteValued, VolatileMemory, VolatileMemoryError, VolatileSlice};
 
 use super::{FileReadWriteVolatile, IoBuffers, Reader};
@@ -108,7 +105,7 @@ impl<'a> Reader<'a> {
 /// 3. Concurrency, caller should not write to the writer concurrently.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Writer<'a> {
-    fd: c_int,
+    fd: RawFd,
     max_size: usize,
     bytes_written: usize,
     // buf used to support split writer.
@@ -121,7 +118,7 @@ pub struct Writer<'a> {
 
 impl<'a> Writer<'a> {
     /// Construct a new Writer
-    pub fn new(fd: c_int, max_size: usize) -> Result<Writer<'a>> {
+    pub fn new(fd: RawFd, max_size: usize) -> Result<Writer<'a>> {
         Ok(Writer {
             fd,
             max_size,

--- a/src/transport/fusedev/session.rs
+++ b/src/transport/fusedev/session.rs
@@ -347,3 +347,165 @@ mod tests {
         assert!(ch.is_ok());
     }
 }
+
+#[cfg(feature = "async-io")]
+pub use asyncio::FuseDevTask;
+
+#[cfg(feature = "async-io")]
+/// Task context to handle fuse request in asynchronous mode.
+mod asyncio {
+    use std::os::unix::io::RawFd;
+    use std::sync::Arc;
+
+    use crate::api::filesystem::AsyncFileSystem;
+    use crate::api::server::Server;
+    use crate::async_util::{AsyncDriver, AsyncExecutorState, AsyncUtil};
+    use crate::transport::{FuseBuf, Reader, Writer};
+
+    /// Task context to handle fuse request in asynchronous mode.
+    ///
+    /// This structure provides a context to handle fuse request in asynchronous mode, including
+    /// the fuse fd, a internal buffer and a `Server` instance to serve requests.
+    ///
+    /// ## Examples
+    /// ```ignore
+    /// let buf_size = 0x1_0000;
+    /// let state = AsyncExecutorState::new();
+    /// let mut task = FuseDevTask::new(buf_size, fuse_dev_fd, fs_server, state.clone());
+    ///
+    /// // Run the task
+    /// executor.spawn(async move { task.poll_handler().await });
+    ///
+    /// // Stop the task
+    /// state.quiesce();
+    /// ```
+    pub struct FuseDevTask<F: AsyncFileSystem + Sync> {
+        fd: RawFd,
+        buf: Vec<u8>,
+        state: AsyncExecutorState,
+        server: Arc<Server<F>>,
+    }
+
+    impl<F: AsyncFileSystem + Sync> FuseDevTask<F> {
+        /// Create a new fuse task context for asynchronous IO.
+        ///
+        /// # Parameters
+        /// - buf_size: size of buffer to receive requests from/send reply to the fuse fd
+        /// - fd: fuse device file descriptor
+        /// - server: `Server` instance to serve requests from the fuse fd
+        /// - state: shared state object to control the task object
+        ///
+        /// # Safety
+        /// The caller must ensure `fd` is valid during the lifetime of the returned task object.
+        pub fn new(
+            buf_size: usize,
+            fd: RawFd,
+            server: Arc<Server<F>>,
+            state: AsyncExecutorState,
+        ) -> Self {
+            FuseDevTask {
+                fd,
+                server,
+                state,
+                buf: vec![0x0u8; buf_size],
+            }
+        }
+
+        /// Handler to process fuse requests in asynchronous mode.
+        ///
+        /// An async fn to handle requests from the fuse fd. It works in asynchronous IO mode when:
+        /// - receiving request from fuse fd
+        /// - handling requests by calling Server::async_handle_requests()
+        /// - sending reply to fuse fd
+        ///
+        /// The async fn repeatedly return Poll::Pending when polled until the state has been set
+        /// to quiesce mode.
+        pub async fn poll_handler(&mut self) {
+            // TODO: register self.buf as io uring buffers.
+            let drive = AsyncDriver::default();
+            let msg_size = self.buf.capacity();
+
+            while !self.state.quiescing() {
+                let result = AsyncUtil::read(drive.clone(), self.fd, &mut self.buf, 0).await;
+                match result {
+                    Ok(len) => {
+                        // Reader::new() and Writer::new() should always return success.
+                        let reader = Reader::new(FuseBuf::new(&mut self.buf[0..len])).unwrap();
+                        let writer = Writer::new(self.fd, msg_size).unwrap();
+                        let result = unsafe {
+                            self.server
+                                .async_handle_message(drive.clone(), reader, writer, None)
+                                .await
+                        };
+
+                        if let Err(e) = result {
+                            // TODO: error handling
+                            error!("failed to handle fuse request, {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        // TODO: error handling
+                        error!("failed to read request from fuse device fd, {}", e);
+                    }
+                }
+            }
+
+            // TODO: unregister self.buf as io uring buffers.
+
+            // Report that the task has been quiesced.
+            self.state.report();
+        }
+    }
+
+    impl<F: AsyncFileSystem + Sync> Clone for FuseDevTask<F> {
+        fn clone(&self) -> Self {
+            FuseDevTask {
+                fd: self.fd,
+                server: self.server.clone(),
+                state: self.state.clone(),
+                buf: vec![0x0u8; self.buf.capacity()],
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::os::unix::io::AsRawFd;
+
+        use super::*;
+        use crate::api::{Vfs, VfsOptions};
+        use crate::async_util::AsyncExecutor;
+
+        #[test]
+        fn test_fuse_task() {
+            let state = AsyncExecutorState::new();
+            let fs = Vfs::<AsyncDriver>::new(VfsOptions::default());
+            let server = Arc::new(Server::new(fs));
+            let file = vmm_sys_util::tempfile::TempFile::new().unwrap();
+            let fd = file.as_file().as_raw_fd();
+
+            let mut executor = AsyncExecutor::new(32);
+            executor.setup().unwrap();
+
+            // Create three tasks, which could handle three concurrent fuse requests.
+            let mut task = FuseDevTask::new(0x1000, fd, server.clone(), state.clone());
+            executor
+                .spawn(async move { task.poll_handler().await })
+                .unwrap();
+            let mut task = FuseDevTask::new(0x1000, fd, server.clone(), state.clone());
+            executor
+                .spawn(async move { task.poll_handler().await })
+                .unwrap();
+            let mut task = FuseDevTask::new(0x1000, fd, server.clone(), state.clone());
+            executor
+                .spawn(async move { task.poll_handler().await })
+                .unwrap();
+
+            for _i in 0..10 {
+                executor.run_once(false).unwrap();
+            }
+            state.quiesce();
+            executor.run_once(false).unwrap();
+        }
+    }
+}

--- a/src/transport/fusedev/session.rs
+++ b/src/transport/fusedev/session.rs
@@ -334,9 +334,9 @@ fn fuse_kern_umount(mountpoint: &str, file: File) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::io::FromRawFd;
     use std::path::Path;
     use vmm_sys_util::tempdir::TempDir;
-    use vmm_sys_util::tempfile::TempFile;
 
     #[test]
     fn test_new_session() {
@@ -351,7 +351,7 @@ mod tests {
     #[test]
     fn test_new_channel() {
         let ch = FuseChannel::new(
-            TempFile::new().unwrap().into_file(),
+            unsafe { File::from_raw_fd(EventFd::new(0).unwrap().as_raw_fd()) },
             EventFd::new(0).unwrap(),
             3,
         );

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -10,9 +10,9 @@
 
 use std::cmp;
 use std::collections::VecDeque;
-use std::io::{self, Read};
 #[cfg(feature = "async-io")]
-use std::io::{IoSlice, IoSliceMut};
+use std::io::IoSliceMut;
+use std::io::{self, Read};
 use std::mem::{size_of, MaybeUninit};
 use std::ptr::copy_nonoverlapping;
 
@@ -78,7 +78,7 @@ impl<'a> IoBuffers<'a> {
     }
 
     #[cfg(feature = "async-io")]
-    fn allocate_io_slice(&self, count: usize) -> Vec<IoSlice> {
+    fn allocate_io_slice(&self, count: usize) -> Vec<IoSliceMut> {
         let mut rem = count;
         let mut bufs = Vec::with_capacity(self.buffers.len());
 
@@ -96,8 +96,8 @@ impl<'a> IoBuffers<'a> {
                 buf
             };
             // Safe because we just change the interface to access underlying buffers.
-            bufs.push(IoSlice::new(unsafe {
-                std::slice::from_raw_parts(local_buf.as_ptr(), local_buf.len())
+            bufs.push(IoSliceMut::new(unsafe {
+                std::slice::from_raw_parts_mut(local_buf.as_ptr(), local_buf.len())
             }));
 
             // Don't need check_sub() as we just made sure rem >= local_buf.len()

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -267,7 +267,7 @@ impl<'a> Writer<'a> {
 
     /// Commit all internal buffers of self and others
     /// This is provided just to be compatible with fusedev
-    pub fn commit(&mut self, _others: &[&Writer<'a>]) -> io::Result<usize> {
+    pub fn commit(&mut self, _other: Option<&Writer<'a>>) -> io::Result<usize> {
         Ok(0)
     }
 
@@ -407,9 +407,9 @@ mod async_io {
         pub async fn async_commit<D: AsyncDrive>(
             &mut self,
             _drive: D,
-            others: &[&Writer<'a>],
+            other: Option<&Writer<'a>>,
         ) -> io::Result<usize> {
-            self.commit(others)
+            self.commit(other)
         }
     }
 }

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -363,6 +363,41 @@ mod async_io {
             self.write(data)
         }
 
+        /// Write data from two buffers into this writer in asynchronous mode.
+        pub async fn async_write2<D: AsyncDrive>(
+            &mut self,
+            _drive: D,
+            data: &[u8],
+            data2: &[u8],
+        ) -> io::Result<usize> {
+            let len = data.len() + data2.len();
+            self.check_available_space(len)?;
+
+            let mut cnt = self.write(data)?;
+            cnt += self.write(data2)?;
+
+            Ok(cnt)
+        }
+
+        /// Write data from two buffers into this writer in asynchronous mode.
+        pub async fn async_write3<D: AsyncDrive>(
+            &mut self,
+            _drive: D,
+            data: &[u8],
+            data2: &[u8],
+            data3: &[u8],
+        ) -> io::Result<usize> {
+            let len = data.len() + data2.len() + data3.len();
+            self.check_available_space(len)?;
+
+            let mut cnt = self.write(data)?;
+            cnt += self.write(data2)?;
+            cnt += self.write(data3)?;
+
+            Ok(cnt)
+        }
+
+        /*
         /// Write data from a group of buffers into this writer in asynchronous mode, skipping empty
         /// buffers.
         pub async fn async_write_vectored<D: AsyncDrive>(
@@ -372,6 +407,7 @@ mod async_io {
         ) -> io::Result<usize> {
             self.write_vectored(bufs)
         }
+         */
 
         /// Attempts to write an entire buffer into this writer in asynchronous mode.
         pub async fn async_write_all<D: AsyncDrive>(
@@ -392,11 +428,11 @@ mod async_io {
             off: u64,
         ) -> io::Result<usize> {
             self.check_available_space(count)?;
-            let bufs = self.buffers.allocate_mut_io_slice(count);
+            let mut bufs = self.buffers.allocate_mut_io_slice(count);
             if bufs.is_empty() {
                 Ok(0)
             } else {
-                let result = AsyncUtil::read_vectored(drive, src, &bufs, off).await?;
+                let result = AsyncUtil::read_vectored(drive, src, &mut bufs, off).await?;
                 self.buffers.mark_used(count)?;
                 Ok(result)
             }

--- a/tests/example/passthroughfs.rs
+++ b/tests/example/passthroughfs.rs
@@ -58,7 +58,7 @@ impl Daemon {
         let mut se = FuseSession::new(Path::new(&self.mountpoint), "passthru_example", "").unwrap();
         se.mount().unwrap();
         for _ in 0..self.thread_cnt {
-            let server = FuseServer {
+            let mut server = FuseServer {
                 server: self.server.clone(),
                 ch: se.new_channel(self.event_fd.try_clone().unwrap()).unwrap(),
             };
@@ -97,21 +97,15 @@ struct FuseServer {
 }
 
 impl FuseServer {
-    fn svc_loop(&self) -> Result<()> {
-        let mut buf = vec![0x0u8; 1024 * 1024];
-
+    fn svc_loop(&mut self) -> Result<()> {
         // Given error EBADF, it means kernel has shut down this session.
         let _ebadf = std::io::Error::from_raw_os_error(libc::EBADF);
         loop {
-            if let Some(reader) = self
+            if let Some((reader, writer)) = self
                 .ch
-                .get_reader(&mut buf)
+                .get_request()
                 .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?
             {
-                let writer = self
-                    .ch
-                    .get_writer()
-                    .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
                 if let Err(e) = self.server.handle_message(reader, writer, None, None) {
                     match e {
                         fuse_backend_rs::Error::EncodeMessage(_ebadf) => {


### PR DESCRIPTION
Changwei Ge (1):
      api: fix fuse init-msg response overflow

Eryu Guan (1):
      passthroughfs: don't overwrite existing inode with the same altkey

Liu Jiang (9):
      transport/fusedev: refine doc of session manager
      transport/fusedev: refine FuseChannel
      transport/fusedev: refactor FuseSession interfaces
      transport/fusedev: replace epoll with vmm_sys_util::Poll
      transport/fusedev: remove several unwrap()
      transport: simplify Writer::commit()
      async-io: move FuseDevTask to session.rs
      transport/fusedev: preallocate buffer for Writer
      transport: replace Writer::write_vector()

Peng Tao (3):
      clippy: fix unneeded return statements
      tests: fix test_new_channel
      tests: do not ignore smoke