### PR TITLE
api: forget and batch forget must not reply

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ pub enum Error {
     /// The `size` field of the `SetxattrIn` message does not match the length
     /// of the decoded value.
     InvalidXattrSize((u32, usize)),
+    /// Invalid message that the server cannot handle properly.
+    InvalidMessage(io::Error),
 }
 
 impl error::Error for Error {}
@@ -92,6 +94,7 @@ impl fmt::Display for Error {
                 "The `size` field of the `SetxattrIn` message does not match the length of the \
                  decoded value: size = {size}, value.len() = {len}"
             ),
+            InvalidMessage(err) => write!(f, "cannot process fuse message: {err}"),
         }
     }
 }


### PR DESCRIPTION
Otherwise, the kernel would fail the reply write syscall with ENOENT and we cannot tell whether it's because fuse connection is closed or not.