### PR TITLE
fix: low probability IO hang problem

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -121,7 +121,12 @@ impl<F: FileSystem + Sync> Server<F> {
 
     fn lookup<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, 0)?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
+
         let version = self.vers.load();
         let result = self.fs.lookup(ctx.context(), ctx.nodeid(), name);
 
@@ -205,7 +210,11 @@ impl<F: FileSystem + Sync> Server<F> {
             mode, rdev, umask, ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<MknodIn>())?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self
             .fs
@@ -219,7 +228,11 @@ impl<F: FileSystem + Sync> Server<F> {
     pub(super) fn mkdir<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let MkdirIn { mode, umask } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<MkdirIn>())?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self
             .fs
@@ -232,7 +245,11 @@ impl<F: FileSystem + Sync> Server<F> {
 
     pub(super) fn unlink<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, 0)?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self.fs.unlink(ctx.context(), ctx.nodeid(), name) {
             Ok(()) => ctx.reply_ok(None::<u8>, None),
@@ -242,7 +259,11 @@ impl<F: FileSystem + Sync> Server<F> {
 
     pub(super) fn rmdir<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, 0)?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self.fs.rmdir(ctx.context(), ctx.nodeid(), name) {
             Ok(()) => ctx.reply_ok(None::<u8>, None),
@@ -295,7 +316,11 @@ impl<F: FileSystem + Sync> Server<F> {
     pub(super) fn link<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let LinkIn { oldnodeid } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<LinkIn>())?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self
             .fs
@@ -499,14 +524,16 @@ impl<F: FileSystem + Sync> Server<F> {
         if size != value.len() as u32 {
             return Err(Error::InvalidXattrSize((size, value.len())));
         }
+        let name = bytes_to_cstr(name).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
-        match self.fs.setxattr(
-            ctx.context(),
-            ctx.nodeid(),
-            bytes_to_cstr(name)?,
-            value,
-            flags,
-        ) {
+        match self
+            .fs
+            .setxattr(ctx.context(), ctx.nodeid(), name, value, flags)
+        {
             Ok(()) => ctx.reply_ok(None::<u8>, None),
             Err(e) => ctx.reply_error(e),
         }
@@ -520,7 +547,11 @@ impl<F: FileSystem + Sync> Server<F> {
 
         let buf =
             ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<GetxattrIn>())?;
-        let name = bytes_to_cstr(buf.as_ref())?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self.fs.getxattr(ctx.context(), ctx.nodeid(), name, size) {
             Ok(GetxattrReply::Value(val)) => ctx.reply_ok(None::<u8>, Some(&val)),
@@ -562,7 +593,11 @@ impl<F: FileSystem + Sync> Server<F> {
         mut ctx: SrvContext<'_, F, S>,
     ) -> Result<usize> {
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, 0)?;
-        let name = bytes_to_cstr(&buf)?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self.fs.removexattr(ctx.context(), ctx.nodeid(), name) {
             Ok(()) => ctx.reply_ok(None::<u8>, None),
@@ -870,7 +905,11 @@ impl<F: FileSystem + Sync> Server<F> {
     fn create<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let args: CreateIn = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
         let buf = ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<CreateIn>())?;
-        let name = bytes_to_cstr(&buf)?;
+        let name = bytes_to_cstr(buf.as_ref()).map_err(|e| {
+            let _ = ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::EINVAL));
+            error!("fuse: bytes to cstr error: {:?}, {:?}", buf, e);
+            e
+        })?;
 
         match self.fs.create(ctx.context(), ctx.nodeid(), name, args) {
             Ok((entry, handle, opts)) => {


### PR DESCRIPTION
we found some applications may encounter the io hang:

Call Trace:
[<ffffffff8173ca3b>] ? __schedule+0x23b/0x780
[<ffffffff8173cfb6>] schedule+0x36/0x80
[<ffffffffa0377840>] request_wait_answer+0xc0/0x1f0 [fuse]
[<ffffffff810d5350>] ? prepare_to_wait_event+0x100/0x100
[<ffffffffa03779f4>] __fuse_request_send+0x84/0x90 [fuse]
[<ffffffffa0377a27>] fuse_request_send+0x27/0x30 [fuse]
[<ffffffffa037adaf>] fuse_simple_request+0xcf/0x1a0 [fuse]
[<ffffffffa037c80b>]fuse_dentry_revalidate+0x18b/0x300 [fuse]
[<ffffffff8125b79b>] lookup_fast+0x2eb/0x310
[<ffffffff8125c527>] walk_component+0x47/0x310
[<ffffffff8125d7c7>] path_lookupat+0x67/0x120
[<ffffffff811b6e99>] ? generic_file_read_iter+0x699/0x960
[<ffffffff81260421>] filename_lookup+0xb1/0x180
[<ffffffff812235c6>] ? kmem_cache_alloc+0x146/0x1a0
[<ffffffff8126001f>] ? getname_flags+0x4f/0x1f0
[<ffffffff8126003f>] ? getname_flags+0x6f/0x1f0
[<ffffffff812605c6>] user_path_at_empty+0x36/0x40
[<ffffffff81254896>] vfs_fstatat+0x66/0xc0
...

The root cause MAYBE that fuse daemon encounters errors (bytes_to_cstr() error) when processing requests, but does not reply to kernel.

This patch fixes the issue by adding a reply. Because the exception does not produce any logs, we cannot be 100% sure that it is the cause. However, after applying this patch in our production environment, the issue no longer occurs.