### PR TITLE
deps: bump vm-memory, vmm-sys-util and virtio-queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ nix = "0.24"
 radix_trie = "0.2.1"
 tokio = { version = "1", optional = true }
 tokio-uring = { version = "0.4.0", optional = true }
-vmm-sys-util = { version = "0.11", optional = true }
-vm-memory = { version = "0.10", features = ["backend-mmap"] }
-virtio-queue = { version = "0.7", optional = true }
+vmm-sys-util = { version = "0.12", optional = true }
+vm-memory = { version = "0.14", features = ["backend-mmap"] }
+virtio-queue = { version = "0.12", optional = true }
 vhost = { version = "0.6", features = ["vhost-user-slave"], optional = true }
 versionize_derive = { version = "0.1.6", optional = true }
 versionize = { version = "0.1.10", optional = true }
@@ -46,8 +46,8 @@ tokio-uring = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-vmm-sys-util = "0.11"
-vm-memory = { version = "0.10", features = ["backend-mmap", "backend-bitmap"] }
+vmm-sys-util = "0.12"
+vm-memory = { version = "0.14", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]

--- a/deny.toml
+++ b/deny.toml
@@ -48,12 +48,6 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # stderrlog needs to fix it
-    "RUSTSEC-2020-0071",
-    # stderrlog needs to fix it
-    "RUSTSEC-2020-0159",
-    # stderrlog needs to fix it
-    "RUSTSEC-2022-0006",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -328,7 +328,7 @@ mod tests {
         buf: Vec<libc::c_char>,
     ) -> CFileHandle {
         let mut wrapper = CFileHandle::new(handle_bytes);
-        let fh = wrapper.wrapper.as_mut_fam_struct();
+        let fh = unsafe { wrapper.wrapper.as_mut_fam_struct() };
         fh.handle_type = handle_type;
         unsafe {
             fh.f_handle
@@ -401,7 +401,7 @@ mod tests {
     fn test_c_file_handle_wrapper() {
         let buf = (0..=127).collect::<Vec<libc::c_char>>();
         let mut wrapper = generate_c_file_handle(MAX_HANDLE_SIZE, 3, buf.clone());
-        let fh = wrapper.wrapper.as_mut_fam_struct();
+        let fh = unsafe { wrapper.wrapper.as_mut_fam_struct() };
 
         assert_eq!(fh.handle_bytes as usize, MAX_HANDLE_SIZE);
         assert_eq!(fh.handle_type, 3);

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -15,7 +15,7 @@ use std::os::unix::io::RawFd;
 
 use nix::sys::uio::writev;
 use nix::unistd::write;
-use vm_memory::{ByteValued, VolatileMemory, VolatileSlice};
+use vm_memory::{ByteValued, VolatileSlice};
 
 use super::{Error, FileReadWriteVolatile, IoBuffers, Reader, Result, Writer};
 use crate::file_buf::FileVolatileSlice;
@@ -63,7 +63,7 @@ impl<'a, S: BitmapSlice + Default> Reader<'a, S> {
         let mut buffers: VecDeque<VolatileSlice<'a, S>> = VecDeque::new();
         // Safe because Reader has the same lifetime with buf.
         buffers.push_back(unsafe {
-            VolatileSlice::with_bitmap(buf.mem.as_mut_ptr(), buf.mem.len(), S::default())
+            VolatileSlice::with_bitmap(buf.mem.as_mut_ptr(), buf.mem.len(), S::default(), None)
         });
 
         Ok(Reader {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -741,7 +741,7 @@ pub fn pagesize() -> usize {
 #[cfg(test)]
 mod tests {
     use crate::transport::IoBuffers;
-    use std::collections::VecDeque;
+    use std::{collections::VecDeque, num::NonZeroUsize};
     use vm_memory::{
         bitmap::{AtomicBitmap, Bitmap},
         VolatileSlice,
@@ -797,7 +797,7 @@ mod tests {
     #[test]
     fn test_mark_dirty() {
         let mut buf1 = vec![0x0u8; 16];
-        let bitmap1 = AtomicBitmap::new(16, 2);
+        let bitmap1 = AtomicBitmap::new(16, NonZeroUsize::new(2).unwrap());
 
         assert_eq!(bitmap1.len(), 8);
         for i in 0..8 {
@@ -805,7 +805,7 @@ mod tests {
         }
 
         let mut buf2 = vec![0x0u8; 16];
-        let bitmap2 = AtomicBitmap::new(16, 2);
+        let bitmap2 = AtomicBitmap::new(16, NonZeroUsize::new(2).unwrap());
         let mut bufs = VecDeque::new();
 
         unsafe {
@@ -813,11 +813,13 @@ mod tests {
                 buf1.as_mut_ptr(),
                 buf1.len(),
                 bitmap1.slice_at(0),
+                None,
             ));
             bufs.push_back(VolatileSlice::with_bitmap(
                 buf2.as_mut_ptr(),
                 buf2.len(),
                 bitmap2.slice_at(0),
+                None,
             ));
         }
         let mut buffers = IoBuffers {


### PR DESCRIPTION
The affected dependencies includes:
1. Update vm-memory to fix CVE-2023-41051.
2. Update vmm-sys-util to fix CVE-2023-50711.
3. Update virtio-queue to 0.12 to be compatible with the above changes.