### PR TITLE
deps: Bump versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ nix = "0.24"
 lazy_static = "1.4"
 tokio = { version = "1", optional = true }
 tokio-uring = { version = "0.4.0", optional = true }
-vmm-sys-util = { version = "0.10", optional = true }
-vm-memory = { version = "0.9", features = ["backend-mmap"] }
-virtio-queue = { version = "0.6", optional = true }
-vhost = { version = "0.5", features = ["vhost-user-slave"], optional = true }
+vmm-sys-util = { version = "0.11", optional = true }
+vm-memory = { version = "0.10", features = ["backend-mmap"] }
+virtio-queue = { version = "0.7", optional = true }
+vhost = { version = "0.6", features = ["vhost-user-slave"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = { version = ">=0.8", optional = true }
@@ -42,8 +42,8 @@ tokio-uring = "0.4"
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-vmm-sys-util = "0.10"
-vm-memory = { version = "0.9", features = ["backend-mmap", "backend-bitmap"] }
+vmm-sys-util = "0.11"
+vm-memory = { version = "0.10", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]


### PR DESCRIPTION
The affected dependencies include:

- vmm-sys-util: 0.10 -> 0.11
- vm-memory: 0.9 -> 0.10
- virtio-queue: 0.6 -> 0.7
- vhost: 0.5 -> 0.6