### PR TITLE
fusedev: add `clone_fuse_file` method to `FuseSession`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,8 @@ jobs:
     - name: smoke
       if: ${{ matrix.arch == 'amd64' }}
       run: |
-        make test
         echo user_allow_other | sudo tee --append /etc/fuse.conf
+        make test
         make smoke-all
 
   Macos-CI:


### PR DESCRIPTION
This patch adds `clone_fuse_file` method to `FuseSession`. 

This function obtains a new file descriptor by opening `/dev/fuse` and associates the file descriptor with the original fuse connection of fuse session using the ioctl `FUSE_DEV_IOC_CLONE` command.