### PR TITLE
release: prepare for the 0.3.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Publish
+        run: |
+          sudo apt-get update && sudo apt-get install -y sed
+          VERSION=$(sed -E -n 's/^version = \"(.*)"$/\1/p' Cargo.toml)
+          [ "$GITHUB_REF_NAME" == "v$VERSION" ]
+          cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v1

--- a/CHAGNELOG.md
+++ b/CHAGNELOG.md
@@ -1,6 +1,16 @@
 # Changelog
-## [v0.2.0]
+## [v0.3.0]
+### Added
+- Optionally enable MAX_PAGES feature
+- Allow customizing the default FUSE features before creating a new vfs structure
+- Support more FUSE server APIs
 
+### Changed
+- The FUSE server has no default FUSE feature set now. The default feature set is only
+  defined in VfsOptions. Non VFS users have to define the default FUSE feature set in
+  the init() method.
+
+## [v0.2.0]
 ### Added
 - Enhance passthrough to reduce active fds by using file handle
 - implement From<fusedev::Error> for std::io::Error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse-backend-rs"
-version = "0.2.0"
+version = "0.3.0"
 keywords = ["fuse", "virtio", "virtio-fs", "vhost-user-fs"]
 categories = ["filesystem", "os::linux-apis"]
 description = "A rust library for Fuse(filesystem in userspace) servers and virtio-fs devices"


### PR DESCRIPTION
Add a github action to help publish and release automatically when a new tag is pushed.

Tested here:
https://github.com/bergwolf/fuse-backend-rs/runs/5091078480?check_suite_focus=true
https://github.com/bergwolf/fuse-backend-rs/releases/tag/v1.4.0
https://crates.io/crates/my-test-app-bergwolf/1.4.0