### PR TITLE
Derive Default for CachePolicy (and update Rust CI version)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ smoke-macos: check-macos
 	cargo test --features="fusedev" -- --nocapture
 
 docker-smoke:
-	docker run --env RUST_BACKTRACE=1 --rm --privileged -v ${current_dir}:/fuse-rs rust:1.59 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke-all"
+	docker run --env RUST_BACKTRACE=1 --rm --privileged -v ${current_dir}:/fuse-rs rust:1.68 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke-all"

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -342,7 +342,7 @@ unsafe impl ByteValued for LinuxDirent64 {}
 /// The caching policy that the file system should report to the FUSE client. By default the FUSE
 /// protocol uses close-to-open consistency. This means that any cached contents of the file are
 /// invalidated the next time that file is opened.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum CachePolicy {
     /// The client should never cache file data and all I/O should be directly forwarded to the
     /// server. This policy must be selected when file contents may change without the knowledge of
@@ -351,6 +351,7 @@ pub enum CachePolicy {
 
     /// The client is free to choose when and how to cache file data. This is the default policy and
     /// uses close-to-open consistency as described in the enum documentation.
+    #[default]
     Auto,
 
     /// The client should always cache file data. This means that the FUSE client will not
@@ -370,12 +371,6 @@ impl FromStr for CachePolicy {
             "always" | "Always" | "ALWAYS" => Ok(CachePolicy::Always),
             _ => Err("invalid cache policy"),
         }
-    }
-}
-
-impl Default for CachePolicy {
-    fn default() -> Self {
-        CachePolicy::Auto
     }
 }
 


### PR DESCRIPTION
Thanks to `cargo clippy` for the suggestion.

See
https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls for background.

Edit: we also need to update our CI's version of Rust, as the necessary feature has only been stabilized recently.