### PR TITLE
support fuse kill_priv_v2 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = ">=1.1.0"
 libc = ">=0.2.68"
 log = ">=0.4.6"
 nix = "0.18.0"
+caps = "0.5.1"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
 vmm-sys-util = { version = "0.4", optional = true }
 vm-memory = "0.5"

--- a/src/abi/linux_abi.rs
+++ b/src/abi/linux_abi.rs
@@ -908,7 +908,7 @@ pub struct WriteIn {
     pub fh: u64,
     pub offset: u64,
     pub size: u32,
-    pub write_flags: u32,
+    pub fuse_flags: u32,
     pub lock_owner: u64,
     pub flags: u32,
     pub padding: u32,

--- a/src/abi/linux_abi.rs
+++ b/src/abi/linux_abi.rs
@@ -846,7 +846,7 @@ impl From<SetattrIn> for libc::stat64 {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct OpenIn {
     pub flags: u32,
-    pub unused: u32,
+    pub fuse_flags: u32,
 }
 unsafe impl ByteValued for OpenIn {}
 
@@ -856,7 +856,7 @@ pub struct CreateIn {
     pub flags: u32,
     pub mode: u32,
     pub umask: u32,
-    pub padding: u32,
+    pub fuse_flags: u32,
 }
 unsafe impl ByteValued for CreateIn {}
 

--- a/src/api/filesystem/async_io.rs
+++ b/src/api/filesystem/async_io.rs
@@ -403,6 +403,7 @@ pub trait AsyncFileSystem: FileSystem {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> io::Result<usize>;
 
     /*
@@ -952,6 +953,7 @@ impl<FS: AsyncFileSystem> AsyncFileSystem for Arc<FS> {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> Pin<Box<dyn Future<Output = io::Result<usize>> + Send + 'async_trait>>
     where
         'a: 'async_trait,
@@ -968,6 +970,7 @@ impl<FS: AsyncFileSystem> AsyncFileSystem for Arc<FS> {
             lock_owner,
             delayed_write,
             flags,
+            fuse_flags,
         )
     }
 

--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -402,6 +402,7 @@ pub trait FileSystem {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> io::Result<usize> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
@@ -1000,6 +1001,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> io::Result<usize> {
         self.deref().write(
             ctx,
@@ -1011,6 +1013,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
             lock_owner,
             delayed_write,
             flags,
+            fuse_flags,
         )
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,6 +15,7 @@
 mod pseudo_fs;
 
 pub mod vfs;
+pub use super::abi::linux_abi::CreateIn;
 pub use vfs::{BackendFileSystem, Vfs, VfsOptions, VFS_MAX_INO};
 
 pub mod filesystem;

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -379,7 +379,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
             fh,
             offset,
             size,
-            write_flags,
+            fuse_flags,
             lock_owner,
             flags,
             ..
@@ -391,12 +391,12 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
                 .await;
         }
 
-        let owner = if write_flags & WRITE_LOCKOWNER != 0 {
+        let owner = if fuse_flags & WRITE_LOCKOWNER != 0 {
             Some(lock_owner)
         } else {
             None
         };
-        let delayed_write = write_flags & WRITE_CACHE != 0;
+        let delayed_write = fuse_flags & WRITE_CACHE != 0;
         let mut data_reader = AsyncZcReader(r);
         let result = self
             .fs
@@ -410,6 +410,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
                 owner,
                 delayed_write,
                 flags,
+                fuse_flags,
             )
             .await;
 

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -440,7 +440,7 @@ impl<F: FileSystem + Sync> Server<F> {
             fh,
             offset,
             size,
-            write_flags,
+            fuse_flags,
             lock_owner,
             flags,
             ..
@@ -454,13 +454,13 @@ impl<F: FileSystem + Sync> Server<F> {
             );
         }
 
-        let owner = if write_flags & WRITE_LOCKOWNER != 0 {
+        let owner = if fuse_flags & WRITE_LOCKOWNER != 0 {
             Some(lock_owner)
         } else {
             None
         };
 
-        let delayed_write = write_flags & WRITE_CACHE != 0;
+        let delayed_write = fuse_flags & WRITE_CACHE != 0;
 
         let mut data_reader = ZcReader(r);
 
@@ -474,6 +474,7 @@ impl<F: FileSystem + Sync> Server<F> {
             owner,
             delayed_write,
             flags,
+            fuse_flags,
         ) {
             Ok(count) => {
                 let out = WriteOut {

--- a/src/api/vfs/async_io.rs
+++ b/src/api/vfs/async_io.rs
@@ -133,6 +133,7 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for Vfs<D> {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> Result<usize> {
         match self.get_real_rootfs(inode)? {
             (Left(_fs), _idata) => Err(io::Error::from_raw_os_error(libc::ENOSYS)),
@@ -147,6 +148,7 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for Vfs<D> {
                     lock_owner,
                     delayed_write,
                     flags,
+                    fuse_flags,
                 )
                 .await
             }

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -174,6 +174,10 @@ pub struct VfsOptions {
     /// Disable fuse WRITEBACK_CACHE option so that kernel will not cache
     /// buffer writes.
     pub no_writeback: bool,
+    /// Enable fuse killpriv_v2 support. When enabled, fuse file system makes sure
+    /// to remove security.capability xattr and setuid/setgid bits. See details in
+    /// comments for HANDLE_KILLPRIV_V2
+    pub killpriv_v2: bool,
     /// File system options passed in from client
     pub in_opts: FsOptions,
     /// File system options returned to client
@@ -186,6 +190,7 @@ impl Default for VfsOptions {
             no_open: true,
             no_opendir: true,
             no_writeback: false,
+            killpriv_v2: false,
             in_opts: FsOptions::empty(),
             out_opts: FsOptions::ASYNC_READ
                 | FsOptions::PARALLEL_DIROPS
@@ -198,7 +203,8 @@ impl Default for VfsOptions {
                 | FsOptions::CACHE_SYMLINKS
                 | FsOptions::DO_READDIRPLUS
                 | FsOptions::READDIRPLUS_AUTO
-                | FsOptions::ZERO_MESSAGE_OPENDIR,
+                | FsOptions::ZERO_MESSAGE_OPENDIR
+                | FsOptions::HANDLE_KILLPRIV_V2,
         }
     }
 }
@@ -859,12 +865,14 @@ mod tests {
             | FsOptions::CACHE_SYMLINKS
             | FsOptions::DO_READDIRPLUS
             | FsOptions::READDIRPLUS_AUTO
-            | FsOptions::ZERO_MESSAGE_OPENDIR;
+            | FsOptions::ZERO_MESSAGE_OPENDIR
+            | FsOptions::HANDLE_KILLPRIV_V2;
         let opts = vfs.opts.load();
 
         assert_eq!(opts.no_open, true);
         assert_eq!(opts.no_opendir, true);
         assert_eq!(opts.no_writeback, false);
+        assert_eq!(opts.killpriv_v2, false);
         assert_eq!(opts.in_opts, FsOptions::empty());
         assert_eq!(opts.out_opts, out_opts);
 
@@ -875,6 +883,8 @@ mod tests {
         assert_eq!(opts.no_open, false);
         assert_eq!(opts.no_opendir, false);
         assert_eq!(opts.no_writeback, false);
+        assert_eq!(opts.killpriv_v2, false);
+        assert_eq!(opts.killpriv_v2, false);
 
         vfs.destroy();
         assert!(vfs.initialized());
@@ -887,6 +897,7 @@ mod tests {
         assert_eq!(opts.no_open, true);
         assert_eq!(opts.no_opendir, true);
         assert_eq!(opts.no_writeback, false);
+        assert_eq!(opts.killpriv_v2, false);
         assert_eq!(opts.out_opts, out_opts & in_opts);
     }
 

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -312,6 +312,7 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
         lock_owner: Option<u64>,
         delayed_write: bool,
         flags: u32,
+        fuse_flags: u32,
     ) -> Result<usize> {
         match self.get_real_rootfs(inode)? {
             (Left(fs), idata) => fs.write(
@@ -324,6 +325,7 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
                 lock_owner,
                 delayed_write,
                 flags,
+                fuse_flags,
             ),
             (Right(fs), idata) => fs.write(
                 ctx,
@@ -335,6 +337,7 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
                 lock_owner,
                 delayed_write,
                 flags,
+                fuse_flags,
             ),
         }
     }

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -23,6 +23,9 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
         if n_opts.no_writeback {
             n_opts.out_opts.remove(FsOptions::WRITEBACK_CACHE);
         }
+        if !n_opts.killpriv_v2 {
+            n_opts.out_opts.remove(FsOptions::HANDLE_KILLPRIV_V2);
+        }
         n_opts.in_opts = opts;
 
         n_opts.out_opts &= opts;

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -97,8 +97,9 @@ impl<D: AsyncDrive> PassthroughFs<D> {
         ctx: &Context,
         inode: Inode,
         flags: u32,
-        fuse_flags: u32,
+        _fuse_flags: u32,
     ) -> io::Result<(Option<Handle>, OpenOptions)> {
+        // FIXME: handle FOPEN_IN_KILL_SUIDGID properly
         let file = self.async_open_inode(ctx, inode, flags as i32).await?;
         let data = HandleData::new(inode, file);
         let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -500,6 +500,7 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
         _lock_owner: Option<u64>,
         _delayed_write: bool,
         _flags: u32,
+        _fuse_flags: u32,
     ) -> io::Result<usize> {
         let data = self
             .async_get_data(&ctx, handle, inode, libc::O_RDWR)
@@ -508,6 +509,7 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
             .get_drive::<D>()
             .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
 
+        // FIXME: handle WRITE_KILL_PRIV properly
         r.async_read_to(drive, data.get_handle_raw_fd(), size as usize, offset)
             .await
     }

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -702,7 +702,8 @@ impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
         offset: u64,
         _lock_owner: Option<u64>,
         _delayed_write: bool,
-        flags: u32,
+        _flags: u32,
+        fuse_flags: u32,
     ) -> io::Result<usize> {
         let data = self.get_data(handle, inode, libc::O_RDWR)?;
 
@@ -714,7 +715,7 @@ impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
 
         // Cap restored when _killpriv is dropped
         let _killpriv =
-            if self.killpriv_v2.load(Ordering::Relaxed) && (flags & WRITE_KILL_PRIV != 0) {
+            if self.killpriv_v2.load(Ordering::Relaxed) && (fuse_flags & WRITE_KILL_PRIV != 0) {
                 self::drop_cap_fsetid()?
             } else {
                 None


### PR DESCRIPTION
So that we can make kernel skip querying file system about a file's xattr during write, which would kill wirte performance.