### PR TITLE
fuse: Ensure lookup sets st_ino of attributes

### DIFF
--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -79,7 +79,9 @@ impl FileSystem for Vfs {
                 // parent is in an underlying rootfs
                 let mut entry = fs.lookup(ctx, idata.ino(), name)?;
                 // lookup success, hash it to a real fuse inode
-                entry.inode = self.convert_inode(idata.fs_idx(), entry.inode)?;
+                let new_ino = self.convert_inode(idata.fs_idx(), entry.inode)?;
+                entry.inode = new_ino;
+                entry.attr.st_ino = new_ino;
                 Ok(entry)
             }
         }


### PR DESCRIPTION
The filesystem test utility xfs-tests[1] failed on test generic/007 with the error nametest.16 (8370) lookup, should be inumber 72057594037927972. It can be observed in the kernel that the inode number for the file often switches between the hosts inode number and the fuse assigned one.

In the vfs lookup function the out entry inode is set on the top level but does not update attr.st_ino field. Adjust this so that the inode number is correctly set on the attributes.

After this change the test generic/007 passes.

[1] https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/tree/