### PR TITLE
chore: fix broken CI by pinning virtio-bindings to v0.2.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         declare -A rust_target_map=( ["amd64"]="x86_64-unknown-linux-musl" ["arm64"]="aarch64-unknown-linux-musl" ["ppc64le"]="powerpc64le-unknown-linux-gnu" ["riscv64"]="riscv64gc-unknown-linux-gnu" ["s390x"]="s390x-unknown-linux-gnu")
         RUST_TARGET=${rust_target_map[${{ matrix.arch }}]}
-        cargo install --version 0.2.4 cross
+        cargo install --version 0.2.5 cross
         rustup component add rustfmt clippy
         make -e RUST_TARGET=$RUST_TARGET -e CARGO=cross check
     - name: smoke

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1", optional = true }
 tokio-uring = { version = "0.4.0", optional = true }
 vmm-sys-util = { version = "0.12.1", optional = true }
 vm-memory = { version = "0.14.1", features = ["backend-mmap"] }
+virtio-bindings = { version = "=0.2.4", optional = true }
 virtio-queue = { version = "0.12.0", optional = true }
 vhost = { version = "0.11.0", features = ["vhost-user","vhost-user-backend"], optional = true }
 versionize_derive = { version = "0.1.6", optional = true }


### PR DESCRIPTION
To fix the [broken CI](https://github.com/cloud-hypervisor/fuse-backend-rs/actions/runs/13238505121)  caused by a version bump in virtio-bindings, we need to pin the version to v0.2.4.