### PR TITLE
Properly handle errors from the fuse device.

### DIFF
--- a/src/api/filesystem/async_io.rs
+++ b/src/api/filesystem/async_io.rs
@@ -618,7 +618,9 @@ pub trait AsyncFileSystem: FileSystem {
         /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
         /// undefined.
         ///
-        /// `size` indicates the maximum number of bytes that should be returned by this method.
+        /// `size` indicates the maximum number of bytes that should be returned by this method,
+        /// but can be ignored in practice. Instead, entries are returned by calling the
+        /// `add_entry` function until it returns zero (indicating that the buffer is full).
         ///
         /// If `offset` is non-zero then it corresponds to one of the `offset` values from a `DirEntry`
         /// that was previously returned by a call to `readdir` for the same handle. In this case the
@@ -659,7 +661,9 @@ pub trait AsyncFileSystem: FileSystem {
         /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
         /// undefined.
         ///
-        /// `size` indicates the maximum number of bytes that should be returned by this method.
+        /// `size` indicates the maximum number of bytes that should be returned by this method,
+        /// but can be ignored in practice. Instead, entries are returned by calling the
+        /// `add_entry` function until it returns zero (indicating that the buffer is full).
         ///
         /// Unlike `readdir`, the lookup count for `Inode`s associated with the returned directory
         /// entries **IS** affected by this method (since it returns an `Entry` for each `DirEntry`).

--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -634,7 +634,9 @@ pub trait FileSystem {
     /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
     /// undefined.
     ///
-    /// `size` indicates the maximum number of bytes that should be returned by this method.
+    /// `size` indicates the maximum number of bytes that should be returned by this method,
+    /// but can be ignored in practice. Instead, entries are returned by calling the
+    /// `add_entry` function until it returns zero (indicating that the buffer is full).
     ///
     /// If `offset` is non-zero then it corresponds to one of the `offset` values from a `DirEntry`
     /// that was previously returned by a call to `readdir` for the same handle. In this case the
@@ -675,7 +677,10 @@ pub trait FileSystem {
     /// the file system did not return a `Handle` from `opendir` then the contents of `handle` are
     /// undefined.
     ///
-    /// `size` indicates the maximum number of bytes that should be returned by this method.
+    /// `size` indicates the maximum number of bytes that should be returned by this method,
+    /// but can be ignored in practice. Instead, entries are returned by calling the
+    /// `add_entry` function until it returns zero (indicating that the buffer is full).
+    ///
     ///
     /// Unlike `readdir`, the lookup count for `Inode`s associated with the returned directory
     /// entries **IS** affected by this method (since it returns an `Entry` for each `DirEntry`).

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -717,7 +717,7 @@ impl<F: FileSystem + Sync> Server<F> {
         match self.fs.init(capable) {
             Ok(want) => {
                 let enabled = capable & want;
-                info!(
+                debug!(
                     "FUSE INIT major {} minor {}\n in_opts: {:?}\nout_opts: {:?}",
                     major, minor, capable, enabled
                 );

--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -285,7 +285,7 @@ impl FuseChannel {
                         return Err(IoError(e.into()));
                     }
                     Errno::ENODEV => {
-                        info!("fuse filesystem umounted");
+                        debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                         return Ok(());
                     }
                     e => {

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -341,7 +341,8 @@ impl FuseChannel {
             }
 
             for event in events.iter() {
-                if event.is_readable() {
+                // We will handle errors when reading from the fuse device
+                if event.is_readable() || event.is_error() {
                     match event.token() {
                         EXIT_FUSE_EVENT => need_exit = true,
                         FUSE_DEV_EVENT => fusereq_available = true,
@@ -350,9 +351,6 @@ impl FuseChannel {
                             return Err(SessionFailure(format!("unexpected epoll event: {}", x.0)));
                         }
                     }
-                } else if event.is_error() {
-                    debug!("FUSE channel already closed!");
-                    return Err(SessionFailure("epoll error".to_string()));
                 } else {
                     // We should not step into this branch as other event is not registered.
                     panic!("unknown epoll result events");

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -351,7 +351,7 @@ impl FuseChannel {
                         }
                     }
                 } else if event.is_error() {
-                    info!("FUSE channel already closed!");
+                    debug!("FUSE channel already closed!");
                     return Err(SessionFailure("epoll error".to_string()));
                 } else {
                     // We should not step into this branch as other event is not registered.
@@ -362,7 +362,7 @@ impl FuseChannel {
             // Handle wake up event first. We don't read the event fd so that a LEVEL triggered
             // event can still be delivered to other threads/daemons.
             if need_exit {
-                info!("Will exit from fuse service");
+                debug!("Will exit from fuse service");
                 return Ok(None);
             }
             if fusereq_available {
@@ -399,7 +399,7 @@ impl FuseChannel {
                             continue;
                         }
                         Errno::ENODEV => {
-                            info!("fuse filesystem umounted");
+                            debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                             return Ok(None);
                         }
                         e => {


### PR DESCRIPTION
At the moment, we are indiscriminately returning a SessionFailure("epoll error")
if any of the registered file descriptors would return an error upon read. This
means that the more detailed error handling code below can never be reached.

Instead, attempt to read from fuse device when the device is either
readable *or* has an error state, and then handle the error as we always
intended.

Fixes: #197.
