### PR TITLE
vfs: add method to export root pseudofs's reference

### DIFF
--- a/src/api/pseudo_fs.rs
+++ b/src/api/pseudo_fs.rs
@@ -329,6 +329,12 @@ impl PseudoFs {
     }
 }
 
+impl Default for PseudoFs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FileSystem for PseudoFs {
     type Inode = Inode;
     type Handle = Handle;

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -466,6 +466,11 @@ impl Vfs {
         }
     }
 
+    /// Get the root pseudo fs's reference in vfs
+    pub fn get_root_pseudofs(&self) -> &PseudoFs {
+        &self.root
+    }
+
     // Inode converting rules:
     // 1. Pseudo fs inode is not hashed
     // 2. Index is always larger than 0 so that pseudo fs inodes are never affected


### PR DESCRIPTION
In some scenario, we need to access root pseudofs's method in outer caller, so we add a method to export its reference in this patch.