### PR TITLE
Fix CI: xfstests: restrict xfstests version 

### DIFF
--- a/tests/scripts/xfstests_pathr.exclude
+++ b/tests/scripts/xfstests_pathr.exclude
@@ -9,3 +9,4 @@ generic/471
 generic/477
 generic/591
 generic/633
+generic/736

--- a/tests/scripts/xfstests_pathr.sh
+++ b/tests/scripts/xfstests_pathr.sh
@@ -12,7 +12,7 @@ sudo apt-get install acl attr automake bc dbench dump e2fsprogs fio gawk \
 
 # clone xfstests and install.
 cd /tmp/
-git clone git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
+git clone -b v2023.12.10 git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git
 cd xfstests-dev
 make
 sudo make install


### PR DESCRIPTION
Set xfstests to tag `v2023.12.10` or new test case will break integration CI occasionally.