### PR TITLE
pseudo_fs: no need to swap hashmap

### DIFF
--- a/src/api/pseudo_fs.rs
+++ b/src/api/pseudo_fs.rs
@@ -210,11 +210,8 @@ impl PseudoFs {
 
     // Caller must hold PseudoFs.lock.
     fn insert_inode(&self, inode: Arc<PseudoInode>) {
-        let mut hashmap = self.inodes.load().deref().deref().clone();
-
+        let mut hashmap = self.inodes.load().deref().deref();
         hashmap.insert(inode.ino, inode);
-
-        self.inodes.store(Arc::new(hashmap));
     }
 
     // Caller must hold PseudoFs.lock.


### PR DESCRIPTION
ArcSwap::load() method give us mutable reference, no
need to clone the entire hash map and swap the original
hash map. This patch should reduce CPU and memory overhead.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>