### PR TITLE
feat: ZeroCopyWriter pass through available bytes from inner writer

### DIFF
--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -370,6 +370,11 @@ pub trait ZeroCopyWriter: io::Write {
             }
         }
     }
+
+    /// Return number of bytes available for writing.
+    ///
+    /// Useful for buffer fixed writers, such as FuseDevWriter, VirtioFsWriter
+    fn available_bytes(&self) -> usize;
 }
 
 /// Additional context associated with requests.

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -88,6 +88,10 @@ impl<'a, S: BitmapSlice> ZeroCopyWriter for AsyncZcWriter<'a, S> {
     ) -> io::Result<usize> {
         self.0.write_from_at(f, count, off)
     }
+
+    fn available_bytes(&self) -> usize {
+        self.0.available_bytes()
+    }
 }
 
 impl<'a, S: BitmapSlice> io::Write for AsyncZcWriter<'a, S> {

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -96,6 +96,10 @@ impl<'a, S: BitmapSlice> ZeroCopyWriter for ZcWriter<'a, S> {
     ) -> io::Result<usize> {
         self.0.write_from_at(f, count, off)
     }
+
+    fn available_bytes(&self) -> usize {
+        self.0.available_bytes()
+    }
 }
 
 impl<'a, S: BitmapSlice> io::Write for ZcWriter<'a, S> {


### PR DESCRIPTION
Useful for writer of fixed buffer, such FuseDevWriter, VirtioFsWriter