### PR TITLE
feat: implement fuse-t feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,10 +34,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Install macfuse
-        run: brew install --cask macfuse
+        run: |
+          brew install --cask macfuse
+          wget https://github.com/macos-fuse-t/fuse-t/releases/download/1.0.24/fuse-t-macos-installer-1.0.24.pkg
+          sudo installer -pkg fuse-t-macos-installer-1.0.24.pkg -target /
       - uses: actions/checkout@v3
       - name: build and check
-        run: make check-macos
+        run: make smoke-macos
 
   deny:
     name: Cargo Deny

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ async-io = ["async-trait", "tokio-uring", "tokio/fs", "tokio/net", "tokio/sync",
 fusedev = ["vmm-sys-util", "caps", "core-foundation-sys"]
 virtiofs = ["virtio-queue", "caps", "vmm-sys-util"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]
+fuse-t=[]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,14 @@ build:
 
 build-macos:
 	cargo build --features="fusedev"
+	cargo build --features="fusedev,fuse-t"
 
 check-macos: build-macos
 	cargo fmt -- --check
 	cargo clippy --features="fusedev" -- -Dwarnings
 	cargo test --features="fusedev" -- --nocapture --skip integration
+	cargo clippy --features="fusedev,fuse-t" -- -Dwarnings
+	cargo test --features="fusedev,fuse-t" -- --nocapture --skip integration
 
 check: build
 	cargo fmt -- --check
@@ -38,7 +41,7 @@ smoke-all: smoke
 	cargo test --features="fusedev" -- --nocapture --ignored
 
 smoke-macos: check-macos
-	cargo test --features="fusedev" -- --nocapture
+	cargo test --features="fusedev,fuse-t" -- --nocapture
 
 docker-smoke:
 	docker run --env RUST_BACKTRACE=1 --rm --privileged --volume ${current_dir}:/fuse-rs rust:1.68 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke-all"

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -27,12 +27,10 @@ use nix::unistd::{getgid, getuid, read};
 use super::{
     super::pagesize,
     Error::{IoError, SessionFailure},
-    FuseBuf, FuseDevWriter, Reader, Result,
+    FuseBuf, FuseDevWriter, Reader, Result, FUSE_HEADER_SIZE, FUSE_KERN_BUF_SIZE,
 };
 
 // These follows definition from libfuse.
-const FUSE_KERN_BUF_SIZE: usize = 256;
-const FUSE_HEADER_SIZE: usize = 0x1000;
 const POLL_EVENTS_CAPACITY: usize = 1024;
 
 const FUSE_DEVICE: &str = "/dev/fuse";

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -27,10 +27,19 @@ mod linux_session;
 #[cfg(target_os = "linux")]
 pub use linux_session::*;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(feature = "fuse-t")))]
 mod macos_session;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(feature = "fuse-t")))]
 pub use macos_session::*;
+
+#[cfg(all(target_os = "macos", feature = "fuse-t"))]
+mod fuse_t_session;
+#[cfg(all(target_os = "macos", feature = "fuse-t"))]
+pub use fuse_t_session::*;
+
+// These follows definition from libfuse.
+pub const FUSE_KERN_BUF_SIZE: usize = 256;
+pub const FUSE_HEADER_SIZE: usize = 0x1000;
 
 /// A buffer reference wrapper for fuse requests.
 #[derive(Debug)]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -14,6 +14,7 @@
 //! - fusedev: communicate with the FUSE driver through `/dev/fuse`
 //! - virtiofs: communicate with the virtiofsd on host side by using virtio descriptors.
 
+use std::any::Any;
 use std::collections::VecDeque;
 use std::io::{self, IoSlice, Read};
 use std::marker::PhantomData;
@@ -97,6 +98,13 @@ impl fmt::Display for Error {
             #[cfg(feature = "virtiofs")]
             GuestMemoryError(e) => write!(f, "descriptor guest memory error: {e}"),
         }
+    }
+}
+
+impl From<Box<dyn Any + Send>> for Error {
+    fn from(value: Box<dyn Any + Send>) -> Self {
+        let err = value.downcast::<Error>().unwrap();
+        *err
     }
 }
 

--- a/tests/example/macfuse.rs
+++ b/tests/example/macfuse.rs
@@ -301,6 +301,8 @@ impl Daemon {
                 })
                 .unwrap();
         }
+        #[cfg(feature = "fuse-t")]
+        se.wait_mount().unwrap();
         self.session = Some(se);
         Ok(())
     }

--- a/tests/macfuse_smoke.rs
+++ b/tests/macfuse_smoke.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[cfg(all(feature = "fusedev", target_os = "macos"))]
+#[cfg(all(feature = "fusedev", feature = "fuse-t", target_os = "macos"))]
 #[macro_use]
 extern crate log;
 
 mod example;
 
-#[cfg(all(feature = "fusedev", target_os = "macos"))]
+#[cfg(all(feature = "fusedev", feature = "fuse-t", target_os = "macos"))]
 mod macfuse_tests {
     use std::io::Result;
     use std::process::Command;
@@ -53,7 +53,7 @@ mod macfuse_tests {
     }
 
     #[test]
-    #[ignore] // it depends on privileged mode to pass through /dev/fuse
+    #[cfg(feature = "fuse-t")]
     fn integration_test_macfuse_hello() -> Result<()> {
         // test the fuse-rs repository
         let tmp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
Use fuse-t to replace MacFUSE as the implementation of FUSE. fuse-t is based on NFS and does not require the use of kernel extensions. Installation can be done with lower privileges and it does not impact system stability.