### PR TITLE
Filter out O_DIRECT at open_inode

### DIFF
--- a/src/passthrough/config.rs
+++ b/src/passthrough/config.rs
@@ -175,6 +175,12 @@ pub struct Config {
     /// is bigger than the threshold.
     /// The default value for this option is `false`.
     pub use_host_ino: bool,
+
+    /// Whether the file system should honor the O_DIRECT flag. If this option is disabled,
+    /// that flag will be filtered out at `open_inode`.
+    ///
+    /// The default is `true`.
+    pub allow_direct_io: bool,
 }
 
 impl Default for Config {
@@ -198,6 +204,7 @@ impl Default for Config {
             dir_entry_timeout: None,
             dir_attr_timeout: None,
             use_host_ino: false,
+            allow_direct_io: true,
         }
     }
 }

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -34,7 +34,10 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
         if !is_safe_inode(data.mode) {
             Err(ebadf())
         } else {
-            let new_flags = self.get_writeback_open_flags(flags);
+            let mut new_flags = self.get_writeback_open_flags(flags);
+            if !self.cfg.allow_direct_io && flags & libc::O_DIRECT != 0 {
+                new_flags &= !libc::O_DIRECT;
+            }
             data.open_file(new_flags | libc::O_CLOEXEC, &self.proc_self_fd)
         }
     }


### PR DESCRIPTION
Filter out the libc::O_DIRECT flag at open_inode. Also, add the "allow_direct_io" flag to allow users to make the file system to honor the flag instead.

reference virtiofsd 894361d1e83c23460ce9aaadc40a6af598a790d4