### PR TITLE
log: print some variables in hexadecimal

### DIFF
--- a/src/abi/fuse_abi.rs
+++ b/src/abi/fuse_abi.rs
@@ -6,6 +6,7 @@
 
 #![allow(missing_docs)]
 
+use std::fmt::{Debug, Formatter};
 use std::mem;
 
 use bitflags::bitflags;
@@ -1169,7 +1170,7 @@ pub struct FallocateIn {
 unsafe impl ByteValued for FallocateIn {}
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct InHeader {
     pub len: u32,
     pub opcode: u32,
@@ -1181,6 +1182,16 @@ pub struct InHeader {
     pub padding: u32,
 }
 unsafe impl ByteValued for InHeader {}
+
+impl Debug for InHeader {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InHeader {{ len: {}, opcode: {}, unique: {}, nodeid: 0x{:x}, uid: {}, gid: {}, pid: {}, padding: {} }}",
+            self.len, self.opcode, self.unique, self.nodeid, self.uid, self.gid, self.pid, self.padding
+        )
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -607,7 +607,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         vu_req: &mut dyn FsCacheReqHandler,
     ) -> io::Result<()> {
         debug!(
-            "fuse: setupmapping ino {:?} foffset {} len {} flags {} moffset {}",
+            "fuse: setupmapping ino {:?} foffset 0x{:x} len 0x{:x} flags 0x{:x} moffset 0x{:x}",
             inode, foffset, len, flags, moffset
         );
 


### PR DESCRIPTION
HEX is more readable for some data, like nodeid/offset/length.

Signed-off-by: gexuyang <gexuyang@linux.alibaba.com>