### PR TITLE
upgrade nix to 0.23.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = ">=1.1.0"
 #iou = { version = "0.3.3", optional = true }
 libc = ">=0.2.68"
 log = ">=0.4.6"
-nix = "0.22"
+nix = "0.23.1"
 lazy_static = "1.4"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
 vmm-sys-util = { version = ">=0.9", optional = true }


### PR DESCRIPTION
This is to fix the warning of `cargo deny check bans`.
Sync to the version of image-service.

```
warning[B004]: found 3 duplicate entries for crate 'nix'
   ┌─ ./dragonball-sandbox/Cargo.lock:87:1
   │
87 │ ╭ nix 0.15.0 registry+https://github.com/rust-lang/crates.io-index
88 │ │ nix 0.22.3 registry+https://github.com/rust-lang/crates.io-index
89 │ │ nix 0.23.1 registry+https://github.com/rust-lang/crates.io-index
   │ ╰────────────────────────────────────────────────────────────────^ lock entries
   │
   = nix v0.15.0
     ├── dbs-address-space v0.1.0
     └── dbs-virtio-devices v0.1.0
   = nix v0.22.3
     └── fuse-backend-rs v0.4.0
         ├── blobfs v0.1.0
         │   └── dbs-virtio-devices v0.1.0
         ├── dbs-virtio-devices v0.1.0 (*)
         ├── nydus-utils v0.1.0
         │   ├── rafs v0.1.0
         │   │   ├── blobfs v0.1.0 (*)
         │   │   └── dbs-virtio-devices v0.1.0 (*)
         │   └── storage v0.5.0
         │       ├── blobfs v0.1.0 (*)
         │       └── rafs v0.1.0 (*)
         ├── rafs v0.1.0 (*)
         └── storage v0.5.0 (*)
   = nix v0.23.1
     ├── rafs v0.1.0
     │   ├── blobfs v0.1.0
     │   │   └── dbs-virtio-devices v0.1.0
     │   └── dbs-virtio-devices v0.1.0 (*)
     └── storage v0.5.0
         ├── blobfs v0.1.0 (*)
         └── rafs v0.1.0 (*)
```

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>