### PR TITLE
bugfix: read/write fd dropped unexpectedly.

### DIFF
--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -320,9 +320,7 @@ impl OpenableFileHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nix::unistd::getuid;
     use std::ffi::CString;
-    use std::io::Read;
 
     fn generate_c_file_handle(
         handle_bytes: usize,

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -665,7 +665,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         // so data.file won't be closed.
         let f = unsafe { File::from_raw_fd(data.borrow_fd().as_raw_fd()) };
 
-        self.check_fd_flags(data, f.as_raw_fd(), flags)?;
+        self.check_fd_flags(data.clone(), f.as_raw_fd(), flags)?;
 
         let mut f = ManuallyDrop::new(f);
 
@@ -692,7 +692,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         // so data.file won't be closed.
         let f = unsafe { File::from_raw_fd(data.borrow_fd().as_raw_fd()) };
 
-        self.check_fd_flags(data, f.as_raw_fd(), flags)?;
+        self.check_fd_flags(data.clone(), f.as_raw_fd(), flags)?;
 
         if self.seal_size.load(Ordering::Relaxed) {
             let st = stat_fd(&f, None)?;


### PR DESCRIPTION
read/write function invokes

```
self.check_fd_flags(data, f.as_raw_fd(), flags)?;
```

which takes ownership of `data` and it's inner `File`, after the function call returns, File will be dropped and cannot be read/write later anymore, causing a failed read/write.

This bug is triggered when `no_open` config option is set, in this case, `self.get_data` opens a new file and it's dropped immediately after `check_fd_flags`.

The bug can be solved by create a new clone of data by `data.clone()`, the original data(and inner File) can be kept in whole lifetime of read/write function.