### PR TITLE
virtiofs: update to use virtio-queue 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,16 @@ libc = ">=0.2.68"
 log = ">=0.4.6"
 nix = "0.22"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
-vmm-sys-util = { version = ">=0.8", optional = true }
-vm-memory = { version = "0.6", features = ["backend-atomic"] }
-virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", rev = "6013dd9", optional = true }
-vhost = { version = "0.2", features = ["vhost-user-slave"], optional = true }
+vmm-sys-util = { version = ">=0.9", optional = true }
+vm-memory = { version = "0.7", features = ["backend-mmap"] }
+virtio-queue = { version = "0.1.0", optional = true }
+vhost = { version = "0.3", features = ["vhost-user-slave"], optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.0", features = ["thread-pool"]}
 stderrlog = "0.4"
-vmm-sys-util = ">=0.8"
-vm-memory = { version = "0.6", features = ["backend-mmap", "backend-atomic"] }
+vmm-sys-util = ">=0.9.0"
+vm-memory = { version = "0.7", features = ["backend-mmap"] }
 
 [features]
 default = ["fusedev"]

--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -334,7 +334,7 @@ pub trait ZeroCopyWriter: io::Write {
 }
 
 /// Additional context associated with requests.
-#[derive(Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct Context {
     /// The user ID of the calling process.
     pub uid: libc::uid_t,
@@ -395,18 +395,6 @@ impl Context {
         } else {
             let drive = unsafe { &*(self.drive as *const u8 as *const D) };
             Some(drive.clone())
-        }
-    }
-}
-
-impl Default for Context {
-    fn default() -> Self {
-        Context {
-            uid: 0,
-            gid: 0,
-            pid: 0,
-            #[cfg(feature = "async-io")]
-            drive: 0,
         }
     }
 }

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -48,8 +48,8 @@ use std::ptr::copy_nonoverlapping;
 use virtio_queue::{DescriptorChain, Error as QueueError};
 use vm_memory::bitmap::BitmapSlice;
 use vm_memory::{
-    Address, ByteValued, GuestMemory, GuestMemoryAtomic, GuestMemoryError, GuestMemoryMmap,
-    GuestMemoryRegion, VolatileMemory, VolatileMemoryError, VolatileSlice,
+    Address, ByteValued, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
+    VolatileMemory, VolatileMemoryError, VolatileSlice,
 };
 
 use super::{FileReadWriteVolatile, IoBuffers, Reader};
@@ -105,10 +105,11 @@ impl std::error::Error for Error {}
 
 impl<'a> Reader<'a> {
     /// Construct a new Reader wrapper over `desc_chain`.
-    pub fn new(
-        mem: &'a GuestMemoryMmap,
-        desc_chain: DescriptorChain<GuestMemoryAtomic<GuestMemoryMmap>>,
-    ) -> Result<Reader<'a>> {
+    pub fn new<M>(mem: &'a GuestMemoryMmap, desc_chain: DescriptorChain<M>) -> Result<Reader<'a>>
+    where
+        M: Deref,
+        M::Target: GuestMemory + Sized,
+    {
         let mut total_len: usize = 0;
         let buffers = desc_chain
             .readable()
@@ -157,10 +158,11 @@ pub struct Writer<'a, S = ()> {
 
 impl<'a> Writer<'a> {
     /// Construct a new Writer wrapper over `desc_chain`.
-    pub fn new(
-        mem: &'a GuestMemoryMmap,
-        desc_chain: DescriptorChain<GuestMemoryAtomic<GuestMemoryMmap>>,
-    ) -> Result<Writer<'a>> {
+    pub fn new<M>(mem: &'a GuestMemoryMmap, desc_chain: DescriptorChain<M>) -> Result<Writer<'a>>
+    where
+        M: Deref,
+        M::Target: GuestMemory + Sized,
+    {
         let mut total_len: usize = 0;
         let buffers = desc_chain
             .writable()
@@ -486,7 +488,7 @@ mod tests {
         mut buffers_start_addr: GuestAddress,
         descriptors: Vec<(DescriptorType, u32)>,
         spaces_between_regions: u32,
-    ) -> Result<DescriptorChain<GuestMemoryAtomic<GuestMemoryMmap>>> {
+    ) -> Result<DescriptorChain<GuestMemoryMmap>> {
         let descriptors_len = descriptors.len();
         for (index, (type_, size)) in descriptors.into_iter().enumerate() {
             let mut flags = 0;


### PR DESCRIPTION
So that we no longer rely on a non-release git commit.
