### PR TITLE
implement stable unique inode for passthroughfs

### DIFF
--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -358,14 +358,14 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
     fn forget(&self, _ctx: &Context, inode: Inode, count: u64) {
         let mut inodes = self.inode_map.get_map_mut();
 
-        Self::forget_one(&mut inodes, inode, count)
+        self.forget_one(&mut inodes, inode, count)
     }
 
     fn batch_forget(&self, _ctx: &Context, requests: Vec<(Inode, u64)>) {
         let mut inodes = self.inode_map.get_map_mut();
 
         for (inode, count) in requests {
-            Self::forget_one(&mut inodes, inode, count)
+            self.forget_one(&mut inodes, inode, count)
         }
     }
 
@@ -485,7 +485,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
                 if r == 0 {
                     // Release the refcount acquired by self.do_lookup().
                     let mut inodes = self.inode_map.get_map_mut();
-                    Self::forget_one(&mut inodes, ino, 1);
+                    self.forget_one(&mut inodes, ino, 1);
                 }
                 r
             })


### PR DESCRIPTION
In the current passthroughfs implementation, temporary inodes are allocated and then stored in memory, But a FORGET request causes the inode to be removed from memory, new inodes are reassigned, resulting in the instability of the inodes of a file. this PR implements a stable inode, Limited by the current implementation limitations of VFS, Host inode + mnt + dev needs to be controlled in 56bit, and it is not supported beyond the range.