### PR TITLE
fusedev: add fd-passthrough support

### DIFF
--- a/src/abi/fuse_abi_linux.rs
+++ b/src/abi/fuse_abi_linux.rs
@@ -197,6 +197,11 @@ const INIT_EXT: u64 = 0x4000_0000;
 // This flag indicates whether the guest kernel enable per-file dax
 const PERFILE_DAX: u64 = 0x2_0000_0000;
 
+// This flag indicates whether to enable fd-passthrough. It was defined in the
+// Anolis kernel but not in the upstream kernel. To avoid collision, we'll set
+// it to the most significant bit.
+const FD_PASSTHROUGH: u64 = 0x8000_0000_0000_0000;
+
 /**
  *
  * fuse_attr flags
@@ -441,6 +446,9 @@ bitflags! {
         ///  -. create has O_TRUNC and FOPEN_IN_KILL_SUIDGID flag set.
         ///  -. write has WRITE_KILL_PRIV
         const HANDLE_KILLPRIV_V2 = HANDLE_KILLPRIV_V2;
+
+        /// Indicates the kernel support fuse fd passthrough.
+        const FD_PASSTHROUGH = FD_PASSTHROUGH;
 
         /// The fuse_init_in is extended.
         const INIT_EXT = INIT_EXT;
@@ -912,7 +920,7 @@ unsafe impl ByteValued for CreateIn {}
 pub struct OpenOut {
     pub fh: u64,
     pub open_flags: u32,
-    pub padding: u32,
+    pub passthrough: u32,
 }
 unsafe impl ByteValued for OpenOut {}
 

--- a/src/abi/fuse_abi_macos.rs
+++ b/src/abi/fuse_abi_macos.rs
@@ -683,7 +683,7 @@ unsafe impl ByteValued for CreateIn {}
 pub struct OpenOut {
     pub fh: u64,
     pub open_flags: u32,
-    pub padding: u32,
+    pub passthrough: u32,
 }
 unsafe impl ByteValued for OpenOut {}
 

--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -313,9 +313,9 @@ pub trait FileSystem {
         inode: Self::Inode,
         flags: u32,
         fuse_flags: u32,
-    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions, Option<u32>)> {
         // Matches the behavior of libfuse.
-        Ok((None, OpenOptions::empty()))
+        Ok((None, OpenOptions::empty(), None))
     }
 
     /// Create and open a file.
@@ -332,13 +332,14 @@ pub trait FileSystem {
     /// addition to the optional `Handle` and the `OpenOptions`, the file system must also return an
     /// `Entry` for the file. This increases the lookup count for the `Inode` associated with the
     /// file by 1.
+    #[allow(clippy::type_complexity)]
     fn create(
         &self,
         ctx: &Context,
         parent: Self::Inode,
         name: &CStr,
         args: CreateIn,
-    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions)> {
+    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions, Option<u32>)> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
@@ -1021,7 +1022,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
         inode: Self::Inode,
         flags: u32,
         fuse_flags: u32,
-    ) -> io::Result<(Option<Self::Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<Self::Handle>, OpenOptions, Option<u32>)> {
         self.deref().open(ctx, inode, flags, fuse_flags)
     }
 
@@ -1031,7 +1032,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
         parent: Self::Inode,
         name: &CStr,
         args: CreateIn,
-    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions)> {
+    ) -> io::Result<(Entry, Option<Self::Handle>, OpenOptions, Option<u32>)> {
         self.deref().create(ctx, parent, name, args)
     }
 

--- a/src/api/vfs/async_io.rs
+++ b/src/api/vfs/async_io.rs
@@ -71,7 +71,9 @@ impl AsyncFileSystem for Vfs {
             Err(Error::from_raw_os_error(libc::ENOSYS))
         } else {
             match self.get_real_rootfs(inode)? {
-                (Left(fs), idata) => fs.open(ctx, idata.ino(), flags, fuse_flags),
+                (Left(fs), idata) => fs
+                    .open(ctx, idata.ino(), flags, fuse_flags)
+                    .map(|(a, b, _)| (a, b)),
                 (Right(fs), idata) => fs
                     .async_open(ctx, idata.ino(), flags, fuse_flags)
                     .await
@@ -90,7 +92,9 @@ impl AsyncFileSystem for Vfs {
         validate_path_component(name)?;
 
         match self.get_real_rootfs(parent)? {
-            (Left(fs), idata) => fs.create(ctx, idata.ino(), name, args),
+            (Left(fs), idata) => fs
+                .create(ctx, idata.ino(), name, args)
+                .map(|(a, b, c, _)| (a, b, c)),
             (Right(fs), idata) => {
                 fs.async_create(ctx, idata.ino(), name, args)
                     .await

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -299,7 +299,7 @@ impl FileSystem for Vfs {
         inode: VfsInode,
         flags: u32,
         fuse_flags: u32,
-    ) -> Result<(Option<u64>, OpenOptions)> {
+    ) -> Result<(Option<u64>, OpenOptions, Option<u32>)> {
         #[cfg(target_os = "linux")]
         if self.opts.load().no_open {
             return Err(Error::from_raw_os_error(libc::ENOSYS));
@@ -308,7 +308,7 @@ impl FileSystem for Vfs {
             (Left(fs), idata) => fs.open(ctx, idata.ino(), flags, fuse_flags),
             (Right(fs), idata) => fs
                 .open(ctx, idata.ino(), flags, fuse_flags)
-                .map(|(h, opt)| (h.map(Into::into), opt)),
+                .map(|(h, opt, passthrough)| (h.map(Into::into), opt, passthrough)),
         }
     }
 
@@ -318,16 +318,16 @@ impl FileSystem for Vfs {
         parent: VfsInode,
         name: &CStr,
         args: CreateIn,
-    ) -> Result<(Entry, Option<u64>, OpenOptions)> {
+    ) -> Result<(Entry, Option<u64>, OpenOptions, Option<u32>)> {
         validate_path_component(name)?;
 
         match self.get_real_rootfs(parent)? {
             (Left(fs), idata) => fs.create(ctx, idata.ino(), name, args),
             (Right(fs), idata) => {
                 fs.create(ctx, idata.ino(), name, args)
-                    .map(|(mut a, b, c)| {
+                    .map(|(mut a, b, c, d)| {
                         self.convert_entry(idata.fs_idx(), a.inode, &mut a)?;
-                        Ok((a, b, c))
+                        Ok((a, b, c, d))
                     })?
             }
         }

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -1689,7 +1689,7 @@ mod tests {
             umask: 0,
             fuse_flags: 0,
         };
-        let (entry, handle, _) = fs.create(&ctx, ROOT_ID, &fname, args).unwrap();
+        let (entry, handle, _, _) = fs.create(&ctx, ROOT_ID, &fname, args).unwrap();
         let handle_data = fs.handle_map.get(handle.unwrap(), entry.inode).unwrap();
         let mut f = unsafe { File::from_raw_fd(handle_data.get_handle_raw_fd()) };
         let mut buf = [0; 4];
@@ -1700,7 +1700,7 @@ mod tests {
         // Then Open an existing file with O_WRONLY, we should be able to read it as well.
         let fname = CString::new("existfile").unwrap();
         let entry = fs.lookup(&ctx, ROOT_ID, &fname).unwrap();
-        let (handle, _) = fs
+        let (handle, _, _) = fs
             .open(&ctx, entry.inode, libc::O_WRONLY as u32, 0)
             .unwrap();
         let handle_data = fs.handle_map.get(handle.unwrap(), entry.inode).unwrap();

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -178,7 +178,7 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
         inode: Inode,
         flags: u32,
         fuse_flags: u32,
-    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<Handle>, OpenOptions, Option<u32>)> {
         let killpriv = if self.killpriv_v2.load(Ordering::Relaxed)
             && (fuse_flags & FOPEN_IN_KILL_SUIDGID != 0)
         {
@@ -204,7 +204,7 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
             _ => {}
         };
 
-        Ok((Some(handle), opts))
+        Ok((Some(handle), opts, None))
     }
 
     fn do_getattr(
@@ -396,6 +396,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             Err(io::Error::from_raw_os_error(libc::ENOSYS))
         } else {
             self.do_open(inode, flags | (libc::O_DIRECTORY as u32), 0)
+                .map(|(a, b, _)| (a, b))
         }
     }
 
@@ -516,7 +517,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         inode: Inode,
         flags: u32,
         fuse_flags: u32,
-    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<Handle>, OpenOptions, Option<u32>)> {
         if self.no_open.load(Ordering::Relaxed) {
             info!("fuse: open is not supported.");
             Err(io::Error::from_raw_os_error(libc::ENOSYS))
@@ -548,7 +549,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         parent: Inode,
         name: &CStr,
         args: CreateIn,
-    ) -> io::Result<(Entry, Option<Handle>, OpenOptions)> {
+    ) -> io::Result<(Entry, Option<Handle>, OpenOptions, Option<u32>)> {
         self.validate_path_component(name)?;
 
         let dir = self.inode_map.get(parent)?;
@@ -604,7 +605,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             _ => {}
         };
 
-        Ok((entry, ret_handle, opts))
+        Ok((entry, ret_handle, opts, None))
     }
 
     fn unlink(&self, _ctx: &Context, parent: Inode, name: &CStr) -> io::Result<()> {


### PR DESCRIPTION
This patch adds support for fd-passthrough feature (in anolis kernel). The fd-passthrough feature significantly improves the read/write performance of passthrough filesystems.
However, it only supports fuse not virtiofs.

About fd-passthrough, see:

https://gitee.com/anolis/cloud-kernel/commit/ea085d4df6697594772a72b55f1ea53018646c3c https://gitee.com/anolis/cloud-kernel/commit/433ec5ac4cea91cebf5682fa729a570c00bb60c5 https://gitee.com/anolis/cloud-kernel/commit/b4f2155fbfafca7763739b9a5a11585ee59f3c67 https://gitee.com/anolis/cloud-kernel/commit/63c4968a7881f61a2ad04176d3ad3a4e3aa1e706 https://gitee.com/anolis/cloud-kernel/commit/01ec57c17665cd793f115385ac8ba2ca735fe582 https://gitee.com/anolis/cloud-kernel/commit/5c7c7e9ec18fba42d03910ac7501f7e6b472a5f7 https://gitee.com/anolis/cloud-kernel/commit/00d1e12e5bf69a51724bd6f3450719f6eeb615bc https://gitee.com/anolis/cloud-kernel/commit/354315cb7497d0943bc974f8a8cad1c748345b56 https://gitee.com/anolis/cloud-kernel/commit/5953f752bfa7609b1302c960bb2d9bd2a90f30a3 https://gitee.com/anolis/cloud-kernel/commit/2a1346c4e5446a8f7a7d6e458f96fe0dd81539ad https://gitee.com/anolis/cloud-kernel/commit/354b614827a953aa688d9f37c37fccbff26aa901 https://gitee.com/anolis/cloud-kernel/commit/881f0097c036c2e8f676b2bb2f38fe3f19b116d7