### PR TITLE
fix request size too large when use direct io

### DIFF
--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -322,12 +322,6 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
             ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
 
-        if size > MAX_BUFFER_SIZE {
-            return ctx
-                .async_reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM))
-                .await;
-        }
-
         let owner = if read_flags & READ_LOCKOWNER != 0 {
             Some(lock_owner)
         } else {

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -436,10 +436,6 @@ impl<F: FileSystem + Sync> Server<F> {
             ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
 
-        if size > MAX_BUFFER_SIZE {
-            return ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM));
-        }
-
         let owner = if read_flags & READ_LOCKOWNER != 0 {
             Some(lock_owner)
         } else {
@@ -494,10 +490,6 @@ impl<F: FileSystem + Sync> Server<F> {
             flags,
             ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
-
-        if size > MAX_BUFFER_SIZE {
-            return ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM));
-        }
 
         let owner = if fuse_flags & WRITE_LOCKOWNER != 0 {
             Some(lock_owner)
@@ -618,9 +610,6 @@ impl<F: FileSystem + Sync> Server<F> {
 
     pub(super) fn getxattr<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let GetxattrIn { size, .. } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
-        if size > MAX_BUFFER_SIZE {
-            return ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM));
-        }
 
         let buf =
             ServerUtil::get_message_body(&mut ctx.r, &ctx.in_header, size_of::<GetxattrIn>())?;
@@ -646,10 +635,6 @@ impl<F: FileSystem + Sync> Server<F> {
 
     pub(super) fn listxattr<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
         let GetxattrIn { size, .. } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
-
-        if size > MAX_BUFFER_SIZE {
-            return ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM));
-        }
 
         match self.fs.listxattr(ctx.context(), ctx.nodeid(), size) {
             Ok(ListxattrReply::Names(val)) => ctx.reply_ok(None::<u8>, Some(&val)),
@@ -819,10 +804,6 @@ impl<F: FileSystem + Sync> Server<F> {
         let ReadIn {
             fh, offset, size, ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
-
-        if size > MAX_BUFFER_SIZE {
-            return ctx.reply_error_explicit(io::Error::from_raw_os_error(libc::ENOMEM));
-        }
 
         let available_bytes = ctx.w.available_bytes();
         if available_bytes < size as usize {


### PR DESCRIPTION
The fuse directio call path is as follows

```
fuse_read_fill+0xa8/0xb0
fuse_send_read+0x3f/0xb0
fuse_direct_io+0x34a/0x5f0
__fuse_direct_read+0x4e/0x70
fuse_file_read_iter+0x9e/0x140
new_sync_read+0xde/0x120
__vfs_read+0x27/0x40
vfs_read+0x94/0x190
ksys_read+0x4e/0xd0
```

under the direct io path, fuse initiates a request whose request size is determined by the combination of the user-supplied buffer size and max_read mount parameters.

```
size_t nmax = write ? fc->max_write : fc->max_read; 
size_t count = iov_iter_count(iter);
size_t nbytes = min(count, nmax);
nres = fuse_send_read(req, io, pos, nbytes, owner);
```

so we have a problem with the checking of the request size in the code, we always compare the request size with MAX_BUFFER_SIZE, but in fact the maximum value of the request size depends on max_read, in virtiofs scenario max_read is UINT_MAX by default, and in fuse scenario it is possible to adjust max_read by the mounting parameter.


the current implementation of fuse-backend-rs uses a fixed buffer to store the fuse response
the default value of this buffer is as follows, but in fact, the kernel in the direct io path,
the size of the request may be larger than the length of this buffer, which leads to the buffer
is not enough to fill the read content, resulting in read failure. so here we limit the size of
max_read to the length of our buffer so that the fuse kernel will not send requests that exceed
the length of the buffer. in virtiofs scene max_read can't be adjusted, his default is UINT_MAX,
but we don't have to worry about it, because the buffer is allocated by the kernel driver, we
just use this buffer to fill the response, so we don't need to do any adjustment.