### PR TITLE
action: run all tests in docker-smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ check: build
 smoke: check
 	cargo test --features="fusedev" -- --nocapture
 
+smoke-all: smoke
+	cargo test --features="fusedev" -- --nocapture --ignored
+
 smoke-macos: check-macos
 	cargo test --features="fusedev" -- --nocapture
 
 docker-smoke:
-	docker run --rm --privileged -v ${current_dir}:/fuse-rs rust:1.58.1 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke"
+	docker run --rm --privileged -v ${current_dir}:/fuse-rs rust:1.58.1 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke-all"

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -36,7 +36,7 @@ mod fusedev_tests {
 
         let src_md5 = exec(
             format!(
-                "cd {}; git ls-files --recurse-submodules | xargs md5sum; cd - > /dev/null",
+                "cd {}; git ls-files --recurse-submodules | grep -v rust-vmm-ci | xargs md5sum; cd - > /dev/null",
                 src
             )
             .as_str(),
@@ -44,7 +44,7 @@ mod fusedev_tests {
         .unwrap();
         let dest_md5 = exec(
             format!(
-                "cd {}; git ls-files --recurse-submodules | xargs md5sum; cd - > /dev/null",
+                "cd {}; git ls-files --recurse-submodules | grep -v rust-vmm-ci | xargs md5sum; cd - > /dev/null",
                 dest
             )
             .as_str(),


### PR DESCRIPTION
Turns out that we have ignored a few tests by default to make it work
when /dev/fuse is not available. But for docker-smoke, we should really
run them all.

Signed-off-by: Peng Tao <bergwolf@hyper.sh>