### PR TITLE
sync_io: Only read InitIn2 if FUSE version is above 7.36

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -694,7 +694,7 @@ impl<F: FileSystem + Sync> Server<F> {
         #[cfg(feature = "fuse-t")]
         let flags_u64 = flags as u64;
         #[cfg(not(feature = "fuse-t"))]
-        if flags_u64 & FsOptions::INIT_EXT.bits() != 0 {
+        if minor >= 36 && flags_u64 & FsOptions::INIT_EXT.bits() != 0 {
             let InitIn2 { flags2, unused: _ } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
             flags_u64 |= (flags2 as u64) << 32;
         }


### PR DESCRIPTION
MacFUSE has INIT_EXT flag set but doesn't support the InitIn2 message since its minor version is only 19 and the comment for InitIn2 indicates that is was introduced in FUSE 7.36.

So this change simply adds a check for minor version larger than 35 and everything seems to work after that.