### PR TITLE
Feat/support fuse resend notify

### DIFF
--- a/src/abi/fuse_abi_linux.rs
+++ b/src/abi/fuse_abi_linux.rs
@@ -197,6 +197,9 @@ const INIT_EXT: u64 = 0x4000_0000;
 // This flag indicates whether the guest kernel enable per-file dax
 const PERFILE_DAX: u64 = 0x2_0000_0000;
 
+// this flag indicates whether the guest kernel enable resend
+const HAS_RESEND: u64 = 1_u64 << 39;
+
 // This flag indicates whether to enable fd-passthrough. It was defined in the
 // Anolis kernel but not in the upstream kernel. To avoid collision, we'll set
 // it to the most significant bit.
@@ -458,6 +461,9 @@ bitflags! {
         /// If this feature is enabled, filesystem will notify guest kernel whether file
         /// enable DAX by EntryOut.Attr.flags of inode when lookup
         const PERFILE_DAX = PERFILE_DAX;
+
+        /// indicates whether the kernel support resend inflight request
+        const HAS_RESEND = HAS_RESEND;
     }
 }
 
@@ -755,7 +761,8 @@ pub enum NotifyOpcode {
     Store = 4,
     Retrieve = 5,
     Delete = 6,
-    CodeMax = 7,
+    Resend = 7,
+    CodeMax = 8,
 }
 
 #[repr(C)]

--- a/src/abi/fuse_abi_macos.rs
+++ b/src/abi/fuse_abi_macos.rs
@@ -498,7 +498,8 @@ pub enum NotifyOpcode {
     Store = 4,
     Retrieve = 5,
     Delete = 6,
-    CodeMax = 7,
+    Resend = 7,
+    CodeMax = 8,
 }
 
 #[repr(C)]

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -51,7 +51,6 @@ pub const MAX_REQ_PAGES: u16 = 256; // 1MB
 pub struct Server<F: FileSystem + Sync> {
     fs: F,
     vers: ArcSwap<ServerVersion>,
-    enabled: Option<FsOptions>,
 }
 
 impl<F: FileSystem + Sync> Server<F> {
@@ -63,7 +62,6 @@ impl<F: FileSystem + Sync> Server<F> {
                 major: KERNEL_VERSION,
                 minor: KERNEL_MINOR_VERSION,
             })),
-            enabled: None,
         }
     }
 }

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -51,6 +51,7 @@ pub const MAX_REQ_PAGES: u16 = 256; // 1MB
 pub struct Server<F: FileSystem + Sync> {
     fs: F,
     vers: ArcSwap<ServerVersion>,
+    enabled: Option<FsOptions>,
 }
 
 impl<F: FileSystem + Sync> Server<F> {
@@ -62,6 +63,7 @@ impl<F: FileSystem + Sync> Server<F> {
                 major: KERNEL_VERSION,
                 minor: KERNEL_MINOR_VERSION,
             })),
+            enabled: None,
         }
     }
 }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -59,17 +59,14 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 
     #[cfg(feature = "fusedev")]
-    /// Send a resend notification message to the kernel via FUSE. This function should be invoked as part of 
-    /// the crash recovery routine. Given that FUSE initialization does not occur again during recovery, 
-    /// the capability to support resend notifications may not be automatically detected. It is the responsibility 
+    /// Send a resend notification message to the kernel via FUSE. This function should be invoked as part of
+    /// the crash recovery routine. Given that FUSE initialization does not occur again during recovery,
+    /// the capability to support resend notifications may not be automatically detected. It is the responsibility
     /// of the upper layers to verify and persist the kernel's support for this feature upon the initial FUSE setup.
-    pub fn notify_resend<S: BitmapSlice>(
-        &self, 
-        mut w: FuseDevWriter<'_, S>,
-    ) -> Result<()> {
+    pub fn notify_resend<S: BitmapSlice>(&self, mut w: FuseDevWriter<'_, S>) -> Result<()> {
         let mut buffer_writer = w.split_at(0).map_err(Error::FailedToSplitWriter)?;
         let header = {
-            OutHeader{
+            OutHeader {
                 unique: 0,
                 error: NotifyOpcode::Resend as i32,
                 ..Default::default()

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -466,7 +466,7 @@ impl Vfs {
         let mut mountpoints = self.mountpoints.load().deref().deref().clone();
         let fs_idx = mountpoints
             .get(&inode)
-            .map(Arc::clone)
+            .cloned()
             .map(|x| {
                 // Do not remove pseudofs inode. We keep all pseudofs inode so that
                 // 1. they can be reused later on
@@ -650,7 +650,7 @@ impl Vfs {
         if inode.is_pseudo_fs() {
             // ROOT_ID is special, we need to check if we have a mountpoint on the vfs root
             if inode.ino() == ROOT_ID {
-                if let Some(mnt) = self.mountpoints.load().get(&inode.ino()).map(Arc::clone) {
+                if let Some(mnt) = self.mountpoints.load().get(&inode.ino()).cloned() {
                     let fs = self.get_fs_by_idx(mnt.fs_idx)?;
                     return Ok((Right(fs), VfsInode::new(mnt.fs_idx, mnt.ino)));
                 }

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -193,7 +193,7 @@ impl InodeMap {
             .read()
             .unwrap()
             .get(&inode)
-            .map(Arc::clone)
+            .cloned()
             .ok_or_else(ebadf)
     }
 
@@ -235,7 +235,7 @@ impl InodeMap {
                     handle.is_none() || data.handle.file_handle().is_none()
                 })
             })
-            .map(Arc::clone)
+            .cloned()
     }
 
     fn get_map_mut(&self) -> RwLockWriteGuard<InodeStore> {
@@ -336,7 +336,7 @@ impl HandleMap {
             .unwrap()
             .get(&handle)
             .filter(|hd| hd.inode == inode)
-            .map(Arc::clone)
+            .cloned()
             .ok_or_else(ebadf)
     }
 }

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -238,6 +238,19 @@ impl FuseSession {
         }
     }
 
+    /// Create a new fuse message channel with a specific buffer size.
+    pub fn with_writer<F>(&mut self, f: F)
+    where
+        F: FnOnce(FuseDevWriter),
+    {
+        if let Some(file) = &self.file {
+            let fd = file.as_raw_fd();
+            let mut buf = vec![0x0u8; self.bufsize];
+            let writer = FuseDevWriter::new(fd, &mut buf).unwrap();
+            f(writer);
+        }
+    }
+
     /// Wake channel loop and exit
     pub fn wake(&self) -> Result<()> {
         let wakers = self

--- a/tests/passthrough/src/main.rs
+++ b/tests/passthrough/src/main.rs
@@ -1,5 +1,3 @@
-use fuse_backend_rs::transport::FuseDevWriter;
-use fuse_backend_rs::transport::Writer;
 use log::{error, info, warn, LevelFilter};
 use std::env;
 use std::fs;
@@ -13,7 +11,6 @@ use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
 use fuse_backend_rs::api::{server::Server, Vfs, VfsOptions};
 use fuse_backend_rs::passthrough::{Config, PassthroughFs};
 use fuse_backend_rs::transport::{FuseChannel, FuseSession};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use simple_logger::SimpleLogger;
 
@@ -63,7 +60,9 @@ impl Daemon {
         se.mount().unwrap();
         
         se.with_writer(|writer| {
-            self.server.notify_resend(writer).unwrap();
+            self.server
+                .notify_resend(writer)
+                .unwrap_or_else(|e| println!("failed to send resend notification {}", e));
         });
 
         for _ in 0..self.thread_cnt {


### PR DESCRIPTION
The "Resend Notification" API is ready for integration into the upstream repository. Implement the resend function to facilitate easier failover implementation.

https://lore.kernel.org/all/20240109092443.519460-1-winters.zc@antgroup.com/T/