### PR TITLE
Add the ability to clean up the dentry cache can be used to clean up resources when VFS umount.

### DIFF
--- a/src/api/pseudo_fs.rs
+++ b/src/api/pseudo_fs.rs
@@ -235,6 +235,12 @@ impl PseudoFs {
         self.inodes.store(Arc::new(hashmap));
     }
 
+    pub fn get_parent_inode(&self, ino: u64) -> Option<u64> {
+        let _guard = self.lock.lock();
+        let inodes = self.inodes.load();
+        inodes.get(&ino).map(|o| o.parent)
+    }
+
     #[allow(dead_code)]
     pub fn evict_inode(&self, ino: u64) {
         let _guard = self.lock.lock();

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -91,7 +91,15 @@ impl FileSystem for Vfs {
                 (Right(fs), idata) => fs.forget(ctx, idata.ino(), count),
             },
             Err(e) => {
-                error!("vfs::forget: failed to get_real_rootfs {:?}", e);
+                // When a directory is umount and invalidate entry, a forget request is triggered,
+                // which cannot be forwarded to the backend file system.
+                // this situation is reasonable, so it is changed to warn here
+                warn!(
+                    "vfs::forget: failed to get_real_rootfs {:?}, inode: {:?}, 
+                       maybe it is possible that the vfs submount was dropped by umount, 
+                       which is reasonable.",
+                    e, inode
+                );
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ pub enum Error {
     InvalidXattrSize((u32, usize)),
     /// Invalid message that the server cannot handle properly.
     InvalidMessage(io::Error),
+    /// Failed to write buffer to writer.
+    FailedToWrite(io::Error),
+    /// Failed to split a writer.
+    FailedToSplitWriter(transport::Error),
 }
 
 impl error::Error for Error {}
@@ -95,6 +99,8 @@ impl fmt::Display for Error {
                  decoded value: size = {size}, value.len() = {len}"
             ),
             InvalidMessage(err) => write!(f, "cannot process fuse message: {err}"),
+            FailedToWrite(err) => write!(f, "cannot write to buffer: {err}"),
+            FailedToSplitWriter(err) => write!(f, "cannot split a writer: {err}"),
         }
     }
 }

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -157,10 +157,7 @@ impl<'a, S: BitmapSlice> FuseDevWriter<'a, S> {
             }
         };
 
-        res.map_err(|e| {
-            error! {"fail to write to fuse device on commit: {}", e};
-            io::Error::from_raw_os_error(e as i32)
-        })
+        res.map_err(|e| io::Error::from_raw_os_error(e as i32))
     }
 
     /// Return number of bytes already written to the internal buffer.


### PR DESCRIPTION
1. In order to make the hot upgrade of virtiofs easy, VFS will save pseudo
inodes when umount for easy recovery. However, in the fuse scenario, if
umount does not remove the pseudo inode, it will cause an invalid
directory to be seen on the host, which is not friendly to users. So add
this option to control this behavior.

2. umount returns the parent's inode information, so that it is convenient
to call fuse's invali entry interface later to clarify the corresponding
dentry cache

3. Use the invalidate entry provided by the fuse kernel to clear the entry
cache, all code references the libfuse implementation.

4. Optimize log output and print in vfs umount scenario
      1. optimize the log of forget, for scenarios where forget cannot handle when the vfs submount is dropped by umount.
      2. remove the error log printed when write fuse fails, and hand it to the caller to process and print.

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>

ref: https://github.com/libfuse/libfuse/blob/f44214be6a2abb4c98f61790cae565c06bdb431c/lib/fuse_lowlevel.c#L2332