### PR TITLE
Reduce FUSE transport log level.

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -717,7 +717,7 @@ impl<F: FileSystem + Sync> Server<F> {
         match self.fs.init(capable) {
             Ok(want) => {
                 let enabled = capable & want;
-                info!(
+                debug!(
                     "FUSE INIT major {} minor {}\n in_opts: {:?}\nout_opts: {:?}",
                     major, minor, capable, enabled
                 );

--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -285,7 +285,7 @@ impl FuseChannel {
                         return Err(IoError(e.into()));
                     }
                     Errno::ENODEV => {
-                        info!("fuse filesystem umounted");
+                        debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                         return Ok(());
                     }
                     e => {

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -351,7 +351,7 @@ impl FuseChannel {
                         }
                     }
                 } else if event.is_error() {
-                    info!("FUSE channel already closed!");
+                    debug!("FUSE channel already closed!");
                     return Err(SessionFailure("epoll error".to_string()));
                 } else {
                     // We should not step into this branch as other event is not registered.
@@ -362,7 +362,7 @@ impl FuseChannel {
             // Handle wake up event first. We don't read the event fd so that a LEVEL triggered
             // event can still be delivered to other threads/daemons.
             if need_exit {
-                info!("Will exit from fuse service");
+                debug!("Will exit from fuse service");
                 return Ok(None);
             }
             if fusereq_available {
@@ -399,7 +399,7 @@ impl FuseChannel {
                             continue;
                         }
                         Errno::ENODEV => {
-                            info!("fuse filesystem umounted");
+                            debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                             return Ok(None);
                         }
                         e => {
@@ -464,7 +464,7 @@ fn fuse_kern_mount(
     }
 
     if let Some(mountpoint) = mountpoint.to_str() {
-        info!(
+        debug!(
             "mount source {} dest {} with fstype {} opts {} fd {}",
             fsname,
             mountpoint,


### PR DESCRIPTION
The FUSE init flags are unlikely to be of use unless one is debugging a problem with the filesystem.

The messages about channel status get printed for every thread, and it's rather confusing for end-users to have a FUSE filesystem terminate with:

fuse filesystem umounted
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!

...when everything went well.