### PR TITLE
fix: fuse-t nobrowse

### DIFF
--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -408,7 +408,7 @@ fn fuse_kern_mount(
 
             let mut cmd = Command::new(FUSE_NFSSRV_PATH);
             cmd.arg("--noatime=true")
-                .arg("--noatime=true")
+                .arg("--dontbrowse=true")
                 // .arg("-d")
                 // .arg("-c")
                 .args(["--volname", &format!("{}-{}", fsname, subtype)]);


### PR DESCRIPTION
Fixed the issue where the drive icon would appear in the finder when using fuse-t.