### PR TITLE
api: support more server APIs

### DIFF
--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -111,6 +111,50 @@ pub struct DirEntry<'a> {
     pub name: &'a [u8],
 }
 
+/// Represents a fuse lock
+#[derive(Copy, Clone)]
+pub struct FileLock {
+    /// Lock range start
+    pub start: u64,
+    /// Lock range end, exclusive?
+    pub end: u64,
+    /// Lock type
+    pub lock_type: u32,
+    /// thread id who owns the lock
+    pub pid: u32,
+}
+
+impl From<fuse::FileLock> for FileLock {
+    fn from(l: fuse::FileLock) -> FileLock {
+        FileLock {
+            start: l.start,
+            end: l.end,
+            lock_type: l.type_,
+            pid: l.pid,
+        }
+    }
+}
+
+impl From<FileLock> for fuse::FileLock {
+    fn from(l: FileLock) -> fuse::FileLock {
+        fuse::FileLock {
+            start: l.start,
+            end: l.end,
+            type_: l.lock_type,
+            pid: l.pid,
+        }
+    }
+}
+
+/// ioctl data and result
+#[derive(Default, Clone)]
+pub struct IoctlData<'a> {
+    /// ioctl result
+    pub result: i32,
+    /// ioctl data
+    pub data: Option<&'a [u8]>,
+}
+
 /// A reply to a `getxattr` method call.
 pub enum GetxattrReply {
     /// The value of the requested extended attribute. This can be arbitrary textual or binary data

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -126,7 +126,10 @@ impl ServerUtil {
         // Allocate buffer without zeroing out the content for performance.
         let mut buf = Vec::<u8>::with_capacity(len);
         // It's safe because read_exact() is called to fill all the allocated buffer.
-        unsafe { buf.set_len(len) };
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            buf.set_len(len)
+        };
         r.read_exact(&mut buf).map_err(Error::DecodeMessage)?;
 
         Ok(buf)


### PR DESCRIPTION
Let the underlying file system decide if they want to handle them.
Add ioctl, getlk, setlk, setlkw, bmap and poll support.

Note, for ioctl we return ENOTTY by default to simulate that the API is
actually implemented but no ioctl is supported. This is needed because
newer overlayfs would query underlying fs for some security features and
we cannot return ENOSYS otherwise the error is treated as fatal and
popped up to userspace.

Signed-off-by: Peng Tao <bergwolf@hyper.sh>