### PR TITLE
passthrough: open file with O_APPEND cleared when writeback is enabled

### DIFF
--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -28,17 +28,7 @@ use crate::transport::FsCacheReqHandler;
 
 impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
     fn open_inode(&self, inode: Inode, flags: i32) -> io::Result<File> {
-        let mut new_flags = self.get_writeback_open_flags(flags);
-
-        // When writeback caching is enabled the kernel is responsible for handling `O_APPEND`.
-        // However, this breaks atomicity as the file may have changed on disk, invalidating the
-        // cached copy of the data in the kernel and the offset that the kernel thinks is the end of
-        // the file. Just allow this for now as it is the user's responsibility to enable writeback
-        // caching only for directories that are not shared. It also means that we need to clear the
-        // `O_APPEND` flag.
-        if self.writeback.load(Ordering::Relaxed) && flags & libc::O_APPEND != 0 {
-            new_flags &= !libc::O_APPEND;
-        }
+        let new_flags = self.get_writeback_open_flags(flags);
 
         let data = self.inode_map.get(inode)?;
         let file = data.get_file(&self.mount_fds)?;


### PR DESCRIPTION
When writeback caching is enabled the kernel is responsible for handling `O_APPEND`. And we only did this in OPEN reuqest but not in CREATE request.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>