### PR TITLE
vfs: disable ATOMIC_O_TRUNC when no_open is set

### DIFF
--- a/src/abi/linux_abi.rs
+++ b/src/abi/linux_abi.rs
@@ -532,25 +532,25 @@ impl From<libc::stat64> for Attr {
     }
 }
 
-impl Into<libc::stat64> for Attr {
-    fn into(self) -> libc::stat64 {
+impl From<Attr> for libc::stat64 {
+    fn from(attr: Attr) -> libc::stat64 {
         // Safe because we are zero-initializing a struct
         let mut out: libc::stat64 = unsafe { mem::zeroed() };
-        out.st_ino = self.ino;
-        out.st_size = self.size as i64;
-        out.st_blocks = self.blocks as i64;
-        out.st_atime = self.atime as i64;
-        out.st_mtime = self.mtime as i64;
-        out.st_ctime = self.ctime as i64;
-        out.st_atime_nsec = self.atimensec as i64;
-        out.st_mtime_nsec = self.mtimensec as i64;
-        out.st_ctime_nsec = self.ctimensec as i64;
-        out.st_mode = self.mode;
-        out.st_nlink = self.nlink as nlink_t;
-        out.st_uid = self.uid;
-        out.st_gid = self.gid;
-        out.st_rdev = self.rdev as u64;
-        out.st_blksize = self.blksize as blksize_t;
+        out.st_ino = attr.ino;
+        out.st_size = attr.size as i64;
+        out.st_blocks = attr.blocks as i64;
+        out.st_atime = attr.atime as i64;
+        out.st_mtime = attr.mtime as i64;
+        out.st_ctime = attr.ctime as i64;
+        out.st_atime_nsec = attr.atimensec as i64;
+        out.st_mtime_nsec = attr.mtimensec as i64;
+        out.st_ctime_nsec = attr.ctimensec as i64;
+        out.st_mode = attr.mode;
+        out.st_nlink = attr.nlink as nlink_t;
+        out.st_uid = attr.uid;
+        out.st_gid = attr.gid;
+        out.st_rdev = attr.rdev as u64;
+        out.st_blksize = attr.blksize as blksize_t;
 
         out
     }
@@ -794,20 +794,20 @@ pub struct SetattrIn {
 }
 unsafe impl ByteValued for SetattrIn {}
 
-impl Into<libc::stat64> for SetattrIn {
-    fn into(self) -> libc::stat64 {
+impl From<SetattrIn> for libc::stat64 {
+    fn from(attr: SetattrIn) -> libc::stat64 {
         // Safe because we are zero-initializing a struct with only POD fields.
         let mut out: libc::stat64 = unsafe { mem::zeroed() };
-        out.st_mode = self.mode;
-        out.st_uid = self.uid;
-        out.st_gid = self.gid;
-        out.st_size = self.size as i64;
-        out.st_atime = self.atime as i64;
-        out.st_mtime = self.mtime as i64;
-        out.st_ctime = self.ctime as i64;
-        out.st_atime_nsec = i64::from(self.atimensec);
-        out.st_mtime_nsec = i64::from(self.mtimensec);
-        out.st_ctime_nsec = i64::from(self.ctimensec);
+        out.st_mode = attr.mode;
+        out.st_uid = attr.uid;
+        out.st_gid = attr.gid;
+        out.st_size = attr.size as i64;
+        out.st_atime = attr.atime as i64;
+        out.st_mtime = attr.mtime as i64;
+        out.st_ctime = attr.ctime as i64;
+        out.st_atime_nsec = i64::from(attr.atimensec);
+        out.st_mtime_nsec = i64::from(attr.mtimensec);
+        out.st_ctime_nsec = i64::from(attr.ctimensec);
 
         out
     }

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -56,9 +56,9 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 }
 
-struct ZCReader<'a>(Reader<'a>);
+struct ZcReader<'a>(Reader<'a>);
 
-impl<'a> ZeroCopyReader for ZCReader<'a> {
+impl<'a> ZeroCopyReader for ZcReader<'a> {
     fn read_to(
         &mut self,
         f: &mut dyn FileReadWriteVolatile,
@@ -69,15 +69,15 @@ impl<'a> ZeroCopyReader for ZCReader<'a> {
     }
 }
 
-impl<'a> io::Read for ZCReader<'a> {
+impl<'a> io::Read for ZcReader<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
 }
 
-struct ZCWriter<'a>(Writer<'a>);
+struct ZcWriter<'a>(Writer<'a>);
 
-impl<'a> ZeroCopyWriter for ZCWriter<'a> {
+impl<'a> ZeroCopyWriter for ZcWriter<'a> {
     fn write_from(
         &mut self,
         f: &mut dyn FileReadWriteVolatile,
@@ -88,7 +88,7 @@ impl<'a> ZeroCopyWriter for ZCWriter<'a> {
     }
 }
 
-impl<'a> io::Write for ZCWriter<'a> {
+impl<'a> io::Write for ZcWriter<'a> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use vm_memory::ByteValued;
 
 use super::{
-    Server, ServerUtil, ServerVersion, ZCReader, ZCWriter, DIRENT_PADDING, MAX_BUFFER_SIZE,
+    Server, ServerUtil, ServerVersion, ZcReader, ZcWriter, DIRENT_PADDING, MAX_BUFFER_SIZE,
     MAX_REQ_PAGES,
 };
 use crate::abi::linux_abi::*;
@@ -403,7 +403,7 @@ impl<F: FileSystem + Sync> Server<F> {
             Ok(v) => v,
             Err(_e) => return Err(Error::InvalidHeaderLength),
         };
-        let mut data_writer = ZCWriter(w2);
+        let mut data_writer = ZcWriter(w2);
 
         match self.fs.read(
             Context::from(in_header),
@@ -460,7 +460,7 @@ impl<F: FileSystem + Sync> Server<F> {
 
         let delayed_write = write_flags & WRITE_CACHE != 0;
 
-        let mut data_reader = ZCReader(r);
+        let mut data_reader = ZcReader(r);
 
         match self.fs.write(
             Context::from(in_header),

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -703,8 +703,7 @@ impl<F: FileSystem + Sync> Server<F> {
             | FsOptions::ASYNC_DIO
             | FsOptions::HAS_IOCTL_DIR
             | FsOptions::MAX_PAGES
-            | FsOptions::EXPLICIT_INVAL_DATA
-            | FsOptions::ATOMIC_O_TRUNC;
+            | FsOptions::EXPLICIT_INVAL_DATA;
 
         let capable = FsOptions::from_bits_truncate(flags);
 

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -16,6 +16,8 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
         let mut n_opts = *self.opts.load().deref().deref();
         if n_opts.no_open {
             n_opts.no_open = !(opts & FsOptions::ZERO_MESSAGE_OPEN).is_empty();
+            // We can't support FUSE_ATOMIC_O_TRUNC with no_open
+            n_opts.out_opts.remove(FsOptions::ATOMIC_O_TRUNC);
         }
         n_opts.no_opendir = !(opts & FsOptions::ZERO_MESSAGE_OPENDIR).is_empty();
         if n_opts.no_writeback {

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -345,6 +345,8 @@ impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
             && capable.contains(FsOptions::ZERO_MESSAGE_OPEN)
         {
             opts |= FsOptions::ZERO_MESSAGE_OPEN;
+            // We can't support FUSE_ATOMIC_O_TRUNC with no_open
+            opts.remove(FsOptions::ATOMIC_O_TRUNC);
             self.no_open.store(true, Ordering::Relaxed);
         }
         if (!self.cfg.do_import || self.cfg.no_opendir)


### PR DESCRIPTION
When no_open is enabled, kernel doesn't send open request to fuse
server, so there's no chance for fuse server to handle O_TRUNC open
flag and truncate file to 0. This ends up in non-zero file after a
O_TRUNC open.

Fix it by disabling ATOMIC_O_TRUNC feature when no_open is set, so that
fuse will send setattr request to do the truncate.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>