### PR TITLE
Prepare for releasing v0.9.1

### DIFF
--- a/CHAGNELOG.md
+++ b/CHAGNELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## [0.9.1]
+
+### Fixed
+- [#74](https://github.com/cloud-hypervisor/fuse-backend-rs/pull/74): Fixed some issues about EINTR and EAGIN handled incorrectly
+
 ## [v0.4.0]
 ### Added
 - MacOS support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse-backend-rs"
-version = "0.9.0"
+version = "0.9.1"
 keywords = ["fuse", "virtio", "virtio-fs", "vhost-user-fs"]
 categories = ["filesystem", "os::linux-apis"]
 description = "A rust library for Fuse(filesystem in userspace) servers and virtio-fs devices"


### PR DESCRIPTION
Prepare for v0.9.1 to fix a bug in handling error code.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>