### PR TITLE
Update dependency to latest version

### DIFF
--- a/CHAGNELOG.md
+++ b/CHAGNELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 - Enhance passthrough to reduce active fds by using file handle
+- implement From<fusedev::Error> for std::io::Error
+- Use `vhost` crate from crates.io
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A rust library for Fuse(filesystem in userspace) servers and virt
 authors = [
     "Liu Bo <bo.liu@linux.alibaba.com>",
     "Liu Jiang <gerry@linux.alibaba.com>",
-    "Peng Tao <bergwolf@hyper.sh>"
+    "Peng Tao <bergwolf@hyper.sh>",
 ]
 readme = "README.md"
 license = "Apache-2.0 AND BSD-3-Clause"
@@ -24,17 +24,17 @@ caps = "0.5.1"
 #iou = { version = "0.3.3", optional = true }
 libc = ">=0.2.68"
 log = ">=0.4.6"
-nix = "0.18.0"
+nix = "0.22"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
-vmm-sys-util = { version = "0.4", optional = true }
+vmm-sys-util = { version = "0.8", optional = true }
 vm-memory = "0.6"
 #vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio.git", branch = "dragonball", optional = true }
-#vhost-rs = { git = "https://github.com/cloud-hypervisor/vhost.git", branch = "dragonball", package = "vhost", optional = true }
+#vhost = { version = "0.1", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.0", features = ["thread-pool"]}
 stderrlog = "0.4"
-vmm-sys-util = "0.4"
+vmm-sys-util = "0.8"
 vm-memory = { version = "0.6", features = ["backend-mmap"] }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 #[cfg(feature = "vhost-user-fs")]
-extern crate vhost_rs;
+extern crate vhost;
 extern crate vm_memory;
 #[cfg(feature = "virtiofs")]
 extern crate vm_virtio;

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -187,9 +187,7 @@ impl<'a, S: BitmapSlice> Writer<'a, S> {
 
         res.map_err(|e| {
             error! {"fail to write to fuse device on commit: {}", e};
-            e.as_errno()
-                .map(|r| io::Error::from_raw_os_error(r as i32))
-                .unwrap_or_else(|| io::Error::new(io::ErrorKind::Other, format!("{}", e)))
+            io::Error::from_raw_os_error(e as i32)
         })
     }
 

--- a/src/transport/fusedev/session.rs
+++ b/src/transport/fusedev/session.rs
@@ -20,7 +20,6 @@ use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::poll::{poll, PollFd, PollFlags};
 use nix::unistd::{getgid, getuid, read};
-use nix::Error as nixError;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::poll::{PollContext, WatchingEvents};
 
@@ -211,7 +210,7 @@ impl FuseChannel {
                                     let writer = Writer::new(fd, buf).unwrap();
                                     return Ok(Some((reader, writer)));
                                 }
-                                Err(nixError::Sys(e)) => match e {
+                                Err(e) => match e {
                                     Errno::ENOENT => {
                                         // ENOENT means the operation was interrupted, it's safe
                                         // to restart
@@ -233,9 +232,6 @@ impl FuseChannel {
                                         )));
                                     }
                                 },
-                                Err(e) => {
-                                    return Err(SessionFailure(format!("epoll error: {}", e)));
-                                }
                             }
                         }
                         x => {

--- a/src/transport/virtiofs/fs_cache_req_handler.rs
+++ b/src/transport/virtiofs/fs_cache_req_handler.rs
@@ -6,11 +6,11 @@ use std::io;
 use std::os::unix::io::RawFd;
 
 #[cfg(feature = "vhost-user-fs")]
-use vhost_rs::vhost_user::message::{
+use vhost::vhost_user::message::{
     VhostUserFSSlaveMsg, VhostUserFSSlaveMsgFlags, VHOST_USER_FS_SLAVE_ENTRIES,
 };
 #[cfg(feature = "vhost-user-fs")]
-use vhost_rs::vhost_user::{SlaveFsCacheReq, VhostUserMasterReqHandler};
+use vhost::vhost_user::{SlaveFsCacheReq, VhostUserMasterReqHandler};
 
 use crate::abi::virtio_fs::RemovemappingOne;
 #[cfg(feature = "vhost-user-fs")]
@@ -64,7 +64,7 @@ impl FsCacheReqHandler for SlaveFsCacheReq {
             VhostUserFSSlaveMsgFlags::MAP_R
         };
 
-        self.fs_slave_map(&msg, fd)?;
+        self.fs_slave_map(&msg, &fd)?;
 
         Ok(())
     }


### PR DESCRIPTION
Update dependency to latest version:
1) use vhost from crates.io
2) use vmm-sys-util v0.8

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>