### PR TITLE
Bump dependencies version to resolve the RUSTSEC warnning.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,4 +68,4 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse-backend-rs"
-version = "0.12.0"
+version = "0.12.1"
 keywords = ["fuse", "virtio", "virtio-fs", "vhost-user-fs"]
 categories = ["filesystem", "os::linux-apis"]
 description = "A rust library for Fuse(filesystem in userspace) servers and virtio-fs devices"
@@ -20,7 +20,7 @@ build = "build.rs"
 arc-swap = "1.5"
 async-trait = { version = "0.1.42", optional = true }
 bitflags = "1.1"
-dbs-snapshot = { version = "1.5.0", optional = true }
+dbs-snapshot = { version = "1.5.2", optional = true }
 io-uring = { version = "0.5.8", optional = true }
 lazy_static = "1.4"
 libc = "0.2.68"
@@ -31,11 +31,11 @@ radix_trie = "0.2.1"
 tokio = { version = "1", optional = true }
 tokio-uring = { version = "0.4.0", optional = true }
 vmm-sys-util = { version = "0.12.1", optional = true }
-vm-memory = { version = "0.16.1", features = ["backend-mmap"] }
-virtio-queue = { version = "0.14.0", optional = true }
-vhost = { version = "0.6", features = ["vhost-user-slave"], optional = true }
+vm-memory = { version = "0.14.1", features = ["backend-mmap"] }
+virtio-queue = { version = "0.12.0", optional = true }
+vhost = { version = "0.11.0", features = ["vhost-user","vhost-user-backend"], optional = true }
 versionize_derive = { version = "0.1.6", optional = true }
-versionize = { version = "0.1.10", optional = true }
+versionize = { version = "0.2.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = { version = ">=0.8", optional = true }
@@ -46,8 +46,8 @@ tokio-uring = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-vmm-sys-util = "0.12.0"
-vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-bitmap"] }
+vmm-sys-util = "0.12.1"
+vm-memory = { version = "0.14.1", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]
@@ -66,7 +66,6 @@ virtiofs = ["virtio-queue", "caps", "vmm-sys-util"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]
 persist = ["dbs-snapshot", "versionize", "versionize_derive"]
 fuse-t = []
-async_io = []
 
 [package.metadata.docs.rs]
 all-features = true
@@ -75,6 +74,3 @@ targets = [
     "aarch64-unknown-linux-gnu",
     "aarch64-apple-darwin",
 ]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(testff)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ nix = "0.24"
 radix_trie = "0.2.1"
 tokio = { version = "1", optional = true }
 tokio-uring = { version = "0.4.0", optional = true }
-vmm-sys-util = { version = "0.11", optional = true }
-vm-memory = { version = "0.10", features = ["backend-mmap"] }
-virtio-queue = { version = "0.7", optional = true }
+vmm-sys-util = { version = "0.12.1", optional = true }
+vm-memory = { version = "0.16.1", features = ["backend-mmap"] }
+virtio-queue = { version = "0.14.0", optional = true }
 vhost = { version = "0.6", features = ["vhost-user-slave"], optional = true }
 versionize_derive = { version = "0.1.6", optional = true }
 versionize = { version = "0.1.10", optional = true }
@@ -46,8 +46,8 @@ tokio-uring = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-vmm-sys-util = "0.11"
-vm-memory = { version = "0.10", features = ["backend-mmap", "backend-bitmap"] }
+vmm-sys-util = "0.12.0"
+vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-bitmap"] }
 
 [features]
 default = ["fusedev"]
@@ -66,6 +66,7 @@ virtiofs = ["virtio-queue", "caps", "vmm-sys-util"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]
 persist = ["dbs-snapshot", "versionize", "versionize_derive"]
 fuse-t = []
+async_io = []
 
 [package.metadata.docs.rs]
 all-features = true
@@ -74,3 +75,6 @@ targets = [
     "aarch64-unknown-linux-gnu",
     "aarch64-apple-darwin",
 ]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(testff)'] }

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@
 # this list would mean the nix crate, as well as any of its exclusive
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
+[graph]
 targets = [
     # The triple can be any string, but only the target triples built in to
     # rustc (as of 1.40) can be checked against actual config expressions
@@ -35,26 +36,12 @@ targets = [
 db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
+version = 2
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-    # stderrlog needs to fix it
-    "RUSTSEC-2020-0071",
-    # stderrlog needs to fix it
-    "RUSTSEC-2020-0159",
-    # stderrlog needs to fix it
-    "RUSTSEC-2022-0006",
-]
+ignore = []
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.
@@ -63,14 +50,12 @@ ignore = [
 # * Medium - CVSS Score 4.0 - 6.9
 # * High - CVSS Score 7.0 - 8.9
 # * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold = 
+#severity-threshold =
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -78,30 +63,8 @@ allow = [
     "MIT",
     "Apache-2.0",
     "BSD-3-Clause",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
-# List of explictly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    "GPL-2.0",
-    "GPL-3.0",
-    #"Nokia",
-]
-# Lint level for licenses considered copyleft
-copyleft = "deny"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -178,8 +141,8 @@ deny = [
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
-# Similarly to `skip` allows you to skip certain crates during duplicate 
-# detection. Unlike skip, it also includes the entire tree of transitive 
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [

--- a/src/abi/fuse_abi_linux.rs
+++ b/src/abi/fuse_abi_linux.rs
@@ -1322,6 +1322,7 @@ unsafe impl ByteValued for CopyFileRangeIn {}
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -1346,7 +1347,12 @@ mod tests {
         let buf = [
             0x1u8, 0x2u8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5u8, 0x6u8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         ];
-        let forget: &ForgetOne = ForgetOne::from_slice(&buf).unwrap();
+        let forget = match ForgetOne::from_slice(&buf) {
+            Some(f) => f,
+            None => {
+                panic!("Failed to parse ForgetOne from buffer: {:?}", buf)
+            }
+        };
 
         assert_eq!(forget.nodeid, 0x201u64);
         assert_eq!(forget.nlookup, 0x605u64);

--- a/src/abi/fuse_abi_macos.rs
+++ b/src/abi/fuse_abi_macos.rs
@@ -1090,7 +1090,12 @@ mod tests {
         let buf = [
             0x1u8, 0x2u8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5u8, 0x6u8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
         ];
-        let forget: &ForgetOne = ForgetOne::from_slice(&buf).unwrap();
+        let forget = match ForgetOne::from_slice(&buf) {
+            Some(f) => f,
+            None => {
+                panic!("Failed to parse ForgetOne from buffer: {:?}", buf)
+            }
+        };
 
         assert_eq!(forget.nodeid, 0x201u64);
         assert_eq!(forget.nlookup, 0x605u64);

--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -269,7 +269,7 @@ pub trait ZeroCopyReader: io::Read {
     ) -> io::Result<usize> {
         let mut out = 0;
         loop {
-            match self.read_to(f, ::std::usize::MAX, off) {
+            match self.read_to(f, usize::MAX, off) {
                 Ok(0) => return Ok(out),
                 Ok(n) => {
                     off = off.saturating_add(n as u64);
@@ -364,7 +364,7 @@ pub trait ZeroCopyWriter: io::Write {
     ) -> io::Result<usize> {
         let mut out = 0;
         loop {
-            match self.write_from(f, ::std::usize::MAX, off) {
+            match self.write_from(f, usize::MAX, off) {
                 Ok(0) => return Ok(out),
                 Ok(n) => {
                     off = off.saturating_add(n as u64);

--- a/src/api/filesystem/overlay.rs
+++ b/src/api/filesystem/overlay.rs
@@ -140,7 +140,7 @@ pub trait Layer: FileSystem {
                 Ok(v) => {
                     // xattr name exists and we get value.
                     if let GetxattrReply::Value(buf) = v {
-                        if buf.len() == 1 && buf[0].to_ascii_lowercase() == b'y' {
+                        if buf.len() == 1 && buf[0].eq_ignore_ascii_case(&b'y') {
                             return Ok(true);
                         }
                     }

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -68,7 +68,7 @@ impl<F: FileSystem + Sync> Server<F> {
 
 struct ZcReader<'a, S: BitmapSlice = ()>(Reader<'a, S>);
 
-impl<'a, S: BitmapSlice> ZeroCopyReader for ZcReader<'a, S> {
+impl<S: BitmapSlice> ZeroCopyReader for ZcReader<'_, S> {
     fn read_to(
         &mut self,
         f: &mut dyn FileReadWriteVolatile,
@@ -79,7 +79,7 @@ impl<'a, S: BitmapSlice> ZeroCopyReader for ZcReader<'a, S> {
     }
 }
 
-impl<'a, S: BitmapSlice> io::Read for ZcReader<'a, S> {
+impl<S: BitmapSlice> io::Read for ZcReader<'_, S> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
@@ -87,7 +87,7 @@ impl<'a, S: BitmapSlice> io::Read for ZcReader<'a, S> {
 
 struct ZcWriter<'a, S: BitmapSlice = ()>(Writer<'a, S>);
 
-impl<'a, S: BitmapSlice> ZeroCopyWriter for ZcWriter<'a, S> {
+impl<S: BitmapSlice> ZeroCopyWriter for ZcWriter<'_, S> {
     fn write_from(
         &mut self,
         f: &mut dyn FileReadWriteVolatile,
@@ -102,7 +102,7 @@ impl<'a, S: BitmapSlice> ZeroCopyWriter for ZcWriter<'a, S> {
     }
 }
 
-impl<'a, S: BitmapSlice> io::Write for ZcWriter<'a, S> {
+impl<S: BitmapSlice> io::Write for ZcWriter<'_, S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -734,8 +734,8 @@ impl<F: FileSystem + Sync> Server<F> {
                     minor: KERNEL_MINOR_VERSION,
                     max_readahead: readahead,
                     flags: enabled_flags as u32,
-                    max_background: ::std::u16::MAX,
-                    congestion_threshold: (::std::u16::MAX / 4) * 3,
+                    max_background: u16::MAX,
+                    congestion_threshold: (u16::MAX / 4) * 3,
                     max_write: MIN_READ_BUFFER - BUFFER_HEADER_SIZE,
                     time_gran: 1, // nanoseconds
                     flags2: (enabled_flags >> 32) as u32,
@@ -1251,7 +1251,7 @@ impl<F: FileSystem + Sync> Server<F> {
     }
 }
 
-impl<'a, F: FileSystem, S: BitmapSlice> SrvContext<'a, F, S> {
+impl<F: FileSystem, S: BitmapSlice> SrvContext<'_, F, S> {
     fn reply_ok<T: ByteValued>(&mut self, out: Option<T>, data: Option<&[u8]>) -> Result<usize> {
         let data2 = out.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
         let data3 = data.unwrap_or(&[]);
@@ -1350,7 +1350,7 @@ fn add_dirent<S: BitmapSlice>(
     d: DirEntry,
     entry: Option<Entry>,
 ) -> io::Result<usize> {
-    if d.name.len() > ::std::u32::MAX as usize {
+    if d.name.len() > u32::MAX as usize {
         return Err(io::Error::from_raw_os_error(libc::EOVERFLOW));
     }
 

--- a/src/common/file_buf.rs
+++ b/src/common/file_buf.rs
@@ -180,7 +180,8 @@ impl<'a> FileVolatileSlice<'a> {
     }
 }
 
-impl Bytes<usize> for FileVolatileSlice<'_> {
+#[allow(clippy::needless_lifetimes)]
+impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
     type E = VError;
 
     fn write(&self, buf: &[u8], addr: usize) -> Result<usize, Self::E> {

--- a/src/common/file_buf.rs
+++ b/src/common/file_buf.rs
@@ -125,6 +125,7 @@ impl<'a> FileVolatileSlice<'a> {
     /// [`vm_memory::BitmapSlice`]: https://docs.rs/vm-memory/latest/vm_memory/bitmap/trait.BitmapSlice.html
     /// [`vm_memory::VolatileSlice`]: https://docs.rs/vm-memory/latest/vm_memory/volatile_memory/struct.VolatileSlice.html
     pub fn from_volatile_slice<S: BitmapSlice>(s: &VolatileSlice<'a, S>) -> Self {
+        #[allow(deprecated)]
         Self::new(s.as_ptr(), s.len())
     }
 
@@ -179,7 +180,7 @@ impl<'a> FileVolatileSlice<'a> {
     }
 }
 
-impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
+impl Bytes<usize> for FileVolatileSlice<'_> {
     type E = VError;
 
     fn write(&self, buf: &[u8], addr: usize) -> Result<usize, Self::E> {
@@ -202,6 +203,7 @@ impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
     where
         F: Read,
     {
+        #[allow(deprecated)]
         VolatileSlice::read_from(&self.as_volatile_slice(), addr, src, count)
     }
 
@@ -209,6 +211,7 @@ impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
     where
         F: Read,
     {
+        #[allow(deprecated)]
         VolatileSlice::read_exact_from(&self.as_volatile_slice(), addr, src, count)
     }
 
@@ -216,6 +219,7 @@ impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
     where
         F: Write,
     {
+        #[allow(deprecated)]
         VolatileSlice::write_to(&self.as_volatile_slice(), addr, dst, count)
     }
 
@@ -223,6 +227,7 @@ impl<'a> Bytes<usize> for FileVolatileSlice<'a> {
     where
         F: Write,
     {
+        #[allow(deprecated)]
         VolatileSlice::write_all_to(&self.as_volatile_slice(), addr, dst, count)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![allow(unexpected_cfgs)]
 
 //! A rust library for Fuse(filesystem in userspace) servers and virtio-fs devices.
 //!

--- a/src/overlayfs/mod.rs
+++ b/src/overlayfs/mod.rs
@@ -244,10 +244,7 @@ impl RealInode {
         // Open the directory and load each entry.
         let opendir_res = self.layer.opendir(ctx, self.inode, libc::O_RDONLY as u32);
         let handle = match opendir_res {
-            Ok((handle, _)) => match handle {
-                Some(h) => h,
-                _ => 0,
-            },
+            Ok((handle, _)) => handle.unwrap_or_default(),
             // opendir may not be supported if no_opendir is set, so we can ignore this error.
             Err(e) => {
                 match e.raw_os_error() {
@@ -970,9 +967,9 @@ impl OverlayFs {
         }
 
         // Current file or dir.
-        if name.eq(".")  
+        if name.eq(".")
             // Root directory has no parent.
-            || (parent == FUSE_ROOT_ID && name.eq("..")) 
+            || (parent == FUSE_ROOT_ID && name.eq(".."))
             // Special convention: empty name indicates current dir.
             || name.is_empty()
         {

--- a/src/passthrough/config.rs
+++ b/src/passthrough/config.rs
@@ -161,7 +161,7 @@ pub struct Config {
     /// * If dax_file_size == None, DAX will disable to all files.
     /// * If dax_file_size == 0, DAX will enable all files.
     /// * If dax_file_size == N, DAX will enable only when the file size is greater than or equal
-    /// to N Bytes.
+    ///   to N Bytes.
     pub dax_file_size: Option<u64>,
 
     /// Reduce memory consumption by directly use host inode when possible.

--- a/src/passthrough/file_handle.rs
+++ b/src/passthrough/file_handle.rs
@@ -328,7 +328,7 @@ mod tests {
         buf: Vec<libc::c_char>,
     ) -> CFileHandle {
         let mut wrapper = CFileHandle::new(handle_bytes);
-        let fh = wrapper.wrapper.as_mut_fam_struct();
+        let fh = unsafe { wrapper.wrapper.as_mut_fam_struct() };
         fh.handle_type = handle_type;
         unsafe {
             fh.f_handle
@@ -401,7 +401,7 @@ mod tests {
     fn test_c_file_handle_wrapper() {
         let buf = (0..=127).collect::<Vec<libc::c_char>>();
         let mut wrapper = generate_c_file_handle(MAX_HANDLE_SIZE, 3, buf.clone());
-        let fh = wrapper.wrapper.as_mut_fam_struct();
+        let fh = unsafe { wrapper.wrapper.as_mut_fam_struct() };
 
         assert_eq!(fh.handle_bytes as usize, MAX_HANDLE_SIZE);
         assert_eq!(fh.handle_type, 3);

--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -416,7 +416,7 @@ fn fuse_kern_mount(
                 cmd.arg("-r");
             }
             cmd.arg(mountpoint);
-            cmd.exec();
+            let _ = cmd.exec();
             panic!("never arrive here")
         }
     }

--- a/src/transport/fusedev/macos_session.rs
+++ b/src/transport/fusedev/macos_session.rs
@@ -395,8 +395,14 @@ fn create_disk(mountpoint: &Path, dasession: DASessionRef) -> DADiskRef {
         let url =
             CFURLCreateWithFileSystemPath(std::ptr::null(), url_str, kCFURLPOSIXPathStyle, 1u8);
         let disk = DADiskCreateFromVolumePath(std::ptr::null(), dasession, url);
-        CFRelease(std::mem::transmute(url_str));
-        CFRelease(std::mem::transmute(url));
+        CFRelease(std::mem::transmute::<
+            *const core_foundation_sys::string::__CFString,
+            *const libc::c_void,
+        >(url_str));
+        CFRelease(std::mem::transmute::<
+            *const core_foundation_sys::url::__CFURL,
+            *const libc::c_void,
+        >(url));
         disk
     }
 }
@@ -419,7 +425,7 @@ fn fuse_kern_umount(file: File, disk: Option<DADiskRef>) -> Result<()> {
                 None,
                 std::ptr::null_mut(),
             );
-            CFRelease(std::mem::transmute(disk));
+            CFRelease(std::mem::transmute::<DADiskRef, *const libc::c_void>(disk));
         }
     }
     Ok(())

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -797,7 +797,7 @@ mod tests {
     #[test]
     fn test_mark_dirty() {
         let mut buf1 = vec![0x0u8; 16];
-        let bitmap1 = AtomicBitmap::new(16, 2);
+        let bitmap1 = AtomicBitmap::new(16, std::num::NonZero::new(2).unwrap());
 
         assert_eq!(bitmap1.len(), 8);
         for i in 0..8 {
@@ -805,7 +805,7 @@ mod tests {
         }
 
         let mut buf2 = vec![0x0u8; 16];
-        let bitmap2 = AtomicBitmap::new(16, 2);
+        let bitmap2 = AtomicBitmap::new(16, std::num::NonZero::new(2).unwrap());
         let mut bufs = VecDeque::new();
 
         unsafe {
@@ -813,11 +813,13 @@ mod tests {
                 buf1.as_mut_ptr(),
                 buf1.len(),
                 bitmap1.slice_at(0),
+                None,
             ));
             bufs.push_back(VolatileSlice::with_bitmap(
                 buf2.as_mut_ptr(),
                 buf2.len(),
                 bitmap2.slice_at(0),
+                None,
             ));
         }
         let mut buffers = IoBuffers {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -530,7 +530,7 @@ pub enum Writer<'a, S: BitmapSlice = ()> {
     Noop(PhantomData<&'a S>),
 }
 
-impl<'a, S: BitmapSlice> Writer<'a, S> {
+impl<S: BitmapSlice> Writer<'_, S> {
     /// Write data to the descriptor chain buffer from a File at offset `off`.
     ///
     /// Return the number of bytes written to the descriptor chain buffer.
@@ -601,7 +601,7 @@ impl<'a, S: BitmapSlice> Writer<'a, S> {
     }
 }
 
-impl<'a, S: BitmapSlice> io::Write for Writer<'a, S> {
+impl<S: BitmapSlice> io::Write for Writer<'_, S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
             #[cfg(feature = "fusedev")]

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -388,7 +388,6 @@ mod async_io {
 
 /// Disabled since vm-virtio doesn't export any DescriptorChain constructors.
 /// Should re-enable once it does.
-#[allow(unexpected_cfgs)]
 #[cfg(testff)]
 mod tests {
     use super::*;

--- a/src/transport/virtiofs/mod.rs
+++ b/src/transport/virtiofs/mod.rs
@@ -273,7 +273,7 @@ impl<'a, S: BitmapSlice> VirtioFsWriter<'a, S> {
     }
 }
 
-impl<'a, S: BitmapSlice> io::Write for VirtioFsWriter<'a, S> {
+impl<S: BitmapSlice> io::Write for VirtioFsWriter<'_, S> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.check_available_space(buf.len(), 0, 0)?;
 
@@ -388,6 +388,7 @@ mod async_io {
 
 /// Disabled since vm-virtio doesn't export any DescriptorChain constructors.
 /// Should re-enable once it does.
+#[allow(unexpected_cfgs)]
 #[cfg(testff)]
 mod tests {
     use super::*;


### PR DESCRIPTION
To fix this https://github.com/dragonflyoss/nydus/issues/1647, we need bump `vm-memory` and `vmm-sys-util` here first. The releated RUSTSEC advisories are [RUSTSEC-2023-0056](https://rustsec.org/advisories/RUSTSEC-2023-0056) and [RUSTSEC-2024-0002](https://rustsec.org/advisories/RUSTSEC-2024-0002).

In addtion, since the `async_io` is not a supported feature as #188 mentioned, I removed the related code in linux_session.rs to address the clippy error in CI. Now all [CI](https://github.com/BraveY/fuse-backend-rs/actions/runs/12908477335) got green. @PlamenHristov cc.
