### PR TITLE
fix some log noise

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -717,7 +717,7 @@ impl<F: FileSystem + Sync> Server<F> {
         match self.fs.init(capable) {
             Ok(want) => {
                 let enabled = capable & want;
-                info!(
+                debug!(
                     "FUSE INIT major {} minor {}\n in_opts: {:?}\nout_opts: {:?}",
                     major, minor, capable, enabled
                 );

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -351,7 +351,7 @@ impl FuseChannel {
                         }
                     }
                 } else if event.is_error() {
-                    info!("FUSE channel already closed!");
+                    debug!("FUSE channel already closed!");
                     return Err(SessionFailure("epoll error".to_string()));
                 } else {
                     // We should not step into this branch as other event is not registered.


### PR DESCRIPTION
This downgrades two of the `info!` level log messages to `debug`.

They becomes quite noisy if `fuse-backend-rs` is used as a library. Logging it at `debug!` keeps them silent until log levels are increased.