### PR TITLE
UID/GID remapping support

### DIFF
--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -896,6 +896,11 @@ pub trait FileSystem {
     fn notify_reply(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
+
+    /// Remap the external IDs in context to internal IDs.
+    fn id_remap(&self, ctx: &mut Context) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 impl<FS: FileSystem> FileSystem for Arc<FS> {
@@ -1340,5 +1345,10 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
     /// Send notify reply.
     fn notify_reply(&self) -> io::Result<()> {
         self.deref().notify_reply()
+    }
+
+    #[inline]
+    fn id_remap(&self, ctx: &mut Context) -> io::Result<()> {
+        self.deref().id_remap(ctx)
     }
 }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -72,6 +72,9 @@ impl<F: FileSystem + Sync> Server<F> {
     ) -> Result<usize> {
         let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
         let mut ctx = SrvContext::<F, S>::new(in_header, r, w);
+        self.fs
+            .id_remap(&mut ctx.context)
+            .map_err(|e| Error::FailedToRemapID((ctx.context.uid, ctx.context.gid)))?;
         if ctx.in_header.len > (MAX_BUFFER_SIZE + BUFFER_HEADER_SIZE) {
             if in_header.opcode == Opcode::Forget as u32
                 || in_header.opcode == Opcode::BatchForget as u32

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -242,6 +242,10 @@ pub struct VfsOptions {
     pub in_opts: FsOptions,
     /// File system options returned to client
     pub out_opts: FsOptions,
+    /// Declaration of ID mapping, in the format (internal ID, external ID, range).
+    /// For example, (0, 1, 65536) represents mapping the external UID/GID range of `1~65536`
+    /// to the range of `0~65535` within the filesystem.
+    pub id_mapping: (u32, u32, u32),
 }
 
 impl VfsOptions {
@@ -277,6 +281,7 @@ impl Default for VfsOptions {
                 | FsOptions::ZERO_MESSAGE_OPENDIR
                 | FsOptions::HANDLE_KILLPRIV_V2
                 | FsOptions::PERFILE_DAX,
+            id_mapping: (0, 0, 0),
         }
     }
 }
@@ -293,6 +298,7 @@ pub struct Vfs {
     initialized: AtomicBool,
     lock: Mutex<()>,
     remove_pseudo_root: bool,
+    id_mapping: Option<(u32, u32, u32)>,
 }
 
 impl Default for Vfs {
@@ -313,6 +319,10 @@ impl Vfs {
             lock: Mutex::new(()),
             initialized: AtomicBool::new(false),
             remove_pseudo_root: false,
+            id_mapping: match opts.id_mapping.2 {
+                0 => None,
+                _ => Some(opts.id_mapping),
+            },
         }
     }
 
@@ -496,8 +506,52 @@ impl Vfs {
         self.convert_inode(fs_idx, inode).map(|ino| {
             entry.inode = ino;
             entry.attr.st_ino = ino;
+            // If id_mapping is enabled, map the internal ID to the external ID.
+            if let Some((internal_id, external_id, range)) = self.id_mapping {
+                if entry.attr.st_uid >= internal_id && entry.attr.st_uid < internal_id + range {
+                    entry.attr.st_uid += external_id - internal_id;
+                }
+                if entry.attr.st_gid >= internal_id && entry.attr.st_gid < internal_id + range {
+                    entry.attr.st_gid += external_id - internal_id;
+                }
+            }
             *entry
         })
+    }
+
+    /// If id_mapping is enabled, remap the uid/gid in attributes.
+    ///
+    /// If `map_internal_to_external` is true, the IDs inside VFS will be mapped
+    /// to external IDs.
+    /// If `map_internal_to_external` is false, the external IDs will be mapped
+    /// to VFS internal IDs.
+    fn remap_attr_id(&self, map_internal_to_external: bool, attr: &mut stat64) {
+        if let Some((internal_id, external_id, range)) = self.id_mapping {
+            if map_internal_to_external
+                && attr.st_uid >= internal_id
+                && attr.st_uid < internal_id + range
+            {
+                attr.st_uid += external_id - internal_id;
+            }
+            if map_internal_to_external
+                && attr.st_gid >= internal_id
+                && attr.st_gid < internal_id + range
+            {
+                attr.st_gid += external_id - internal_id;
+            }
+            if !map_internal_to_external
+                && attr.st_uid >= external_id
+                && attr.st_uid < external_id + range
+            {
+                attr.st_uid += internal_id - external_id;
+            }
+            if !map_internal_to_external
+                && attr.st_gid >= external_id
+                && attr.st_gid < external_id + range
+            {
+                attr.st_gid += internal_id - external_id;
+            }
+        }
     }
 
     fn allocate_fs_idx(&self) -> Result<VfsIndex> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub enum Error {
     FailedToWrite(io::Error),
     /// Failed to split a writer.
     FailedToSplitWriter(transport::Error),
+    /// Failed to remap uid/gid.
+    FailedToRemapID((u32, u32)),
 }
 
 impl error::Error for Error {}
@@ -101,6 +103,10 @@ impl fmt::Display for Error {
             InvalidMessage(err) => write!(f, "cannot process fuse message: {err}"),
             FailedToWrite(err) => write!(f, "cannot write to buffer: {err}"),
             FailedToSplitWriter(err) => write!(f, "cannot split a writer: {err}"),
+            FailedToRemapID((uid, gid)) => write!(
+                f,
+                "failed to remap the context of user (uid={uid}, gid={gid})."
+            ),
         }
     }
 }


### PR DESCRIPTION
Once ID mapping is configured, the VFS layer remaps:
1. the external IDs in context to internal IDs
2. the external IDs in attribute to internal IDs (in `setattr()`)
3. the internal IDs in entry back to external IDs
4. the internal IDs in attribute back to external IDs (in `getattr()` and `setattr()`)

![id remap](https://github.com/cloud-hypervisor/fuse-backend-rs/assets/49408466/84fa4759-b3f4-4a6d-b21f-476d38a290d1)
In a container, as well as within the backend filesystem, there are independent ID ranges, and remapping only occurs when passing through the VFS.