### PR TITLE
release: prepare for v0.10.5 release

### DIFF
--- a/CHAGNELOG.md
+++ b/CHAGNELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## [Unreleased]
 
+## [0.10.5]
+### Added
+- [138](https://github.com/cloud-hypervisor/fuse-backend-rs/pull/138): linuxsession: support mount in given mount namespace
+- [141](https://github.com/cloud-hypervisor/fuse-backend-rs/pull/141): linux_session: support set fusermount binary
+
+### Fixed
+- [140](https://github.com/cloud-hypervisor/fuse-backend-rs/pull/140): fuse: Ensure readdir returns same ino as lookup
+
 ## [0.10.4]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse-backend-rs"
-version = "0.10.4"
+version = "0.10.5"
 keywords = ["fuse", "virtio", "virtio-fs", "vhost-user-fs"]
 categories = ["filesystem", "os::linux-apis"]
 description = "A rust library for Fuse(filesystem in userspace) servers and virtio-fs devices"


### PR DESCRIPTION
    3cff242 deps: Bump versions of dependencies
    dac955b Avoid compile tokio-uring when use default features
    86a46d6 linux_session: support set fusermount binary
    f4293a9 fuse: Ensure readdir returns same ino as lookup
    9f9b50c api/vfs: implement Display trait for VfsError
    d8031bf abi: properly document OpenOptions flags
    6d1f933 abi: implement Debug for Entry struct
    6e40753 linuxsession: support mount in given mount namespace
    ecbd517 cargo: bump version to 0.10.4
    e891287 Changelog: prepare to release 0.10.4
    c5a44d9 fix: st_nlink in macos aarch64 is u16
    2bcc32d feat: ZeroCopyWriter pass through available bytes from inner writer
    79d673d CHANGELOG: add more logs for the 0.10.3 release
    70dc263 implement stable unique inode for passthroughfs
    2d286b2 abi: st_nlink is u32 on aarch64
    fb4b1c7 avoid too much error logs for non-fatal errors in data-path
    2e522ba api/vfs: ensure entry attr st_ino consistency
    89c5fa7 fix: low probability IO hang problem
    d62776c Use long options for better self-documentation
    05f5937 fuse: Ensure lookup sets st_ino of attributes
    9ad3977 prepare for v0.10.3 release
    f9d0de3 changelog: fill in 0.10.2 changes
    29f639e api: forget and batch forget must not reply
    ffaea12 fusedev: drop newer fusermount3 mount options
    e644983 workflow: run smoke test w/o docker
    d700482 Remove unecessary mut reference
    4a4887f passthroughfs: add unit test for inode store
    3c20438 transport: pre-allocate VecDeque to avoid expending at runtime
    8c3b49a passthroughfs: remove trace log in hot path
    48e7f75 passthroughfs: convert MultiKeyBTreeMap to InodeStore for InodeMap
    f3a25b8 passthroughfs: add config to specify entry and attr timeout for dir
    6c4c726 passthroughfs: add config to control count mntid in altkey or not
    1b528af Support non-privileged users