### PR TITLE
Vfs: remove no opendir flags correctly

### DIFF
--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -25,7 +25,11 @@ impl FileSystem for Vfs {
         } else {
             n_opts.out_opts.remove(FsOptions::ZERO_MESSAGE_OPEN);
         }
-        n_opts.no_opendir = !(opts & FsOptions::ZERO_MESSAGE_OPENDIR).is_empty();
+        if n_opts.no_opendir {
+            n_opts.no_opendir = !(opts & FsOptions::ZERO_MESSAGE_OPENDIR).is_empty();
+        } else {
+            n_opts.out_opts.remove(FsOptions::ZERO_MESSAGE_OPENDIR);
+        }
         if n_opts.no_writeback {
             n_opts.out_opts.remove(FsOptions::WRITEBACK_CACHE);
         }


### PR DESCRIPTION
Like the commit 345bc0924299ebe9a92210403c10648ba3d5f8e9, we should also
remove ZERO_MESSAGE_OPENDIR when no_opendir is disabled, otherwise,
passthroughfs would always set its no_opendir to true.

Fixes: 345bc0924299ebe9a92210403c10648ba3d5f8e9
Reported-by: Daowen Luo <luodaowen.backend@bytedance.com>
Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>