### PR TITLE
Fix: unable to perform sync on directory

### DIFF
--- a/src/api/filesystem/overlay.rs
+++ b/src/api/filesystem/overlay.rs
@@ -195,8 +195,8 @@ pub(crate) fn is_chardev(st: stat64) -> bool {
 pub(crate) fn is_whiteout(st: stat64) -> bool {
     // A whiteout is created as a character device with 0/0 device number.
     // See ref: https://docs.kernel.org/filesystems/overlayfs.html#whiteouts-and-opaque-directories
-    let major = unsafe { libc::major(st.st_rdev) };
-    let minor = unsafe { libc::minor(st.st_rdev) };
+    let major = libc::major(st.st_rdev);
+    let minor = libc::minor(st.st_rdev);
     is_chardev(st) && major == 0 && minor == 0
 }
 

--- a/src/api/vfs/sync_io.rs
+++ b/src/api/vfs/sync_io.rs
@@ -306,9 +306,7 @@ impl FileSystem for Vfs {
         }
         match self.get_real_rootfs(inode)? {
             (Left(fs), idata) => fs.open(ctx, idata.ino(), flags, fuse_flags),
-            (Right(fs), idata) => fs
-                .open(ctx, idata.ino(), flags, fuse_flags)
-                .map(|(h, opt, passthrough)| (h.map(Into::into), opt, passthrough)),
+            (Right(fs), idata) => fs.open(ctx, idata.ino(), flags, fuse_flags),
         }
     }
 
@@ -522,9 +520,7 @@ impl FileSystem for Vfs {
         }
         match self.get_real_rootfs(inode)? {
             (Left(fs), idata) => fs.opendir(ctx, idata.ino(), flags),
-            (Right(fs), idata) => fs
-                .opendir(ctx, idata.ino(), flags)
-                .map(|(h, opt)| (h.map(Into::into), opt)),
+            (Right(fs), idata) => fs.opendir(ctx, idata.ino(), flags),
         }
     }
 

--- a/src/passthrough/util.rs
+++ b/src/passthrough/util.rs
@@ -225,6 +225,22 @@ pub fn eperm() -> io::Error {
     io::Error::from_raw_os_error(libc::EPERM)
 }
 
+pub fn sync_fd(fd: &impl AsRawFd, datasync: bool) -> io::Result<()> {
+    // Safe because this doesn't modify any memory and we check the return value.
+    let res = unsafe {
+        if datasync {
+            libc::fdatasync(fd.as_raw_fd())
+        } else {
+            libc::fsync(fd.as_raw_fd())
+        }
+    };
+    if res == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -265,7 +265,7 @@ impl<'a, S: BitmapSlice> FuseDevWriter<'a, S> {
     }
 
     fn check_available_space(&self, sz: usize) -> io::Result<()> {
-        assert!(self.buffered || self.buf.len() == 0);
+        assert!(self.buffered || self.buf.is_empty());
         if sz > self.available_bytes() {
             Err(io::Error::new(
                 io::ErrorKind::InvalidData,


### PR DESCRIPTION
when no_open=false, no_opendir=true, we can't execute the sync command on the directory, because fsyncdir uses get_data to get the handle of the directory, but no_open=false, so it will go to the handle map to find it, but in fact this is a directory, and the no_opendir is true, so it is not in the handle map, It needs to be reopened.

#204 