### PR TITLE
passthrough: hornor no_open in do_getattr()

### DIFF
--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -222,8 +222,11 @@ impl<D: AsyncDrive> PassthroughFs<D> {
             e
         })?;
 
-        if let Some(h) = handle {
-            let hd = self.handle_map.get(h, inode)?;
+        // kernel sends 0 as handle in case of no_open, and it depends on fuse server to handle
+        // this case correctly.
+        if !self.no_open.load(Ordering::Relaxed) && handle.is_some() {
+            // Safe as we just checked handle
+            let hd = self.handle_map.get(handle.unwrap(), inode)?;
             fd = hd.get_handle_raw_fd();
             st = Self::stat_fd(fd, None);
         } else {


### PR DESCRIPTION
Otherwise we'll get EBADF failure as we can't find handle in handle map.

Fixes: 2895435c15e7 ("passthrough: optimize async_do_getattr/do_getattr()")
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>