### PR TITLE
feat: add "persist" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ build = "build.rs"
 arc-swap = "1.5"
 async-trait = { version = "0.1.42", optional = true }
 bitflags = "1.1"
+dbs-snapshot = { version = "1.5.0", optional = true }
 io-uring = { version = "0.5.8", optional = true }
 libc = "0.2.68"
 log = "0.4.6"
-mio = { version = "0.8", features = ["os-poll", "os-ext"]}
+mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 nix = "0.24"
 lazy_static = "1.4"
 tokio = { version = "1", optional = true }
@@ -32,6 +33,8 @@ vmm-sys-util = { version = "0.11", optional = true }
 vm-memory = { version = "0.10", features = ["backend-mmap"] }
 virtio-queue = { version = "0.7", optional = true }
 vhost = { version = "0.6", features = ["vhost-user-slave"], optional = true }
+versionize_derive = { version = "0.1.6", optional = true }
+versionize = { version = "0.1.10", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = { version = ">=0.8", optional = true }
@@ -47,12 +50,26 @@ vm-memory = { version = "0.10", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]
-async-io = ["async-trait", "tokio-uring", "tokio/fs", "tokio/net", "tokio/sync", "tokio/rt", "tokio/macros", "io-uring"]
+async-io = [
+    "async-trait",
+    "tokio-uring",
+    "tokio/fs",
+    "tokio/net",
+    "tokio/sync",
+    "tokio/rt",
+    "tokio/macros",
+    "io-uring",
+]
 fusedev = ["vmm-sys-util", "caps", "core-foundation-sys"]
 virtiofs = ["virtio-queue", "caps", "vmm-sys-util"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]
-fuse-t=[]
+persist = ["dbs-snapshot", "versionize", "versionize_derive"]
+fuse-t = []
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+]

--- a/src/api/pseudo_fs.rs
+++ b/src/api/pseudo_fs.rs
@@ -401,6 +401,178 @@ impl FileSystem for PseudoFs {
     }
 }
 
+/// Save and restore PseudoFs state.
+#[cfg(feature = "persist")]
+pub mod persist {
+    use std::collections::HashMap;
+    use std::io::{Error as IoError, ErrorKind, Result};
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use dbs_snapshot::Snapshot;
+    use versionize::{VersionMap, Versionize, VersionizeResult};
+    use versionize_derive::Versionize;
+
+    use super::{PseudoFs, PseudoInode};
+    use crate::api::filesystem::ROOT_ID;
+
+    #[derive(Versionize, PartialEq, Debug, Default, Clone)]
+    struct PseudoInodeState {
+        ino: u64,
+        parent: u64,
+        name: String,
+    }
+
+    #[derive(Versionize, PartialEq, Debug, Default)]
+    pub struct PseudoFsState {
+        next_inode: u64,
+        inodes: Vec<PseudoInodeState>,
+    }
+
+    impl PseudoFs {
+        fn get_version_map() -> VersionMap {
+            let mut vm = VersionMap::new();
+            vm.set_type_version(PseudoFsState::type_id(), 1);
+
+            // more versions for the future
+
+            vm
+        }
+
+        /// Saves part of the PseudoFs into a byte array.
+        /// The upper layer caller can use this method to save
+        /// and transfer metadata for the reloading in the future.
+        pub fn save_to_bytes(&self) -> Result<Vec<u8>> {
+            let mut inodes = Vec::new();
+            let next_inode = self.next_inode.load(Ordering::Relaxed);
+
+            let _guard = self.lock.lock().unwrap();
+            for inode in self.inodes.load().values() {
+                if inode.ino == ROOT_ID {
+                    // no need to save the root inode
+                    continue;
+                }
+
+                inodes.push(PseudoInodeState {
+                    ino: inode.ino,
+                    parent: inode.parent,
+                    name: inode.name.clone(),
+                });
+            }
+            let state = PseudoFsState { next_inode, inodes };
+
+            let vm = PseudoFs::get_version_map();
+            let target_version = vm.latest_version();
+            let mut s = Snapshot::new(vm, target_version);
+            let mut buf = Vec::new();
+            s.save(&mut buf, &state).map_err(|e| {
+                IoError::new(
+                    ErrorKind::Other,
+                    format!("Failed to save PseudoFs to bytes: {:?}", e),
+                )
+            })?;
+
+            Ok(buf)
+        }
+
+        /// Restores the PseudoFs from a byte array.
+        pub fn restore_from_bytes(&self, buf: &mut Vec<u8>) -> Result<()> {
+            let state: PseudoFsState =
+                Snapshot::load(&mut buf.as_slice(), buf.len(), PseudoFs::get_version_map())
+                    .map_err(|e| {
+                        IoError::new(
+                            ErrorKind::Other,
+                            format!("Failed to load PseudoFs from bytes: {:?}", e),
+                        )
+                    })?
+                    .0;
+            self.restore_from_state(&state)
+        }
+
+        fn restore_from_state(&self, state: &PseudoFsState) -> Result<()> {
+            // first, reconstruct all the inodes
+            let mut inode_map = HashMap::new();
+            let mut state_inodes = state.inodes.clone();
+            for inode in state_inodes.iter() {
+                let inode = Arc::new(PseudoInode::new(
+                    inode.ino,
+                    inode.parent,
+                    inode.name.clone(),
+                ));
+                inode_map.insert(inode.ino, inode);
+            }
+
+            // insert root inode to make sure the others inodes can find their parents
+            inode_map.insert(self.root_inode.ino, self.root_inode.clone());
+
+            // then, connect the inodes
+            state_inodes.sort_by(|a, b| a.ino.cmp(&b.ino));
+            for inode in state_inodes.iter() {
+                let inode = inode_map
+                    .get(&inode.ino)
+                    .ok_or_else(|| {
+                        IoError::new(
+                            ErrorKind::InvalidData,
+                            format!("invalid inode {}", inode.ino),
+                        )
+                    })?
+                    .clone();
+                let parent = inode_map.get_mut(&inode.parent).ok_or_else(|| {
+                    IoError::new(
+                        ErrorKind::InvalidData,
+                        format!(
+                            "invalid parent inode {} for inode {}",
+                            inode.parent, inode.ino
+                        ),
+                    )
+                })?;
+                parent.insert_child(inode);
+            }
+            self.inodes.store(Arc::new(inode_map));
+
+            // last, restore next_inode
+            self.next_inode.store(state.next_inode, Ordering::Relaxed);
+
+            Ok(())
+        }
+    }
+
+    mod test {
+
+        #[test]
+        fn save_restore_test() {
+            use crate::api::pseudo_fs::PseudoFs;
+
+            let fs = &PseudoFs::new();
+            let paths = vec!["/a", "/a/b", "/a/b/c", "/b", "/b/a/c", "/d"];
+
+            for path in paths.iter() {
+                fs.mount(path).unwrap();
+            }
+
+            // save fs
+            let mut buf = fs.save_to_bytes().unwrap();
+
+            // restore fs
+            let restored_fs = &PseudoFs::new();
+            restored_fs.restore_from_bytes(&mut buf).unwrap();
+
+            // check fs and restored_fs
+            let next_inode = fs.next_inode.load(std::sync::atomic::Ordering::Relaxed);
+            let restored_next_inode = restored_fs
+                .next_inode
+                .load(std::sync::atomic::Ordering::Relaxed);
+            assert_eq!(next_inode, restored_next_inode);
+
+            for path in paths.iter() {
+                let inode = fs.path_walk(path).unwrap();
+                let restored_inode = restored_fs.path_walk(path).unwrap();
+                assert_eq!(inode, restored_inode);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -78,6 +78,8 @@ pub enum VfsError {
     Unsupported,
     /// Mount backend filesystem
     Mount(Error),
+    /// Restore mount backend filesystem
+    RestoreMount(Error),
     /// Illegal inode index is used
     InodeIndex(String),
     /// Filesystem index related. For example, an index can't be allocated.
@@ -88,6 +90,8 @@ pub enum VfsError {
     NotFound(String),
     /// File system can't ba initialized
     Initialize(String),
+    /// Error serializing or deserializing the vfs state
+    Persist(String),
 }
 
 impl fmt::Display for VfsError {
@@ -96,11 +100,13 @@ impl fmt::Display for VfsError {
         match self {
             Unsupported => write!(f, "Vfs operation not supported"),
             Mount(e) => write!(f, "Mount backend filesystem: {e}"),
+            RestoreMount(e) => write!(f, "Restore mount backend filesystem: {e}"),
             InodeIndex(s) => write!(f, "Illegal inode index: {s}"),
             FsIndex(e) => write!(f, "Filesystem index error: {e}"),
             PathWalk(e) => write!(f, "Walking path error: {e}"),
             NotFound(s) => write!(f, "Entry can't be found: {s}"),
             Initialize(s) => write!(f, "File system can't be initialized: {s}"),
+            Persist(e) => write!(f, "Error serializing: {e}"),
         }
     }
 }
@@ -387,6 +393,24 @@ impl Vfs {
         Ok(index)
     }
 
+    /// Restore a backend file system to path
+    #[cfg(feature = "persist")]
+    pub fn restore_mount(&self, fs: BackFileSystem, fs_idx: VfsIndex, path: &str) -> Result<()> {
+        let (entry, ino) = fs.mount()?;
+        if ino > VFS_MAX_INO {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "Unsupported max inode number, requested {} supported {}",
+                    ino, VFS_MAX_INO
+                ),
+            ));
+        }
+
+        let _guard = self.lock.lock().unwrap();
+        self.insert_mount_locked(fs, entry, fs_idx, path)
+    }
+
     /// Umount a backend file system at path
     pub fn umount(&self, path: &str) -> VfsResult<()> {
         // Serialize mount operations. Do not expect poisoned lock here.
@@ -565,6 +589,334 @@ impl Vfs {
                 Ok(entry)
             }
             None => self.convert_entry(idata.fs_idx(), entry.inode, &mut entry),
+        }
+    }
+}
+
+/// Sava and restore Vfs state.
+#[cfg(feature = "persist")]
+pub mod persist {
+    use std::{
+        ops::Deref,
+        sync::{atomic::Ordering, Arc},
+    };
+
+    use dbs_snapshot::Snapshot;
+    use versionize::{VersionMap, Versionize, VersionizeResult};
+    use versionize_derive::Versionize;
+
+    use crate::api::{
+        filesystem::FsOptions,
+        pseudo_fs::persist::PseudoFsState,
+        vfs::{VfsError, VfsResult},
+        Vfs, VfsOptions,
+    };
+
+    /// VfsState stores the state of the VFS.
+    #[derive(Versionize, Debug)]
+    struct VfsState {
+        /// Vfs options
+        options: VfsOptionsState,
+        /// Vfs root
+        root: Vec<u8>,
+        /// next super block index
+        next_super: u8,
+    }
+
+    #[derive(Versionize, Debug, Default)]
+    struct VfsOptionsState {
+        no_open: bool,
+        no_opendir: bool,
+        no_writeback: bool,
+        in_opts: u64,
+        out_opts: u64,
+        killpriv_v2: bool,
+        no_readdir: bool,
+        seal_size: bool,
+    }
+
+    impl VfsOptions {
+        fn save(&self) -> VfsOptionsState {
+            VfsOptionsState {
+                no_open: self.no_open,
+                no_opendir: self.no_opendir,
+                no_writeback: self.no_writeback,
+                in_opts: self.in_opts.bits(),
+                out_opts: self.out_opts.bits(),
+                killpriv_v2: self.killpriv_v2,
+                no_readdir: self.no_readdir,
+                seal_size: self.seal_size,
+            }
+        }
+
+        fn restore(state: &VfsOptionsState) -> VfsResult<VfsOptions> {
+            Ok(VfsOptions {
+                no_open: state.no_open,
+                no_opendir: state.no_opendir,
+                no_writeback: state.no_writeback,
+                in_opts: FsOptions::from_bits(state.in_opts).ok_or(VfsError::Persist(
+                    "Failed to restore VfsOptions.in_opts".to_owned(),
+                ))?,
+                out_opts: FsOptions::from_bits(state.out_opts).ok_or(VfsError::Persist(
+                    "Failed to restore VfsOptions.out_opts".to_owned(),
+                ))?,
+                killpriv_v2: state.killpriv_v2,
+                no_readdir: state.no_readdir,
+                seal_size: state.seal_size,
+            })
+        }
+    }
+
+    impl Vfs {
+        fn get_version_map() -> versionize::VersionMap {
+            let mut version_map = VersionMap::new();
+            version_map
+                .set_type_version(VfsState::type_id(), 1)
+                .set_type_version(PseudoFsState::type_id(), 1)
+                .set_type_version(VfsOptionsState::type_id(), 1);
+
+            // more versions for the future
+
+            version_map
+        }
+
+        /// Saves part of the Vfs metadata into a byte array.
+        /// The upper layer caller can use this method to save
+        /// and transfer metadata for the reloading in the future.
+        ///
+        /// Note! This function does not save the information
+        /// of the Backend FileSystem mounted by VFS,
+        /// which means that when the caller restores VFS,
+        /// in addition to restoring the information in the byte array
+        /// returned by this function,
+        /// it also needs to manually remount each Backend FileSystem
+        /// according to the Index obtained from the previous mount,
+        /// the method `restore_mount` may be help to do this.
+        ///
+        /// # Example
+        ///
+        /// The following example shows how the function is used in conjunction with
+        /// `restore_from_bytes` to implement the serialization and deserialization of VFS.
+        ///
+        /// ```
+        /// use fuse_backend_rs::api::{Vfs, VfsIndex, VfsOptions};
+        /// use fuse_backend_rs::passthrough::{Config, PassthroughFs};
+        ///
+        /// let new_backend_fs = || {
+        ///     let fs_cfg = Config::default();
+        ///     let fs = PassthroughFs::<()>::new(fs_cfg.clone()).unwrap();
+        ///     fs.import().unwrap();
+        ///     Box::new(fs)
+        /// };
+        ///
+        /// // create new vfs
+        /// let vfs = &Vfs::new(VfsOptions::default());
+        /// let paths = vec!["/a", "/a/b", "/a/b/c", "/b", "/b/a/c", "/d"];
+        /// // record the backend fs and their VfsIndexes
+        /// let backend_fs_list: Vec<(&str, VfsIndex)> = paths
+        ///     .iter()
+        ///     .map(|path| {
+        ///         let fs = new_backend_fs();
+        ///         let idx = vfs.mount(fs, path).unwrap();
+        ///
+        ///         (path.to_owned(), idx)
+        ///     })
+        ///     .collect();
+        ///
+        /// // save the vfs state
+        /// let mut buf = vfs.save_to_bytes().unwrap();
+        ///
+        /// // restore the vfs state
+        /// let restored_vfs = &Vfs::new(VfsOptions::default());
+        /// restored_vfs.restore_from_bytes(&mut buf).unwrap();
+        ///
+        /// // mount the backend fs
+        /// backend_fs_list.into_iter().for_each(|(path, idx)| {
+        ///     let fs = new_backend_fs();
+        ///     vfs.restore_mount(fs, idx, path).unwrap();
+        /// });
+        /// ```
+        pub fn save_to_bytes(&self) -> VfsResult<Vec<u8>> {
+            let root_state = self
+                .root
+                .save_to_bytes()
+                .map_err(|e| VfsError::Persist(format!("Failed to save Vfs root: {:?}", e)))?;
+            let vfs_state = VfsState {
+                options: self.opts.load().deref().deref().save(),
+                root: root_state,
+                next_super: self.next_super.load(Ordering::SeqCst),
+            };
+
+            let vm = Vfs::get_version_map();
+            let target_version = vm.latest_version();
+            let mut s = Snapshot::new(vm, target_version);
+            let mut buf = Vec::new();
+            s.save(&mut buf, &vfs_state).map_err(|e| {
+                VfsError::Persist(format!("Failed to save Vfs using snapshot: {:?}", e))
+            })?;
+
+            Ok(buf)
+        }
+
+        /// Restores part of the Vfs metadata from a byte array.
+        /// For more information, see the example of `save_to_bytes`.
+        pub fn restore_from_bytes(&self, buf: &mut Vec<u8>) -> VfsResult<()> {
+            let mut state: VfsState =
+                Snapshot::load(&mut buf.as_slice(), buf.len(), Vfs::get_version_map())
+                    .map_err(|e| {
+                        VfsError::Persist(format!("Failed to load Vfs using snapshot: {:?}", e))
+                    })?
+                    .0;
+            let opts = VfsOptions::restore(&state.options)?;
+            self.initialized
+                .store(!opts.in_opts.is_empty(), Ordering::Release);
+            self.opts.store(Arc::new(opts));
+
+            self.next_super.store(state.next_super, Ordering::SeqCst);
+            self.root
+                .restore_from_bytes(&mut state.root)
+                .map_err(|e| VfsError::Persist(format!("Failed to restore Vfs root: {:?}", e)))?;
+
+            Ok(())
+        }
+    }
+
+    mod test {
+
+        // This test is to make sure that VfsState can be serialized and deserialized
+        #[test]
+        fn test_vfs_save_restore_simple() {
+            use crate::api::{Vfs, VfsOptions};
+
+            // create new vfs
+            let vfs = &Vfs::new(VfsOptions::default());
+
+            // save the vfs state using Snapshot
+            let mut buf = vfs.save_to_bytes().unwrap();
+
+            // restore the vfs state
+            let vfs = &Vfs::new(VfsOptions::default());
+            vfs.restore_from_bytes(&mut buf).unwrap();
+            assert_eq!(vfs.next_super.load(std::sync::atomic::Ordering::SeqCst), 1);
+        }
+
+        #[test]
+        fn test_vfs_save_restore_with_backend_fs() {
+            use crate::api::{Vfs, VfsIndex, VfsOptions};
+            use crate::passthrough::{Config, PassthroughFs};
+
+            let new_backend_fs = || {
+                let fs_cfg = Config::default();
+                let fs = PassthroughFs::<()>::new(fs_cfg.clone()).unwrap();
+                fs.import().unwrap();
+                Box::new(fs)
+            };
+
+            // create new vfs
+            let vfs = &Vfs::new(VfsOptions::default());
+            let paths = vec!["/a", "/a/b", "/a/b/c", "/b", "/b/a/c", "/d"];
+            let backend_fs_list: Vec<(&str, VfsIndex)> = paths
+                .iter()
+                .map(|path| {
+                    let fs = new_backend_fs();
+                    let idx = vfs.mount(fs, path).unwrap();
+
+                    (path.to_owned(), idx)
+                })
+                .collect();
+
+            // save the vfs state using Snapshot
+            let mut buf = vfs.save_to_bytes().unwrap();
+
+            // restore the vfs state
+            let restored_vfs = &Vfs::new(VfsOptions::default());
+            restored_vfs.restore_from_bytes(&mut buf).unwrap();
+            // restore the backend fs
+            backend_fs_list.into_iter().for_each(|(path, idx)| {
+                let fs = new_backend_fs();
+                vfs.restore_mount(fs, idx, path).unwrap();
+            });
+
+            // check the vfs and restored_vfs
+            assert_eq!(
+                vfs.next_super.load(std::sync::atomic::Ordering::SeqCst),
+                restored_vfs
+                    .next_super
+                    .load(std::sync::atomic::Ordering::SeqCst)
+            );
+            assert_eq!(
+                vfs.initialized.load(std::sync::atomic::Ordering::SeqCst),
+                restored_vfs
+                    .initialized
+                    .load(std::sync::atomic::Ordering::SeqCst)
+            );
+            for path in paths.iter() {
+                let inode = vfs.root.path_walk(path).unwrap();
+                let restored_inode = restored_vfs.root.path_walk(path).unwrap();
+                assert_eq!(inode, restored_inode);
+            }
+        }
+
+        #[test]
+        fn test_vfs_save_restore_with_backend_fs_with_initialized() {
+            use crate::api::filesystem::{FileSystem, FsOptions};
+            use crate::api::{Vfs, VfsIndex, VfsOptions};
+            use crate::passthrough::{Config, PassthroughFs};
+            use std::sync::atomic::Ordering;
+
+            let new_backend_fs = || {
+                let fs_cfg = Config::default();
+                let fs = PassthroughFs::<()>::new(fs_cfg.clone()).unwrap();
+                fs.import().unwrap();
+                Box::new(fs)
+            };
+
+            // create new vfs
+            let vfs = &Vfs::new(VfsOptions::default());
+            let paths = vec!["/a", "/a/b", "/a/b/c", "/b", "/b/a/c", "/d"];
+            let backend_fs_list: Vec<(&str, VfsIndex)> = paths
+                .iter()
+                .map(|path| {
+                    let fs = new_backend_fs();
+                    let idx = vfs.mount(fs, path).unwrap();
+
+                    (path.to_owned(), idx)
+                })
+                .collect();
+            vfs.init(FsOptions::ASYNC_READ).unwrap();
+            assert!(vfs.initialized.load(Ordering::Acquire));
+
+            // save the vfs state using Snapshot
+            let mut buf = vfs.save_to_bytes().unwrap();
+
+            // restore the vfs state
+            let restored_vfs = &Vfs::new(VfsOptions::default());
+            restored_vfs.restore_from_bytes(&mut buf).unwrap();
+
+            // restore the backend fs
+            backend_fs_list.into_iter().for_each(|(path, idx)| {
+                let fs = new_backend_fs();
+                vfs.restore_mount(fs, idx, path).unwrap();
+            });
+
+            // check the vfs and restored_vfs
+            assert_eq!(
+                vfs.next_super.load(std::sync::atomic::Ordering::SeqCst),
+                restored_vfs
+                    .next_super
+                    .load(std::sync::atomic::Ordering::SeqCst)
+            );
+            assert_eq!(
+                vfs.initialized.load(std::sync::atomic::Ordering::Acquire),
+                restored_vfs
+                    .initialized
+                    .load(std::sync::atomic::Ordering::Acquire)
+            );
+            for path in paths.iter() {
+                let inode = vfs.root.path_walk(path).unwrap();
+                let restored_inode = restored_vfs.root.path_walk(path).unwrap();
+                assert_eq!(inode, restored_inode);
+            }
         }
     }
 }


### PR DESCRIPTION
This patch add a new sub module `persist` for the `fuse_backend_rs::api::vfs` module.

The `persist` module export two functions to help to save and restore the `Vfs` state:
- `save_to_bytes`, which save the mete data of the `Vfs` struct into a byte array;
- `restore_from_bytes`, which restore the meta data of the `Vfs` struct from a byte array.

As the two above functions only save and restore the vfs meta data, but don't save and restore the backend file systems,
this patch also provides a method named `restore_mount` to re-mount the backend file system into the `Vfs` using the same index as before.

For more information and usage, please refer to the doc of the `save_to_bytes` and `restore_from_bytes` functions.