### PR TITLE
server: fix cargo build warning

### DIFF
--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -140,7 +140,10 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
             Opcode::from(in_header.opcode),
             in_header
         );
-        hook.map_or((), |h| h.collect(in_header));
+
+        if let Some(h) = hook {
+            h.collect(&in_header);
+        }
 
         let res = match in_header.opcode {
             x if x == Opcode::Lookup as u32 => self.async_lookup(ctx).await,
@@ -209,7 +212,9 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
         // Pass `None` because current API handler's design does not allow us to catch
         // the `out_header`. Hopefully, we can reach to `out_header` after some
         // refactoring work someday.
-        hook.map_or((), |h| h.release(None));
+        if let Some(h) = hook {
+            h.release(None);
+        }
 
         res
     }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -90,7 +90,9 @@ impl<F: FileSystem + Sync> Server<F> {
             in_header
         );
 
-        hook.map_or((), |h| h.collect(&in_header));
+        if let Some(h) = hook {
+            h.collect(&in_header);
+        }
 
         let res = match in_header.opcode {
             x if x == Opcode::Lookup as u32 => self.lookup(ctx),
@@ -156,7 +158,9 @@ impl<F: FileSystem + Sync> Server<F> {
         // Pass `None` because current API handler's design does not allow us to catch
         // the `out_header`. Hopefully, we can reach to `out_header` after some
         // refactoring work someday.
-        hook.map_or((), |h| h.release(None));
+        if let Some(h) = hook {
+            h.release(None);
+        }
 
         res
     }


### PR DESCRIPTION
clippy doesn't like the solution proposed by rustc. Let's just use the plain if let statement.

error: unused return value of `std::option::Option::<T>::map_or` that must be used
  --> src/api/server/sync_io.rs:93:9
   |
93 |         hook.map_or((), |h| h.collect(&in_header));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: if you don't need the returned value, use `if let` instead
   = note: `-D unused-must-use` implied by `-D warnings`