### PR TITLE
filesystem: fix warnings in rust 1.56

### DIFF
--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -22,7 +22,6 @@ pub use fuse::SetattrValid;
 pub use fuse::ROOT_ID;
 
 #[cfg(feature = "async-io")]
-#[doc(inline)]
 mod async_io;
 #[cfg(feature = "async-io")]
 pub use async_io::{AsyncFileSystem, AsyncZeroCopyReader, AsyncZeroCopyWriter};


### PR DESCRIPTION
Got:
warning: this attribute can only be applied to a `use` item
  --> src/api/filesystem/mod.rs:25:7
   |
25 | #[doc(inline)]
   |       ^^^^^^ only applicable on `use` items
26 | mod async_io;
   | ------------- not a `use` item
   |
   = note: `#[warn(invalid_doc_attributes)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
   = note: read https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#docno_inlinedocinline for more information

This commit would fix this problem.

Signed-off-by: Tim Zhang <tim@hyper.sh>