### PR TITLE
cargo: fix and enforce clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ build-macos:
 
 check-macos: build-macos
 	cargo fmt -- --check
-	cargo clippy --features="fusedev" -- -Dclippy::all
+	cargo clippy --features="fusedev" -- -Dwarnings
 	cargo test --features="fusedev" -- --nocapture --skip integration
 
 check: build
 	cargo fmt -- --check
-	cargo clippy --features="fusedev" -- -Dclippy::all
-	cargo clippy --features="virtiofs" -- -Dclippy::all
-	cargo clippy --features="vhost-user-fs" -- -Dclippy::all
+	cargo clippy --features="fusedev" -- -Dwarnings
+	cargo clippy --features="virtiofs" -- -Dwarnings
+	cargo clippy --features="vhost-user-fs" -- -Dwarnings
 	cargo test --features="virtiofs" -- --nocapture --skip integration
 	cargo test --features="fusedev" -- --nocapture --skip integration
 	cargo test --features="vhost-user-fs" -- --nocapture --skip integration

--- a/src/api/pseudo_fs.rs
+++ b/src/api/pseudo_fs.rs
@@ -235,6 +235,7 @@ impl PseudoFs {
         self.inodes.store(Arc::new(hashmap));
     }
 
+    #[allow(dead_code)]
     pub fn evict_inode(&self, ino: u64) {
         let _guard = self.lock.lock();
         let inodes = self.inodes.load();

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -135,7 +135,7 @@ impl<F: AsyncFileSystem<D> + Sync, D: AsyncDrive> Server<F, D> {
             Opcode::from(in_header.opcode),
             in_header
         );
-        hook.map_or((), |h| h.collect(&in_header));
+        hook.map_or((), |h| h.collect(in_header));
 
         let res = match in_header.opcode {
             x if x == Opcode::Lookup as u32 => self.async_lookup(ctx).await,
@@ -217,7 +217,7 @@ impl<F: AsyncFileSystem<D> + Sync, D: AsyncDrive> Server<F, D> {
         let name = bytes_to_cstr(buf.as_ref())?;
         let result = self
             .fs
-            .async_lookup(ctx.context(), ctx.nodeid(), &name)
+            .async_lookup(ctx.context(), ctx.nodeid(), name)
             .await;
 
         match result {

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -213,10 +213,12 @@ impl MountFds {
         MountFds::default()
     }
 
+    #[allow(dead_code)]
     pub fn get_map(&self) -> RwLockReadGuard<'_, HashMap<u64, std::fs::File>> {
         self.map.read().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn get_map_mut(&self) -> RwLockWriteGuard<'_, HashMap<u64, std::fs::File>> {
         self.map.write().unwrap()
     }

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -8,8 +8,7 @@
 //! sequentially. A FUSE session is a connection from a FUSE mountpoint to a FUSE server daemon.
 //! A FUSE session can have multiple FUSE channels so that FUSE requests are handled in parallel.
 
-use mio::unix::SourceFd;
-use mio::{Events, Interest, Poll, Token, Waker};
+use mio::{Events, Poll, Token, Waker};
 use std::fs::{File, OpenOptions};
 use std::ops::Deref;
 use std::os::unix::fs::PermissionsExt;
@@ -24,9 +23,7 @@ use nix::poll::{poll, PollFd, PollFlags};
 use nix::sys::epoll::{epoll_ctl, EpollEvent, EpollFlags, EpollOp};
 use nix::unistd::{getgid, getuid, read};
 
-use super::{
-    super::pagesize, Error::IoError, Error::SessionFailure, FuseBuf, Reader, Result, Writer,
-};
+use super::{super::pagesize, Error::SessionFailure, FuseBuf, Reader, Result, Writer};
 
 // These follows definition from libfuse.
 const FUSE_KERN_BUF_SIZE: usize = 256;


### PR DESCRIPTION
Turns out that we missed clippy for a long time by passing a wrong
argument to clippy. Re-enable it and fix all the remaining failures.