### PR TITLE
workflow: run smoke test w/o docker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,9 @@ jobs:
     - name: build and check
       run: make check
     - name: smoke
-      run: make docker-smoke
+      run: |
+        echo user_allow_other | sudo tee -a /etc/fuse.conf
+        make smoke-all
 
   Macos-CI:
     runs-on: macos-latest

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -408,10 +408,6 @@ fn msflags_to_string(flags: MsFlags) -> String {
         (MsFlags::MS_NOEXEC, ("exec", "noexec")),
         (MsFlags::MS_SYNCHRONOUS, ("async", "sync")),
         (MsFlags::MS_NOATIME, ("atime", "noatime")),
-        (MsFlags::MS_NODIRATIME, ("diratime", "nodiratime")),
-        (MsFlags::MS_LAZYTIME, ("nolazytime", "lazytime")),
-        (MsFlags::MS_RELATIME, ("norelatime", "relatime")),
-        (MsFlags::MS_STRICTATIME, ("nostrictatime", "strictatime")),
     ]
     .map(
         |(flag, (neg, pos))| {


### PR DESCRIPTION
Now with fusermount3, we can mount with a normal user. So no need for docker to run somke.