### PR TITLE
api: add support for multiple uid/gid idmappings

### DIFF
--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -899,9 +899,7 @@ pub trait FileSystem {
     }
 
     /// Remap the external IDs in context to internal IDs.
-    fn id_remap(&self, ctx: &mut Context) -> io::Result<()> {
-        Ok(())
-    }
+    fn id_remap(&self, ctx: &mut Context) {}
 }
 
 impl<FS: FileSystem> FileSystem for Arc<FS> {
@@ -1349,7 +1347,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
     }
 
     #[inline]
-    fn id_remap(&self, ctx: &mut Context) -> io::Result<()> {
-        self.deref().id_remap(ctx)
+    fn id_remap(&self, ctx: &mut Context) {
+        self.deref().id_remap(ctx);
     }
 }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -72,9 +72,7 @@ impl<F: FileSystem + Sync> Server<F> {
     ) -> Result<usize> {
         let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
         let mut ctx = SrvContext::<F, S>::new(in_header, r, w);
-        self.fs
-            .id_remap(&mut ctx.context)
-            .map_err(|e| Error::FailedToRemapID((ctx.context.uid, ctx.context.gid)))?;
+        self.fs.id_remap(&mut ctx.context);
         if ctx.in_header.len > (MAX_BUFFER_SIZE + BUFFER_HEADER_SIZE) {
             if in_header.opcode == Opcode::Forget as u32
                 || in_header.opcode == Opcode::BatchForget as u32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@ pub enum Error {
     FailedToWrite(io::Error),
     /// Failed to split a writer.
     FailedToSplitWriter(transport::Error),
-    /// Failed to remap uid/gid.
-    FailedToRemapID((u32, u32)),
 }
 
 impl error::Error for Error {}
@@ -103,10 +101,6 @@ impl fmt::Display for Error {
             InvalidMessage(err) => write!(f, "cannot process fuse message: {err}"),
             FailedToWrite(err) => write!(f, "cannot write to buffer: {err}"),
             FailedToSplitWriter(err) => write!(f, "cannot split a writer: {err}"),
-            FailedToRemapID((uid, gid)) => write!(
-                f,
-                "failed to remap the context of user (uid={uid}, gid={gid})."
-            ),
         }
     }
 }

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -320,9 +320,7 @@ impl OpenableFileHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nix::unistd::getuid;
     use std::ffi::CString;
-    use std::io::Read;
 
     fn generate_c_file_handle(
         handle_bytes: usize,

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -644,6 +644,14 @@ mod tests {
     use std::path::Path;
     use vmm_sys_util::tempdir::TempDir;
 
+    fn is_root() -> bool {
+        if unsafe { libc::getuid() } == 0 {
+            true
+        } else {
+            false
+        }
+    }
+
     #[test]
     fn test_new_session() {
         let se = FuseSession::new(Path::new("haha"), "foo", "bar", true);
@@ -675,6 +683,10 @@ mod tests {
 
     #[test]
     fn test_clone_fuse_file() {
+        // skip test if not root user
+        if !is_root() {
+            return;
+        }
         let dir = TempDir::new().unwrap();
         let mut se = FuseSession::new(dir.as_path(), "foo", "bar", true).unwrap();
         se.mount().unwrap();


### PR DESCRIPTION
Currently, only single uid/gid idmapping supported. However, in userns, multiple idmappings can be setted. Besides, in the fuse-overlayfs project, multiple idmappings are supported. 
https://github.com/containers/fuse-overlayfs/blob/18f4d6768ab2178f0147c1bac0ccfd7d44841a56/README.md?plain=1#L16

This commit will be used to support https://github.com/kata-containers/kata-containers/issues/8170. Currently, there is no idmap mount support for virtiofs in kernel side. So the support from the virtiofs server side can be used as a temporary workaround.

This comment https://github.com/containerd/containerd/issues/7063#issuecomment-1157072496 provides a way to solve the rootfs' idmapping problem. Although it is not used in their implementation at last, but can be used for us to support userns in kata in the first place.