### PR TITLE
server: do not filter out the RENAME_WHITEOUT flag of rename2

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -282,7 +282,8 @@ impl<F: FileSystem<S> + Sync, D: AsyncDrive, S: BitmapSlice> Server<F, D, S> {
     pub(super) fn rename2(&self, mut ctx: SrvContext<'_, F, D, S>) -> Result<usize> {
         let Rename2In { newdir, flags, .. } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
 
-        let flags = flags & (libc::RENAME_EXCHANGE | libc::RENAME_NOREPLACE) as u32;
+        let flags =
+            flags & (libc::RENAME_EXCHANGE | libc::RENAME_NOREPLACE | libc::RENAME_WHITEOUT) as u32;
 
         self.do_rename(ctx, size_of::<Rename2In>(), newdir, flags)
     }


### PR DESCRIPTION
To use virtio-fs directories as the upperdir of overlayfs in VMs, we
need to passthrough the RENAME_WHITEOUT flag. The Linux kernel commit
519525fa47b5a8155f0b203e49a3a6a2319f75ae already enabled the passthrough
of the flag. Therefore, let's avoid filtering out it for rename2.

Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>