### PR TITLE
Reduce dependent crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ build = "build.rs"
 arc-swap = "1.5"
 async-trait = { version = "0.1.42", optional = true }
 bitflags = "1.1"
-futures = { version = "0.3", optional = true }
 libc = "0.2.68"
 log = "0.4.6"
 mio = { version = "0.8", features = ["os-poll", "os-ext"]}
@@ -28,7 +27,7 @@ nix = "0.24"
 lazy_static = "1.4"
 tokio = { version = "1", optional = true }
 vmm-sys-util = { version = "0.10", optional = true }
-vm-memory = { version = "0.8", features = ["backend-mmap"] }
+vm-memory = { version = "0.9", features = ["backend-mmap"] }
 virtio-queue = { version = "0.4", optional = true }
 vhost = { version = "0.4", features = ["vhost-user-slave"], optional = true }
 
@@ -36,23 +35,21 @@ vhost = { version = "0.4", features = ["vhost-user-slave"], optional = true }
 core-foundation-sys = { version = ">=0.8", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-caps = { version = "0.3", optional = true }
-tokio-uring = "0.3.0"
-io-uring = { version = "0.5.2", features = ["unstable"] }
+caps = { version = "0.5", optional = true }
+tokio-uring = "0.3"
+io-uring = { version = "0.5", features = ["unstable"] }
 socket2 = { version = "0.4.4", features = ["all"] }
 scoped-tls = "1.0.0"
 slab = "0.4.6"
 
 [dev-dependencies]
-futures = { version = "0.3", features = ["thread-pool"]}
-stderrlog = "0.5"
-vmm-sys-util = "0.10"
-vm-memory = { version = "0.8", features = ["backend-mmap", "backend-bitmap"] }
 tokio-test = "0.4.2"
+vmm-sys-util = "0.10"
+vm-memory = { version = "0.9", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]
-async-io = ["async-trait", "futures", "tokio/fs", "tokio/net", "tokio/sync", "tokio/rt", "tokio/macros"]
+async-io = ["async-trait", "tokio/fs", "tokio/net", "tokio/sync", "tokio/rt", "tokio/macros"]
 fusedev = ["vmm-sys-util", "caps", "core-foundation-sys"]
 virtiofs = ["virtio-queue", "caps"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]

--- a/src/common/file_traits.rs
+++ b/src/common/file_traits.rs
@@ -454,7 +454,7 @@ pub use async_io::AsyncFileReadWriteVolatile;
 mod async_io {
     use std::sync::Arc;
 
-    use futures::join;
+    use tokio::join;
 
     use super::*;
     use crate::async_file::File;

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -341,7 +341,7 @@ unsafe impl ByteValued for LinuxDirent64 {}
 /// The caching policy that the file system should report to the FUSE client. By default the FUSE
 /// protocol uses close-to-open consistency. This means that any cached contents of the file are
 /// invalidated the next time that file is opened.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum CachePolicy {
     /// The client should never cache file data and all I/O should be directly forwarded to the
     /// server. This policy must be selected when file contents may change without the knowledge of
@@ -379,7 +379,7 @@ impl Default for CachePolicy {
 }
 
 /// Options that configure the behavior of the passthrough fuse file system.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Config {
     /// How long the FUSE client should consider directory entries to be valid. If the contents of a
     /// directory can only be modified by the FUSE client (i.e., the file system has exclusive

--- a/src/transport/fusedev/macos_session.rs
+++ b/src/transport/fusedev/macos_session.rs
@@ -429,7 +429,7 @@ fn fuse_kern_umount(file: File, disk: Option<DADiskRef>) -> Result<()> {
 
 fn set_fuse_fd_dead(fd: RawFd) -> std::io::Result<()> {
     unsafe {
-        match ioctl::set_fuse_fd_dead(fd, std::mem::transmute(&fd)) {
+        match ioctl::set_fuse_fd_dead(fd, &fd as *const i32 as *const u32) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.into()),
         }

--- a/tests/macfuse_smoke.rs
+++ b/tests/macfuse_smoke.rs
@@ -11,8 +11,6 @@ mod example;
 
 #[cfg(all(feature = "fusedev", target_os = "macos"))]
 mod macfuse_tests {
-    extern crate stderrlog;
-
     use std::io::Result;
     use std::process::Command;
 
@@ -52,17 +50,6 @@ mod macfuse_tests {
         let stdout = std::str::from_utf8(&output.stdout).unwrap();
 
         return Ok(stdout.to_string());
-    }
-
-    #[test]
-    fn integration_test_init() -> Result<()> {
-        stderrlog::new()
-            .quiet(false)
-            .timestamp(stderrlog::Timestamp::Microsecond)
-            .verbosity(log::LevelFilter::Trace as usize - 1)
-            .init()
-            .unwrap();
-        Ok(())
     }
 
     #[test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -11,8 +11,6 @@ mod example;
 
 #[cfg(all(feature = "fusedev", target_os = "linux"))]
 mod fusedev_tests {
-    extern crate stderrlog;
-
     use std::io::Result;
     use std::path::Path;
     use std::process::Command;
@@ -73,17 +71,6 @@ mod fusedev_tests {
         let stdout = std::str::from_utf8(&output.stdout).unwrap();
 
         return Ok(stdout.to_string());
-    }
-
-    #[test]
-    fn integration_test_init() -> Result<()> {
-        stderrlog::new()
-            .quiet(false)
-            .timestamp(stderrlog::Timestamp::Microsecond)
-            .verbosity(log::LevelFilter::Trace as usize - 1)
-            .init()
-            .unwrap();
-        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Refine Cargo.toml to reduce dependent crates.

root@de1000351b95:/fuse-backend# cargo update
    Updating crates.io index
    Removing android_system_properties v0.1.4
    Removing atty v0.2.14
    Removing bumpalo v3.11.0
    Updating caps v0.3.4 -> v0.5.4
    Removing cc v1.0.73
    Removing chrono v0.4.22
    Removing errno v0.2.8
    Removing errno-dragonfly v0.1.2
    Removing error-chain v0.12.4
    Removing futures v0.3.23
    Removing futures-channel v0.3.23
    Removing futures-executor v0.3.23
    Removing futures-io v0.3.23
    Removing futures-macro v0.3.23
    Removing futures-sink v0.3.23
    Removing futures-task v0.3.23
    Removing futures-util v0.3.23
    Removing hermit-abi v0.1.19
    Removing iana-time-zone v0.1.46
    Removing js-sys v0.3.59
    Removing memchr v2.5.0
    Removing num-integer v0.1.45
    Removing num-traits v0.2.15
    Removing num_cpus v1.13.1
    Removing pin-utils v0.1.0
    Removing stderrlog v0.5.3
    Removing termcolor v1.1.3
      Adding thiserror v1.0.32
      Adding thiserror-impl v1.0.32
    Removing thread_local v1.1.4
    Removing time v0.1.44
    Removing version_check v0.9.4
    Removing vm-memory v0.8.0
    Removing wasi v0.10.0+wasi-snapshot-preview1
    Removing wasm-bindgen v0.2.82
    Removing wasm-bindgen-backend v0.2.82
    Removing wasm-bindgen-macro v0.2.82
    Removing wasm-bindgen-macro-support v0.2.82
    Removing wasm-bindgen-shared v0.2.82
    Removing winapi-util v0.1.5

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>