### PR TITLE
Enhance passthrough to reduce active fds by using file handle

### DIFF
--- a/CHAGNELOG.md
+++ b/CHAGNELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [Unreleased]
+
+### Added
+- Enhance passthrough to reduce active fds by using file handle
+
+### Fixed
+
+### Deprecated 
 
 ## [v0.1.2]
 - support KILLPRIV_v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,15 @@ log = ">=0.4.6"
 nix = "0.18.0"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
 vmm-sys-util = { version = "0.4", optional = true }
-vm-memory = "0.5"
+vm-memory = "0.6"
 #vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio.git", branch = "dragonball", optional = true }
 #vhost-rs = { git = "https://github.com/cloud-hypervisor/vhost.git", branch = "dragonball", package = "vhost", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.0", features = ["thread-pool"]}
-vmm-sys-util = "0.4"
 stderrlog = "0.4"
-
-[dev-dependencies.vm-memory]
-version = "0.5"
-features = ["backend-mmap"]
+vmm-sys-util = "0.4"
+vm-memory = { version = "0.6", features = ["backend-mmap"] }
 
 [features]
 default = ["fusedev"]

--- a/src/api/filesystem/async_io.rs
+++ b/src/api/filesystem/async_io.rs
@@ -73,7 +73,7 @@ pub trait AsyncZeroCopyWriter<D: AsyncDrive = AsyncDriver, S: BitmapSlice = ()>:
     ) -> io::Result<usize>;
 }
 
-/// The main trait that connects a file system with a transport.
+/// The main trait that connects a file system with a transport with asynchronous IO.
 #[allow(unused_variables)]
 #[async_trait]
 pub trait AsyncFileSystem<D: AsyncDrive = AsyncDriver, S: BitmapSlice = ()>: FileSystem<S> {

--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -377,6 +377,18 @@ impl Context {
     }
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Context {
+            uid: 0,
+            gid: 0,
+            pid: 0,
+            #[cfg(feature = "async-io")]
+            drive: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -703,7 +703,7 @@ mod tests {
             parent: <Self as FileSystem>::Inode,
             name: &CStr,
         ) -> Result<Entry> {
-            unimplemented!()
+            Err(std::io::Error::from_raw_os_error(libc::EINVAL))
         }
 
         async fn async_getattr(

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -22,6 +22,8 @@ impl<D: AsyncDrive, S: BitmapSlice> FileSystem<S> for Vfs<D, S> {
             n_opts.no_open = !(opts & FsOptions::ZERO_MESSAGE_OPEN).is_empty();
             // We can't support FUSE_ATOMIC_O_TRUNC with no_open
             n_opts.out_opts.remove(FsOptions::ATOMIC_O_TRUNC);
+        } else {
+            n_opts.out_opts.remove(FsOptions::ZERO_MESSAGE_OPEN);
         }
         n_opts.no_opendir = !(opts & FsOptions::ZERO_MESSAGE_OPENDIR).is_empty();
         if n_opts.no_writeback {

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -8,7 +8,7 @@ use crate::async_util::AsyncDrive;
 #[cfg(any(feature = "vhost-user-fs", feature = "virtiofs"))]
 use crate::transport::FsCacheReqHandler;
 
-impl<D: AsyncDrive> FileSystem for Vfs<D> {
+impl<D: AsyncDrive, S: BitmapSlice> FileSystem<S> for Vfs<D, S> {
     type Inode = VfsInode;
     type Handle = VfsHandle;
 
@@ -288,7 +288,7 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
         ctx: Context,
         inode: VfsInode,
         handle: u64,
-        w: &mut dyn ZeroCopyWriter,
+        w: &mut dyn ZeroCopyWriter<S = S>,
         size: u32,
         offset: u64,
         lock_owner: Option<u64>,
@@ -309,7 +309,7 @@ impl<D: AsyncDrive> FileSystem for Vfs<D> {
         ctx: Context,
         inode: VfsInode,
         handle: u64,
-        r: &mut dyn ZeroCopyReader,
+        r: &mut dyn ZeroCopyReader<S = S>,
         size: u32,
         offset: u64,
         lock_owner: Option<u64>,

--- a/src/async_util.rs
+++ b/src/async_util.rs
@@ -168,7 +168,7 @@ impl<D: AsyncDrive> AsyncUtil<D> {
         let bufs: Vec<Box<[u8]>> = slices
             .iter()
             .filter(|b| b.is_empty())
-            .map(|&b| unsafe { Vec::from_raw_parts(b.as_ptr(), b.len(), b.len()).into() })
+            .map(|b| unsafe { Vec::from_raw_parts(b.as_ptr(), b.len(), b.len()).into() })
             .collect();
         let bufs = bufs.into();
 
@@ -289,7 +289,7 @@ impl<D: AsyncDrive> AsyncUtil<D> {
         let bufs: Vec<Box<[u8]>> = slices
             .iter()
             .filter(|b| b.is_empty())
-            .map(|&b| unsafe { Vec::from_raw_parts(b.as_ptr(), b.len(), b.len()).into() })
+            .map(|b| unsafe { Vec::from_raw_parts(b.as_ptr(), b.len(), b.len()).into() })
             .collect();
         let bufs = bufs.into();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ use std::ffi::{CStr, FromBytesWithNulError};
 use std::io::ErrorKind;
 use std::{error, fmt, io};
 
+use vm_memory::bitmap::BitmapSlice;
+
 /// Error codes for Fuse related operations.
 #[derive(Debug)]
 pub enum Error {

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -254,7 +254,7 @@ impl<D: AsyncDrive + Sync, S: BitmapSlice + Send + Sync> AsyncFileSystem<D, S>
             self.inode_map.insert(
                 inode,
                 altkey,
-                InodeData::new(inode, FileOrHandle::File(f), 1),
+                InodeData::new(inode, FileOrHandle::File(f), 1, altkey),
             );
 
             inode

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -15,7 +15,9 @@ use crate::async_util::{AsyncDrive, AsyncUtil};
 
 //use crate::passthrough::sync_io::set_creds;
 
-impl<D: AsyncDrive + Sync> BackendFileSystem for PassthroughFs<D> {
+impl<D: AsyncDrive + Sync, S: 'static + BitmapSlice + Send + Sync> BackendFileSystem<D, S>
+    for PassthroughFs<D, S>
+{
     fn mount(&self) -> io::Result<(Entry, u64)> {
         let entry = self.do_lookup(fuse::ROOT_ID, &CString::new(".").unwrap())?;
         Ok((entry, VFS_MAX_INO))
@@ -26,7 +28,7 @@ impl<D: AsyncDrive + Sync> BackendFileSystem for PassthroughFs<D> {
     }
 }
 
-impl<D: AsyncDrive> PassthroughFs<D> {
+impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
     async fn async_open_file(
         ctx: &Context,
         dfd: i32,
@@ -181,13 +183,13 @@ impl<D: AsyncDrive> PassthroughFs<D> {
 
 #[async_trait]
 #[allow(unused_variables)]
-impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
-    type D = D;
-
+impl<D: AsyncDrive + Sync, S: BitmapSlice + Send + Sync> AsyncFileSystem<D, S>
+    for PassthroughFs<D, S>
+{
     async fn async_lookup(
         &self,
         ctx: Context,
-        parent: <Self as FileSystem>::Inode,
+        parent: <Self as FileSystem<S>>::Inode,
         name: &CStr,
     ) -> io::Result<Entry> {
         let p = self.inode_map.get(parent)?;
@@ -263,8 +265,8 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_getattr(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
-        handle: Option<<Self as FileSystem>::Handle>,
+        inode: <Self as FileSystem<S>>::Inode,
+        handle: Option<<Self as FileSystem<S>>::Handle>,
     ) -> io::Result<(libc::stat64, Duration)> {
         self.async_do_getattr(inode).await
     }
@@ -272,9 +274,9 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_setattr(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
+        inode: <Self as FileSystem<S>>::Inode,
         attr: libc::stat64,
-        handle: Option<<Self as FileSystem>::Handle>,
+        handle: Option<<Self as FileSystem<S>>::Handle>,
         valid: SetattrValid,
     ) -> io::Result<(libc::stat64, Duration)> {
         let inode_data = self.inode_map.get(inode)?;
@@ -409,10 +411,10 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_open(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
+        inode: <Self as FileSystem<S>>::Inode,
         flags: u32,
         fuse_flags: u32,
-    ) -> io::Result<(Option<<Self as FileSystem>::Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<<Self as FileSystem<S>>::Handle>, OpenOptions)> {
         if self.no_open.load(Ordering::Relaxed) {
             info!("fuse: open is not supported.");
             Err(io::Error::from_raw_os_error(libc::ENOSYS))
@@ -424,10 +426,10 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_create(
         &self,
         ctx: Context,
-        parent: <Self as FileSystem>::Inode,
+        parent: <Self as FileSystem<S>>::Inode,
         name: &CStr,
         args: CreateIn,
-    ) -> io::Result<(Entry, Option<<Self as FileSystem>::Handle>, OpenOptions)> {
+    ) -> io::Result<(Entry, Option<<Self as FileSystem<S>>::Handle>, OpenOptions)> {
         unimplemented!()
         // let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
         // let data = self.inode_map.get(parent)?;
@@ -470,9 +472,9 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_read(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
-        handle: <Self as FileSystem>::Handle,
-        w: &mut (dyn AsyncZeroCopyWriter<D> + Send),
+        inode: <Self as FileSystem<S>>::Inode,
+        handle: <Self as FileSystem<S>>::Handle,
+        w: &mut (dyn AsyncZeroCopyWriter<D, S> + Send),
         size: u32,
         offset: u64,
         _lock_owner: Option<u64>,
@@ -493,9 +495,9 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_write(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
-        handle: <Self as FileSystem>::Handle,
-        r: &mut (dyn AsyncZeroCopyReader<D> + Send),
+        inode: <Self as FileSystem<S>>::Inode,
+        handle: <Self as FileSystem<S>>::Handle,
+        r: &mut (dyn AsyncZeroCopyReader<D, S> + Send),
         size: u32,
         offset: u64,
         _lock_owner: Option<u64>,
@@ -518,9 +520,9 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_fsync(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
+        inode: <Self as FileSystem<S>>::Inode,
         datasync: bool,
-        handle: <Self as FileSystem>::Handle,
+        handle: <Self as FileSystem<S>>::Handle,
     ) -> io::Result<()> {
         let data = self
             .async_get_data(&ctx, handle, inode, libc::O_RDONLY)
@@ -536,8 +538,8 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_fallocate(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
-        handle: <Self as FileSystem>::Handle,
+        inode: <Self as FileSystem<S>>::Inode,
+        handle: <Self as FileSystem<S>>::Handle,
         mode: u32,
         offset: u64,
         length: u64,
@@ -557,9 +559,9 @@ impl<D: AsyncDrive + Sync> AsyncFileSystem for PassthroughFs<D> {
     async fn async_fsyncdir(
         &self,
         ctx: Context,
-        inode: <Self as FileSystem>::Inode,
+        inode: <Self as FileSystem<S>>::Inode,
         datasync: bool,
-        handle: <Self as FileSystem>::Handle,
+        handle: <Self as FileSystem<S>>::Handle,
     ) -> io::Result<()> {
         self.async_fsync(ctx, inode, datasync, handle).await
     }

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -206,7 +206,7 @@ impl<D: AsyncDrive + Sync, S: BitmapSlice + Send + Sync> AsyncFileSystem<D, S>
         )
         .await?;
         let st = Self::async_stat(&f, None).await?;
-        let altkey = InodeAltKey::from_stat(&st);
+        let altkey = InodeAltKey::ids_from_stat(&st);
 
         let mut found = None;
         'search: loop {

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -432,6 +432,7 @@ impl<D: AsyncDrive + Sync, S: BitmapSlice + Send + Sync> AsyncFileSystem<D, S>
         args: CreateIn,
     ) -> io::Result<(Entry, Option<<Self as FileSystem<S>>::Handle>, OpenOptions)> {
         unimplemented!()
+        // TODO: implement
         // let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
         // let data = self.inode_map.get(parent)?;
 

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -456,7 +456,7 @@ impl<D: AsyncDrive + Sync, S: BitmapSlice + Send + Sync> AsyncFileSystem<D, S>
         name: &CStr,
         args: CreateIn,
     ) -> io::Result<(Entry, Option<<Self as FileSystem<S>>::Handle>, OpenOptions)> {
-        unimplemented!()
+        self.create(ctx, parent, name, args)
         // TODO: implement
         // let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
         // let data = self.inode_map.get(parent)?;

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -141,7 +141,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
         Ok((st, self.cfg.attr_timeout))
     }
 
-    async fn async_stat(dir: &File, path: Option<&CStr>) -> io::Result<libc::stat64> {
+    async fn async_stat(dir: &impl AsRawFd, path: Option<&CStr>) -> io::Result<libc::stat64> {
         // Safe because this is a constant value and a valid C string.
         let pathname =
             path.unwrap_or_else(|| unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) });

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -25,6 +25,7 @@ pub struct MountFds {
     map: RwLock<HashMap<u64, File>>,
 }
 
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug)]
 #[repr(C)]
 struct CFileHandle {
     // Size of f_handle [in, out]
@@ -45,6 +46,7 @@ impl CFileHandle {
     }
 }
 
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug)]
 pub struct FileHandle {
     mnt_id: u64,
     handle: CFileHandle,

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::fmt::{Debug, Formatter};
 use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::RwLock;
 
+use crate::async_util::AsyncDriver;
 use crate::passthrough::PassthroughFs;
 
 /// An arbitrary maximum size for CFileHandle::f_handle.
@@ -17,17 +20,7 @@ use crate::passthrough::PassthroughFs;
 /// hard-coded here for simplicity.
 const MAX_HANDLE_SZ: usize = 128;
 
-/**
- * Creating a file handle only returns a mount ID; opening a file handle requires an open fd on the
- * respective mount.  This is a type in which we can store fds that we know are associated with a
- * given mount ID, so that when opening a handle we can look it up.
- */
-#[derive(Default)]
-pub struct MountFds {
-    map: RwLock<HashMap<u64, File>>,
-}
-
-#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy)]
 #[repr(C)]
 struct CFileHandle {
     // Size of f_handle [in, out]
@@ -48,6 +41,49 @@ impl CFileHandle {
     }
 }
 
+impl Ord for CFileHandle {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.handle_bytes != other.handle_bytes {
+            return self.handle_bytes.cmp(&other.handle_bytes);
+        }
+        if self.handle_type != other.handle_type {
+            return self.handle_type.cmp(&other.handle_type);
+        }
+
+        self.f_handle
+            .iter()
+            .zip(other.f_handle.iter())
+            .map(|(x, y)| x.cmp(y))
+            .find(|&ord| ord != std::cmp::Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for CFileHandle {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for CFileHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for CFileHandle {}
+
+impl Debug for CFileHandle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "File handle: type {}, len {}",
+            self.handle_type, self.handle_bytes
+        )
+    }
+}
+
+/// Struct to maintain information for a file handle.
 #[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug)]
 pub struct FileHandle {
     mnt_id: u64,
@@ -72,21 +108,15 @@ extern "C" {
     ) -> libc::c_int;
 }
 
-impl MountFds {
-    pub fn new() -> Self {
-        MountFds::default()
-    }
-}
-
 impl FileHandle {
     /// Create a file handle for the given file.
-    fn from_name_at(dir: &impl AsRawFd, path: &CStr) -> io::Result<Self> {
+    fn from_name_at(dir_fd: RawFd, path: &CStr) -> io::Result<Self> {
         let mut mount_id: libc::c_int = 0;
         let mut c_fh = CFileHandle::new();
 
         let ret = unsafe {
             name_to_handle_at(
-                dir.as_raw_fd(),
+                dir_fd,
                 path.as_ptr(),
                 &mut c_fh,
                 &mut mount_id,
@@ -105,15 +135,15 @@ impl FileHandle {
         }
     }
 
-    /**
-     * Create a file handle for the given file, and ensure that `mount_fds` contains a valid fd for
-     * the mount the file is on (so that `handle.open_with_mount_fds()` will work).
-     *
-     * If `path` is empty, `reopen_dir` may be invoked to duplicate `dir` with custom
-     * `libc::open()` flags.
-     */
+    /// Create a file handle for the given file.
+    ///
+    /// Also ensure that `mount_fds` contains a valid fd for the mount the file is on (so that
+    /// `handle.open_with_mount_fds()` will work).
+    ///
+    /// If `path` is empty, `reopen_dir` may be invoked to duplicate `dir` with custom
+    /// `libc::open()` flags.
     pub fn from_name_at_with_mount_fds<F>(
-        dir: &impl AsRawFd,
+        dir_fd: RawFd,
         path: &CStr,
         mount_fds: &MountFds,
         reopen_dir: F,
@@ -121,66 +151,17 @@ impl FileHandle {
     where
         F: FnOnce(RawFd, libc::c_int) -> io::Result<File>,
     {
-        let handle = Self::from_name_at(dir, path)?;
+        let handle = Self::from_name_at(dir_fd, path)?;
 
-        if !mount_fds.map.read().unwrap().contains_key(&handle.mnt_id) {
-            let (path_fd, _path_file) = if path.to_bytes().is_empty() {
-                // `open_by_handle_at()` needs a non-`O_PATH` fd, and `dir` may be `O_PATH`, so we
-                // have to open a new fd here
-                // We do not know whether `dir`/`path` is a special file, though, and we must not open
-                // special files with anything but `O_PATH`, so we have to get some `O_PATH` fd first
-                // that we can stat to find out whether it is safe to open.
-                // (When opening a new fd here, keep a `File` object around so the fd is closed when it
-                // goes out of scope.)
-                (dir.as_raw_fd(), None)
-            } else {
-                let f = PassthroughFs::open_file(
-                    dir.as_raw_fd(),
-                    path,
-                    libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                    0,
-                )
-                .map_err(|e| {
-                    error!(
-                        "from_name_at_with_mount_fds: open_file on {:?} failed error {:?}",
-                        path, e
-                    );
-                    e
-                })?;
-                (f.as_raw_fd(), Some(f))
-            };
-
-            // liubo: TODO find mnt id
-            // Ensure that `file` refers to an inode with the mount ID we need
-            // if statx(&file, None)?.mnt_id != handle.mnt_id {
-            //     return Err(io::Error::from_raw_os_error(libc::EIO));
-            // }
-
-            let st = PassthroughFs::stat(&path_fd, None)?;
-            // Ensure that we can safely reopen `path_fd` with `O_RDONLY`
-            let file_type = st.st_mode & libc::S_IFMT;
-            if file_type != libc::S_IFREG && file_type != libc::S_IFDIR {
-                error!(
-                    "from_name_at_with_mount_fds: file {:?} is special file",
-                    path
-                );
-                return Err(io::Error::from_raw_os_error(libc::EIO));
-            }
-
-            let file = reopen_dir(path_fd, libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC)?;
-
-            mount_fds.map.write().unwrap().insert(handle.mnt_id, file);
-        }
+        mount_fds.ensure_mount_point(handle.mnt_id, dir_fd, path, reopen_dir)?;
 
         Ok(handle)
     }
 
-    /**
-     * Open a file handle (low-level wrapper).
-     *
-     * `mount_fd` must be an open non-`O_PATH` file descriptor for an inode on the same mount as
-     * the file to be opened, i.e. the mount given by `self.mnt_id`.
-     */
+    /// Open a file handle (low-level wrapper).
+    ///
+    /// `mount_fd` must be an open non-`O_PATH` file descriptor for an inode on the same mount as
+    /// the file to be opened, i.e. the mount given by `self.mnt_id`.
     fn open(&self, mount_fd: &impl AsRawFd, flags: libc::c_int) -> io::Result<File> {
         let ret = unsafe { open_by_handle_at(mount_fd.as_raw_fd(), &self.handle, flags) };
         if ret >= 0 {
@@ -194,27 +175,157 @@ impl FileHandle {
         }
     }
 
-    /**
-     * Open a file handle, using the given `mount_fds` hash map.
-     *
-     * Look up `self.mnt_id` in `mount_fds`, and pass the result to `self.open()`.
-     */
+    /// Open a file handle, using the given `mount_fds` hash map.
+    ///
+    /// Look up `self.mnt_id` in `mount_fds`, and pass the result to `self.open()`.
     pub fn open_with_mount_fds(
         &self,
         mount_fds: &MountFds,
         flags: libc::c_int,
     ) -> io::Result<File> {
         let mount_fds_locked = mount_fds.map.read().unwrap();
-        let mount_file = mount_fds_locked
-            .get(&self.mnt_id)
-            .ok_or_else(|| {
-                error!(
-                    "open_with_mount_fds: mnt_id {:?} is not found.",
-                    &self.mnt_id
-                );
-                io::Error::from_raw_os_error(libc::ENODEV)
-            })?;
+        let mount_file = mount_fds_locked.get(&self.mnt_id).ok_or_else(|| {
+            error!(
+                "open_with_mount_fds: mnt_id {:?} is not found.",
+                &self.mnt_id
+            );
+            io::Error::from_raw_os_error(libc::ENODEV)
+        })?;
 
         self.open(mount_file, flags)
+    }
+}
+
+/// Struct to maintain <mount ID, mountpoint file> mapping for open_by_handle_at().
+///
+/// Creating a file handle only returns a mount ID; opening a file handle requires an open fd on the
+/// respective mount.  This is a type in which we can store fds that we know are associated with a
+/// given mount ID, so that when opening a handle we can look it up.
+#[derive(Default)]
+pub struct MountFds {
+    map: RwLock<HashMap<u64, File>>,
+}
+
+impl MountFds {
+    pub fn new() -> Self {
+        MountFds::default()
+    }
+
+    pub fn get_map(&self) -> RwLockReadGuard<'_, HashMap<u64, std::fs::File>> {
+        self.map.read().unwrap()
+    }
+
+    pub fn get_map_mut(&self) -> RwLockWriteGuard<'_, HashMap<u64, std::fs::File>> {
+        self.map.write().unwrap()
+    }
+
+    fn ensure_mount_point<F>(
+        &self,
+        mnt_id: u64,
+        dir_fd: RawFd,
+        path: &CStr,
+        reopen_dir: F,
+    ) -> io::Result<()>
+    where
+        F: FnOnce(RawFd, libc::c_int) -> io::Result<File>,
+    {
+        if self.map.read().unwrap().contains_key(&mnt_id) {
+            return Ok(());
+        }
+
+        let (path_fd, _path_file) = if path.to_bytes().is_empty() {
+            // `open_by_handle_at()` needs a non-`O_PATH` fd, and `dir` may be `O_PATH`, so we
+            // have to open a new fd here
+            // We do not know whether `dir`/`path` is a special file, though, and we must not open
+            // special files with anything but `O_PATH`, so we have to get some `O_PATH` fd first
+            // that we can stat to find out whether it is safe to open.
+            // (When opening a new fd here, keep a `File` object around so the fd is closed when it
+            // goes out of scope.)
+            (dir_fd, None)
+        } else {
+            let f = PassthroughFs::<AsyncDriver, ()>::open_file(
+                dir_fd,
+                path,
+                libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0,
+            )
+            .map_err(|e| {
+                error!(
+                    "from_name_at_with_mount_fds: open_file on {:?} failed error {:?}",
+                    path, e
+                );
+                e
+            })?;
+            (f.as_raw_fd(), Some(f))
+        };
+
+        // liubo: TODO find mnt id
+        // Ensure that `file` refers to an inode with the mount ID we need
+        // if statx(&file, None)?.mnt_id != handle.mnt_id {
+        //     return Err(io::Error::from_raw_os_error(libc::EIO));
+        // }
+
+        let st = PassthroughFs::<AsyncDriver, ()>::stat_fd(path_fd, None)?;
+        // Ensure that we can safely reopen `path_fd` with `O_RDONLY`
+        let file_type = st.st_mode & libc::S_IFMT;
+        if file_type != libc::S_IFREG && file_type != libc::S_IFDIR {
+            error!(
+                "from_name_at_with_mount_fds: file {:?} is special file",
+                path
+            );
+            return Err(io::Error::from_raw_os_error(libc::EIO));
+        }
+
+        let file = reopen_dir(path_fd, libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC)?;
+        self.map.write().unwrap().insert(mnt_id, file);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_file_handle_derives() {
+        let mut h1 = CFileHandle {
+            handle_bytes: 128,
+            handle_type: 3,
+            f_handle: [0; MAX_HANDLE_SZ],
+        };
+        let h2 = CFileHandle {
+            handle_bytes: 129,
+            handle_type: 3,
+            f_handle: [0; MAX_HANDLE_SZ],
+        };
+        let h3 = CFileHandle {
+            handle_bytes: 128,
+            handle_type: 4,
+            f_handle: [0; MAX_HANDLE_SZ],
+        };
+        let h4 = CFileHandle {
+            handle_bytes: 128,
+            handle_type: 4,
+            f_handle: [1; MAX_HANDLE_SZ],
+        };
+        let mut h5 = CFileHandle {
+            handle_bytes: 128,
+            handle_type: 3,
+            f_handle: [0; MAX_HANDLE_SZ],
+        };
+
+        assert!(h1 < h2);
+        assert!(h1 != h2);
+        assert!(h1 < h3);
+        assert!(h1 != h3);
+        assert!(h1 < h4);
+        assert!(h1 != h4);
+
+        assert!(h1 == h5);
+        h1.f_handle[0] = 1;
+        assert!(h1 > h5);
+        h5.f_handle[0] = 1;
+        assert!(h1 == h5);
     }
 }

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -211,14 +211,6 @@ impl MountFds {
         MountFds::default()
     }
 
-    pub fn get_map(&self) -> RwLockReadGuard<'_, HashMap<u64, std::fs::File>> {
-        self.map.read().unwrap()
-    }
-
-    pub fn get_map_mut(&self) -> RwLockWriteGuard<'_, HashMap<u64, std::fs::File>> {
-        self.map.write().unwrap()
-    }
-
     fn ensure_mount_point<F>(
         &self,
         mnt_id: u64,

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -6,8 +6,10 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::sync::RwLock;
+
+use crate::passthrough::PassthroughFs;
 
 /// An arbitrary maximum size for CFileHandle::f_handle.
 ///
@@ -78,7 +80,6 @@ impl MountFds {
 
 impl FileHandle {
     /// Create a file handle for the given file.
-    #[allow(dead_code)]
     fn from_name_at(dir: &impl AsRawFd, path: &CStr) -> io::Result<Self> {
         let mut mount_id: libc::c_int = 0;
         let mut c_fh = CFileHandle::new();
@@ -100,6 +101,53 @@ impl FileHandle {
         } else {
             Err(io::Error::last_os_error())
         }
+    }
+
+    /**
+     * Create a file handle for the given file, and ensure that `mount_fds` contains a valid fd for
+     * the mount the file is on (so that `handle.open_with_mount_fds()` will work).
+     *
+     * If `path` is empty, `reopen_dir` may be invoked to duplicate `dir` with custom
+     * `libc::open()` flags.
+     */
+    pub fn from_name_at_with_mount_fds<F>(
+        dir: &impl AsRawFd,
+        path: &CStr,
+        mount_fds: &MountFds,
+        reopen_dir: F,
+    ) -> io::Result<Self>
+    where
+        F: FnOnce(RawFd, libc::c_int) -> io::Result<File>,
+    {
+        let handle = Self::from_name_at(dir, path)?;
+
+        if !mount_fds.map.read().unwrap().contains_key(&handle.mnt_id) {
+            let file = if path.to_bytes().is_empty() {
+                // `open_by_handle_at()` needs a non-`O_PATH` fd, and `dir` may be `O_PATH`, so we
+                // have to open a new fd here
+                reopen_dir(
+                    dir.as_raw_fd(),
+                    libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )?
+            } else {
+                PassthroughFs::open_file(
+                    dir.as_raw_fd(),
+                    path,
+                    libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                    0,
+                )?
+            };
+
+            // liubo: TODO find mnt id
+            // Ensure that `file` refers to an inode with the mount ID we need
+            // if statx(&file, None)?.mnt_id != handle.mnt_id {
+            //     return Err(io::Error::from_raw_os_error(libc::EIO));
+            // }
+
+            mount_fds.map.write().unwrap().insert(handle.mnt_id, file);
+        }
+
+        Ok(handle)
     }
 
     /**

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -2,16 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE-BSD-3-Clause file.
 
+use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::sync::RwLock;
 
 /// An arbitrary maximum size for CFileHandle::f_handle.
 ///
 /// According to Linux ABI, struct file_handle has a flexible array member 'f_handle', but it's
 /// hard-coded here for simplicity.
 const MAX_HANDLE_SZ: usize = 128;
+
+/**
+ * Creating a file handle only returns a mount ID; opening a file handle requires an open fd on the
+ * respective mount.  This is a type in which we can store fds that we know are associated with a
+ * given mount ID, so that when opening a handle we can look it up.
+ */
+#[derive(Default)]
+pub struct MountFds {
+    map: RwLock<HashMap<u64, File>>,
+}
 
 #[repr(C)]
 struct CFileHandle {
@@ -34,7 +46,6 @@ impl CFileHandle {
 }
 
 pub struct FileHandle {
-    #[allow(dead_code)]
     mnt_id: u64,
     handle: CFileHandle,
 }
@@ -55,6 +66,12 @@ extern "C" {
         file_handle: *const CFileHandle,
         flags: libc::c_int,
     ) -> libc::c_int;
+}
+
+impl MountFds {
+    pub fn new() -> Self {
+        MountFds::default()
+    }
 }
 
 impl FileHandle {
@@ -89,7 +106,6 @@ impl FileHandle {
      * `mount_fd` must be an open non-`O_PATH` file descriptor for an inode on the same mount as
      * the file to be opened, i.e. the mount given by `self.mnt_id`.
      */
-    #[allow(dead_code)]
     fn open(&self, mount_fd: &impl AsRawFd, flags: libc::c_int) -> io::Result<File> {
         let ret = unsafe { open_by_handle_at(mount_fd.as_raw_fd(), &self.handle, flags) };
         if ret >= 0 {
@@ -99,5 +115,23 @@ impl FileHandle {
         } else {
             Err(io::Error::last_os_error())
         }
+    }
+
+    /**
+     * Open a file handle, using the given `mount_fds` hash map.
+     *
+     * Look up `self.mnt_id` in `mount_fds`, and pass the result to `self.open()`.
+     */
+    pub fn open_with_mount_fds(
+        &self,
+        mount_fds: &MountFds,
+        flags: libc::c_int,
+    ) -> io::Result<File> {
+        let mount_fds_locked = mount_fds.map.read().unwrap();
+        let mount_file = mount_fds_locked
+            .get(&self.mnt_id)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENODEV))?;
+
+        self.open(mount_file, flags)
     }
 }

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -1,0 +1,103 @@
+// Copyright 2021 Red Hat, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::io;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+
+/// An arbitrary maximum size for CFileHandle::f_handle.
+///
+/// According to Linux ABI, struct file_handle has a flexible array member 'f_handle', but it's
+/// hard-coded here for simplicity.
+const MAX_HANDLE_SZ: usize = 128;
+
+#[repr(C)]
+struct CFileHandle {
+    // Size of f_handle [in, out]
+    handle_bytes: libc::c_uint,
+    // Handle type [out]
+    handle_type: libc::c_int,
+    // File identifier (sized by caller) [out]
+    f_handle: [libc::c_char; MAX_HANDLE_SZ],
+}
+
+impl CFileHandle {
+    fn new() -> Self {
+        CFileHandle {
+            handle_bytes: MAX_HANDLE_SZ as libc::c_uint,
+            handle_type: 0,
+            f_handle: [0; MAX_HANDLE_SZ],
+        }
+    }
+}
+
+pub struct FileHandle {
+    #[allow(dead_code)]
+    mnt_id: u64,
+    handle: CFileHandle,
+}
+
+extern "C" {
+    fn name_to_handle_at(
+        dirfd: libc::c_int,
+        pathname: *const libc::c_char,
+        file_handle: *mut CFileHandle,
+        mount_id: *mut libc::c_int,
+        flags: libc::c_int,
+    ) -> libc::c_int;
+
+    // Technically `file_handle` should be a `mut` pointer, but `open_by_handle_at()` is specified
+    // not to change it, so we can declare it `const`.
+    fn open_by_handle_at(
+        mount_fd: libc::c_int,
+        file_handle: *const CFileHandle,
+        flags: libc::c_int,
+    ) -> libc::c_int;
+}
+
+impl FileHandle {
+    /// Create a file handle for the given file.
+    #[allow(dead_code)]
+    fn from_name_at(dir: &impl AsRawFd, path: &CStr) -> io::Result<Self> {
+        let mut mount_id: libc::c_int = 0;
+        let mut c_fh = CFileHandle::new();
+
+        let ret = unsafe {
+            name_to_handle_at(
+                dir.as_raw_fd(),
+                path.as_ptr(),
+                &mut c_fh,
+                &mut mount_id,
+                libc::AT_EMPTY_PATH,
+            )
+        };
+        if ret == 0 {
+            Ok(FileHandle {
+                mnt_id: mount_id as u64,
+                handle: c_fh,
+            })
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    /**
+     * Open a file handle (low-level wrapper).
+     *
+     * `mount_fd` must be an open non-`O_PATH` file descriptor for an inode on the same mount as
+     * the file to be opened, i.e. the mount given by `self.mnt_id`.
+     */
+    #[allow(dead_code)]
+    fn open(&self, mount_fd: &impl AsRawFd, flags: libc::c_int) -> io::Result<File> {
+        let ret = unsafe { open_by_handle_at(mount_fd.as_raw_fd(), &self.handle, flags) };
+        if ret >= 0 {
+            // Safe because `open_by_handle_at()` guarantees this is a valid fd
+            let file = unsafe { File::from_raw_fd(ret) };
+            Ok(file)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -752,9 +752,10 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
                         ));
                     }
                     trace!(
-                        "fuse: do_lookup adds new inode {} ids_altkey {:?}",
+                        "fuse: do_lookup adds new inode {} ids_altkey {:?} handle_altkey {:?}",
                         inode,
-                        ids_altkey
+                        ids_altkey,
+                        handle_altkey
                     );
 
                     self.inode_map.insert(

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -646,13 +646,13 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
             libc::openat(
                 dfd,
                 pathname.as_ptr(),
-                flags & libc::O_CREAT & libc::O_EXCL,
+                flags | libc::O_CREAT | libc::O_EXCL,
                 mode,
             )
         };
         if fd < 0 {
             let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::NotFound {
+            if err.kind() == io::ErrorKind::AlreadyExists {
                 return Ok(None);
             }
             return Err(err);

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -894,6 +894,7 @@ mod tests {
     use super::*;
     use crate::api::filesystem::*;
     use crate::api::{Vfs, VfsOptions};
+    use caps::{CapSet, Capability};
     use log;
     use std::ops::Deref;
     use vmm_sys_util::{tempdir::TempDir, tempfile::TempFile};
@@ -936,6 +937,14 @@ mod tests {
     #[test]
     fn test_passthroughfs_inode_file_handles() {
         log::set_max_level(log::LevelFilter::Trace);
+
+        match caps::has_cap(None, CapSet::Effective, Capability::CAP_DAC_READ_SEARCH) {
+            Ok(false) | Err(_) => {
+                println!("invoking open_by_handle_at needs CAP_DAC_READ_SEARCH");
+                return;
+            }
+            Ok(true) => {}
+        }
 
         let source = TempDir::new().expect("Cannot create temporary directory.");
         let parent_path =

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -115,6 +115,7 @@ struct InodeData {
     inode: Inode,
     // Most of these aren't actually files but ¯\_(ツ)_/¯.
     file_or_handle: FileOrHandle,
+    #[allow(dead_code)]
     altkey: InodeAltKey,
     refcount: AtomicU64,
 }
@@ -187,7 +188,7 @@ impl InodeMap {
             .map(|altkey| inodes.get_alt(altkey))
             .flatten()
             .or_else(|| {
-                inodes.get_alt(&ids_altkey).filter(|data| {
+                inodes.get_alt(ids_altkey).filter(|data| {
                     // When we have to fall back to looking up an inode by its IDs, ensure that
                     // we hit an entry that does not have a file handle.  Entries with file
                     // handles must also have a handle alt key, so if we have not found it by

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -452,7 +452,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
         vec![self.proc.as_raw_fd()]
     }
 
-    fn stat(dir: &File, path: Option<&CStr>) -> io::Result<libc::stat64> {
+    fn stat(dir: &impl AsRawFd, path: Option<&CStr>) -> io::Result<libc::stat64> {
         // Safe because this is a constant value and a valid C string.
         let pathname =
             path.unwrap_or_else(|| unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) });

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -33,6 +33,7 @@ use crate::BitmapSlice;
 
 #[cfg(feature = "async-io")]
 mod async_io;
+mod file_handle;
 mod sync_io;
 
 mod multikey;

--- a/src/passthrough/multikey.rs
+++ b/src/passthrough/multikey.rs
@@ -143,10 +143,6 @@ where
         self.alt.clear();
         self.main.clear()
     }
-
-    pub fn iter(&self) -> Iter<'_, K1, (Vec<K2>, V)> {
-        self.main.iter()
-    }
 }
 
 #[cfg(test)]

--- a/src/passthrough/multikey.rs
+++ b/src/passthrough/multikey.rs
@@ -8,19 +8,19 @@ use std::borrow::Borrow;
 use std::collections::BTreeMap;
 
 /// A BTreeMap that supports 2 types of keys per value. All the usual restrictions and warnings for
-/// `std::collections::BTreeMap` also apply to this struct. Additionally, there is a 1:1
-/// relationship between the 2 key types. In other words, for each `K1` in the map, there is exactly
-/// one `K2` in the map and vice versa.
+/// `std::collections::BTreeMap` also apply to this struct. Additionally, there is a 1:n
+/// relationship between the 2 key types: For each `K1` in the map, any number of `K2` may exist;
+/// but each `K2` only has exactly one `K1` associated with it.
 #[derive(Default)]
 pub struct MultikeyBTreeMap<K1, K2, V>
 where
     K1: Ord,
     K2: Ord,
 {
-    // We need to keep a copy of the second key in the main map so that we can remove entries using
-    // just the main key. Otherwise we would require the caller to provide both keys when calling
+    // We need to keep a copy of the second keys in the main map so that we can remove entries using
+    // just the main key. Otherwise we would require the caller to provide all keys when calling
     // `remove`.
-    main: BTreeMap<K1, (K2, V)>,
+    main: BTreeMap<K1, (Vec<K2>, V)>,
     alt: BTreeMap<K2, K1>,
 }
 
@@ -49,7 +49,7 @@ where
         self.main.get(key).map(|(_, v)| v)
     }
 
-    /// Returns a reference to the value corresponding to the alternate key.
+    /// Returns a reference to the value corresponding to an alternate key.
     ///
     /// The key may be any borrowed form of the `K2``, but the ordering on the borrowed form must
     /// match the ordering on `K2`.
@@ -69,28 +69,40 @@ where
         }
     }
 
-    /// Inserts a new entry into the map with the given keys and value.
+    /// Inserts a new entry into the map with the given main key and value.
     ///
-    /// Returns `None` if the map did not have an entry with `k1` or `k2` present. If exactly one
-    /// key was present, then the value associated with that key is updated, the other key is
-    /// removed, and the old value is returned. If **both** keys were present then the value
-    /// associated with the main key is updated, the value associated with the alternate key is
-    /// removed, and the old value associated with the main key is returned.
-    pub fn insert(&mut self, k1: K1, k2: K2, v: V) -> Option<V> {
-        let oldval = if let Some(oldkey) = self.alt.insert(k2.clone(), k1.clone()) {
-            self.main.remove(&oldkey)
+    /// If there already was an entry present with the given key, then the value is updated,
+    /// all alternate keys pointing to the main key are removed, and the old value is returned.
+    /// Otherwise, returns `None`.
+    pub fn insert(&mut self, k1: K1, v: V) -> Option<V> {
+        self.main.insert(k1, (vec![], v)).map(|(k2s, old_v)| {
+            for k2 in &k2s {
+                self.alt.remove(k2);
+            }
+            old_v
+        })
+    }
+
+    /// Adds an alternate key for an existing main key.
+    ///
+    /// If the given alternate key was present already, then the main key it points to is updated,
+    /// and that previous main key is returned.
+    /// Otherwise, returns `None`.
+    pub fn insert_alt(&mut self, k2: K2, k1: K1) -> Option<K1> {
+        // `k1` must exist, so we can .unwrap()
+        self.main.get_mut(&k1).unwrap().0.push(k2.clone());
+
+        if let Some(old_k1) = self.alt.insert(k2.clone(), k1) {
+            if let Some((old_k1_v2s, _)) = self.main.get_mut(&old_k1) {
+                if let Some(i) = old_k1_v2s.iter().position(|x| *x == k2) {
+                    old_k1_v2s.remove(i);
+                }
+            }
+
+            Some(old_k1)
         } else {
             None
-        };
-        self.main
-            .insert(k1, (k2.clone(), v))
-            .or(oldval)
-            .map(|(oldk2, v)| {
-                if oldk2 != k2 {
-                    self.alt.remove(&oldk2);
-                }
-                v
-            })
+        }
     }
 
     /// Remove a key from the map, returning the value associated with that key if it was previously
@@ -103,16 +115,37 @@ where
         K1: Borrow<Q>,
         Q: Ord + ?Sized,
     {
-        self.main.remove(key).map(|(k2, v)| {
-            self.alt.remove(&k2);
+        self.main.remove(key).map(|(k2s, v)| {
+            for k2 in &k2s {
+                self.alt.remove(k2);
+            }
             v
         })
+    }
+
+    #[allow(dead_code)]
+    pub fn remove_alt(&mut self, key: &K2) -> Option<K1> {
+        if let Some(k1) = self.alt.remove(key) {
+            if let Some((k1_v2s, _)) = self.main.get_mut(&k1) {
+                if let Some(i) = k1_v2s.iter().position(|x| *x == *key) {
+                    k1_v2s.remove(i);
+                }
+            }
+
+            Some(k1)
+        } else {
+            None
+        }
     }
 
     /// Clears the map, removing all values.
     pub fn clear(&mut self) {
         self.alt.clear();
         self.main.clear()
+    }
+
+    pub fn iter(&self) -> Iter<'_, K1, (Vec<K2>, V)> {
+        self.main.iter()
     }
 }
 
@@ -127,10 +160,28 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         assert_eq!(*m.get(&k1).expect("failed to look up main key"), val);
         assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val);
+    }
+
+    #[test]
+    fn get_multi_alt() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1 = 0xc6c8_f5e0_b13e_ed40;
+        let k2a = 0x1a04_ce4b_8329_14fe;
+        let k2b = 0x6825_a60b_61ac_b333;
+        let val = 0xf4e3_c360;
+
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2a, k1).is_none());
+        assert!(m.insert_alt(k2b, k1).is_none());
+
+        assert_eq!(*m.get_alt(&k2a).expect("failed to look up alt key A"), val);
+        assert_eq!(*m.get_alt(&k2b).expect("failed to look up alt key B"), val);
     }
 
     #[test]
@@ -140,15 +191,18 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         let new_k1 = 0x3add_f8f8_c7c5_df5e;
         let val2 = 0x7389_f8a7;
+        assert!(m.insert(new_k1, val2).is_none());
         assert_eq!(
-            m.insert(new_k1, k2, val2)
-                .expect("failed to update main key"),
-            val
+            m.insert_alt(k2, new_k1)
+                .expect("failed to update main key to which alt key points"),
+            k1
         );
+        assert_eq!(m.remove(&k1).expect("failed to remove old main key"), val);
 
         assert!(m.get(&k1).is_none());
         assert_eq!(*m.get(&new_k1).expect("failed to look up main key"), val2);
@@ -162,15 +216,14 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         let new_k2 = 0x6825_a60b_61ac_b333;
         let val2 = 0xbb14_8f2c;
-        assert_eq!(
-            m.insert(k1, new_k2, val2)
-                .expect("failed to update alt key"),
-            val
-        );
+        assert_eq!(m.insert(k1, val2).expect("failed to update value"), val);
+        // Updating a main key invalidates all its alt keys
+        assert!(m.insert_alt(new_k2, k1).is_none());
 
         assert!(m.get_alt(&k2).is_none());
         assert_eq!(*m.get(&k1).expect("failed to look up main key"), val2);
@@ -187,13 +240,13 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         let val2 = 0xe42d_79ba;
-        assert_eq!(
-            m.insert(k1, k2, val2).expect("failed to update alt key"),
-            val
-        );
+        assert_eq!(m.insert(k1, val2).expect("failed to update alt key"), val);
+        // Updating a main key invalidates all its alt keys
+        assert!(m.insert_alt(k2, k1).is_none());
 
         assert_eq!(*m.get(&k1).expect("failed to look up main key"), val2);
         assert_eq!(*m.get_alt(&k2).expect("failed to look up alt key"), val2);
@@ -206,22 +259,26 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         let new_k1 = 0xc980_587a_24b3_ae30;
         let new_k2 = 0x2773_c5ee_8239_45a2;
         let val2 = 0x31f4_33f9;
-        assert!(m.insert(new_k1, new_k2, val2).is_none());
+        assert!(m.insert(new_k1, val2).is_none());
+        assert!(m.insert_alt(new_k2, new_k1).is_none());
 
         let val3 = 0x8da1_9cf7;
+        assert_eq!(m.insert(k1, val3).expect("failed to update main key"), val);
         assert_eq!(
-            m.insert(k1, new_k2, val3)
-                .expect("failed to update main key"),
-            val
+            m.insert_alt(new_k2, k1).expect("failed to update alt key"),
+            new_k1
         );
 
-        // Both new_k1 and k2 should now be gone from the map.
-        assert!(m.get(&new_k1).is_none());
+        // We did not touch new_k1, so it should still be there
+        assert_eq!(*m.get(&new_k1).expect("failed to look up main key"), val2);
+
+        // However, we did update k1, which removed its associated alt keys
         assert!(m.get_alt(&k2).is_none());
 
         assert_eq!(*m.get(&k1).expect("failed to look up main key"), val3);
@@ -238,22 +295,29 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         let new_k1 = 0xc980_587a_24b3_ae30;
         let new_k2 = 0x2773_c5ee_8239_45a2;
         let val2 = 0x31f4_33f9;
-        assert!(m.insert(new_k1, new_k2, val2).is_none());
+        assert!(m.insert(new_k1, val2).is_none());
+        assert!(m.insert_alt(new_k2, new_k1).is_none());
 
         let val3 = 0x8da1_9cf7;
         assert_eq!(
-            m.insert(new_k1, k2, val3)
-                .expect("failed to update main key"),
+            m.insert(new_k1, val3).expect("failed to update main key"),
             val2
         );
+        assert_eq!(
+            m.insert_alt(k2, new_k1).expect("failed to update alt key"),
+            k1
+        );
 
-        // Both k1 and new_k2 should now be gone from the map.
-        assert!(m.get(&k1).is_none());
+        // We did not touch k1, so it should still be there
+        assert_eq!(*m.get(&k1).expect("failed to look up first main key"), val);
+
+        // However, we did update new_k1, which removed its associated alt keys
         assert!(m.get_alt(&new_k2).is_none());
 
         assert_eq!(*m.get(&new_k1).expect("failed to look up main key"), val3);
@@ -267,10 +331,49 @@ mod test {
         let k1 = 0xc6c8_f5e0_b13e_ed40;
         let k2 = 0x1a04_ce4b_8329_14fe;
         let val = 0xf4e3_c360;
-        assert!(m.insert(k1, k2, val).is_none());
+        assert!(m.insert(k1, val).is_none());
+        assert!(m.insert_alt(k2, k1).is_none());
 
         assert_eq!(m.remove(&k1).expect("failed to remove entry"), val);
         assert!(m.get(&k1).is_none());
         assert!(m.get_alt(&k2).is_none());
+    }
+
+    #[test]
+    fn remove_multi() {
+        let mut m = MultikeyBTreeMap::<u64, i64, u32>::new();
+
+        let k1a = 0xc6c8_f5e0_b13e_ed40;
+        let k1b = 0x3add_f8f8_c7c5_df5e;
+        let k2a = 0x1a04_ce4b_8329_14fe;
+        let k2b = 0x6825_a60b_61ac_b333;
+        let val_a = 0xf4e3_c360;
+        let val_b = 0xe42d_79ba;
+
+        assert!(m.insert(k1a, val_a).is_none());
+        assert!(m.insert_alt(k2a, k1a).is_none());
+        assert!(m.insert_alt(k2b, k1a).is_none());
+
+        assert!(m.insert(k1b, val_b).is_none());
+
+        assert_eq!(
+            m.insert_alt(k2b, k1b)
+                .expect("failed to make second alt key point to second main key"),
+            k1a
+        );
+
+        assert_eq!(
+            m.remove(&k1a).expect("failed to remove first main key"),
+            val_a
+        );
+
+        assert!(m.get(&k1a).is_none());
+        assert!(m.get_alt(&k2a).is_none());
+
+        assert_eq!(*m.get(&k1b).expect("failed to get second main key"), val_b);
+        assert_eq!(
+            *m.get_alt(&k2b).expect("failed to get second alt key"),
+            val_b
+        );
     }
 }

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -407,8 +407,8 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
     fn statfs(&self, _ctx: Context, inode: Inode) -> io::Result<libc::statvfs64> {
         let data = self.inode_map.get(inode)?;
         let mut out = MaybeUninit::<libc::statvfs64>::zeroed();
-
         let file = data.get_file(&self.mount_fds)?;
+
         // Safe because this will only modify `out` and we check the return value.
         match unsafe { libc::fstatvfs64(file.as_raw_fd(), out.as_mut_ptr()) } {
             // Safe because the kernel guarantees that `out` has been initialized.

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -304,7 +304,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
             e
         })?;
 
-        let st = Self::stat(&data.file).map_err(|e| {
+        let st = Self::stat(&data.file, None).map_err(|e| {
             error!(
                 "fuse: do_getattr stat failed ino {} fd: {:?} err {:?}",
                 inode,
@@ -1072,7 +1072,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
 
     fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
         let data = self.inode_map.get(inode)?;
-        let st = Self::stat(&data.file)?;
+        let st = Self::stat(&data.file, None)?;
         let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
 
         if mode == libc::F_OK {

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -111,7 +111,7 @@ impl Drop for CapFsetid {
     }
 }
 
-impl<D: AsyncDrive> PassthroughFs<D> {
+impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
     fn open_proc_file(&self, pathname: &CStr, flags: i32) -> io::Result<File> {
         Self::open_file(self.proc.as_raw_fd(), pathname, flags, 0)
     }
@@ -359,7 +359,7 @@ impl<D: AsyncDrive> PassthroughFs<D> {
     }
 }
 
-impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
+impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughFs<D, S> {
     type Inode = Inode;
     type Handle = Handle;
 
@@ -675,7 +675,7 @@ impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
         _ctx: Context,
         inode: Inode,
         handle: Handle,
-        w: &mut dyn ZeroCopyWriter,
+        w: &mut dyn ZeroCopyWriter<S = S>,
         size: u32,
         offset: u64,
         _lock_owner: Option<u64>,
@@ -697,7 +697,7 @@ impl<D: AsyncDrive> FileSystem for PassthroughFs<D> {
         _ctx: Context,
         inode: Inode,
         handle: Handle,
-        r: &mut dyn ZeroCopyReader,
+        r: &mut dyn ZeroCopyReader<S = S>,
         size: u32,
         offset: u64,
         _lock_owner: Option<u64>,

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -304,7 +304,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> PassthroughFs<D, S> {
             e
         })?;
 
-        let st = Self::stat(&data.file, None).map_err(|e| {
+        let st = Self::stat(data.get_file_ref(), None).map_err(|e| {
             error!(
                 "fuse: do_getattr stat failed ino {} fd: {:?} err {:?}",
                 inode,
@@ -1086,7 +1086,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
 
     fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
         let data = self.inode_map.get(inode)?;
-        let st = Self::stat(&data.file, None)?;
+        let st = Self::stat(data.get_file_ref(), None)?;
         let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
 
         if mode == libc::F_OK {
@@ -1139,7 +1139,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
         }
 
         let data = self.inode_map.get(inode)?;
-        let pathname = CString::new(format!("/proc/self/fd/{}", data.file.as_raw_fd()))
+        let pathname = CString::new(format!("/proc/self/fd/{}", data.get_raw_fd()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
@@ -1174,7 +1174,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
 
         let data = self.inode_map.get(inode)?;
         let mut buf = Vec::<u8>::with_capacity(size as usize);
-        let pathname = CString::new(format!("/proc/self/fd/{}", data.file.as_raw_fd()))
+        let pathname = CString::new(format!("/proc/self/fd/{}", data.get_raw_fd()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
@@ -1208,7 +1208,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
 
         let data = self.inode_map.get(inode)?;
         let mut buf = Vec::<u8>::with_capacity(size as usize);
-        let pathname = CString::new(format!("/proc/self/fd/{}", data.file.as_raw_fd()))
+        let pathname = CString::new(format!("/proc/self/fd/{}", data.get_raw_fd()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we
@@ -1240,7 +1240,7 @@ impl<D: AsyncDrive, S: BitmapSlice + Send + Sync> FileSystem<S> for PassthroughF
         }
 
         let data = self.inode_map.get(inode)?;
-        let pathname = CString::new(format!("/proc/self/fd/{}", data.file.as_raw_fd()))
+        let pathname = CString::new(format!("/proc/self/fd/{}", data.get_raw_fd()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         // The f{set,get,remove,list}xattr functions don't work on an fd opened with `O_PATH` so we

--- a/src/transport/file_traits.rs
+++ b/src/transport/file_traits.rs
@@ -59,7 +59,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
     fn read_vectored_volatile(&mut self, bufs: &[VolatileSlice<'_, S>]) -> Result<usize> {
         bufs.iter()
             .find(|b| !b.is_empty())
-            .map(|&b| self.read_volatile(b))
+            .map(|b| self.read_volatile(b.clone()))
             .unwrap_or(Ok(0))
     }
 
@@ -67,7 +67,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
     /// error is returned.
     fn read_exact_volatile(&mut self, mut slice: VolatileSlice<'_, S>) -> Result<()> {
         while !slice.is_empty() {
-            let bytes_read = self.read_volatile(slice)?;
+            let bytes_read = self.read_volatile(slice.clone())?;
             if bytes_read == 0 {
                 return Err(Error::from(ErrorKind::UnexpectedEof));
             }
@@ -90,7 +90,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
     fn write_vectored_volatile(&mut self, bufs: &[VolatileSlice<'_, S>]) -> Result<usize> {
         bufs.iter()
             .find(|b| !b.is_empty())
-            .map(|&b| self.write_volatile(b))
+            .map(|b| self.write_volatile(b.clone()))
             .unwrap_or(Ok(0))
     }
 
@@ -98,7 +98,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
     /// written, or an error is returned.
     fn write_all_volatile(&mut self, mut slice: VolatileSlice<'_, S>) -> Result<()> {
         while !slice.is_empty() {
-            let bytes_written = self.write_volatile(slice)?;
+            let bytes_written = self.write_volatile(slice.clone())?;
             if bytes_written == 0 {
                 return Err(Error::from(ErrorKind::WriteZero));
             }
@@ -123,8 +123,8 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
         bufs: &[VolatileSlice<'_, S>],
         offset: u64,
     ) -> Result<usize> {
-        if let Some(&slice) = bufs.first() {
-            self.read_at_volatile(slice, offset)
+        if let Some(slice) = bufs.first() {
+            self.read_at_volatile(slice.clone(), offset)
         } else {
             Ok(0)
         }
@@ -138,7 +138,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
         mut offset: u64,
     ) -> Result<()> {
         while !slice.is_empty() {
-            match self.read_at_volatile(slice, offset) {
+            match self.read_at_volatile(slice.clone(), offset) {
                 Ok(0) => return Err(Error::from(ErrorKind::UnexpectedEof)),
                 Ok(n) => {
                     // Will panic if read_at_volatile read more bytes than we gave it, which would
@@ -167,8 +167,8 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
         bufs: &[VolatileSlice<'_, S>],
         offset: u64,
     ) -> Result<usize> {
-        if let Some(&slice) = bufs.first() {
-            self.write_at_volatile(slice, offset)
+        if let Some(slice) = bufs.first() {
+            self.write_at_volatile(slice.clone(), offset)
         } else {
             Ok(0)
         }
@@ -182,7 +182,7 @@ pub trait FileReadWriteVolatile<S: BitmapSlice = ()> {
         mut offset: u64,
     ) -> Result<()> {
         while !slice.is_empty() {
-            match self.write_at_volatile(slice, offset) {
+            match self.write_at_volatile(slice.clone(), offset) {
                 Ok(0) => return Err(Error::from(ErrorKind::WriteZero)),
                 Ok(n) => {
                     // Will panic if write_at_volatile read more bytes than we gave it, which would

--- a/src/transport/fusedev/session.rs
+++ b/src/transport/fusedev/session.rs
@@ -487,7 +487,7 @@ mod asyncio {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(test1)]
     mod tests {
         use std::os::unix::io::AsRawFd;
 

--- a/src/transport/fusedev/session.rs
+++ b/src/transport/fusedev/session.rs
@@ -487,7 +487,7 @@ mod asyncio {
         }
     }
 
-    #[cfg(test1)]
+    #[cfg(test2)]
     mod tests {
         use std::os::unix::io::AsRawFd;
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -67,11 +67,11 @@ mod fusedev_tests {
             .output()?;
 
         if !output.status.success() || output.stderr.len() > 0 {
-            panic!(format!(
+            panic!(
                 "exec failed: {}: {}",
                 cmd,
                 std::str::from_utf8(&output.stderr).unwrap()
-            ));
+            );
         }
         let stdout = std::str::from_utf8(&output.stdout).unwrap();
 


### PR DESCRIPTION
1. Enhance passthrough to reduce active fds by using file handle
2. Upgrade to latest vm-memory v0.6
3. Enhance fuse-backend crate to support guest dirty page tracking.