### PR TITLE
Add notify_inval_inode and extend get_rootfs to return fs_idx for umount

### DIFF
--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -1032,7 +1032,7 @@ mod tests {
         fs.import().unwrap();
         vfs.mount(Box::new(fs), "/submnt/A").unwrap();
 
-        let p_fs = vfs.get_rootfs("/submnt/A").unwrap().unwrap();
+        let (p_fs, _) = vfs.get_rootfs("/submnt/A").unwrap().unwrap();
         let any_fs = p_fs.deref().as_any();
         any_fs
             .downcast_ref::<PassthroughFs>()


### PR DESCRIPTION
This PR includes two related improvements to better support multi-filesystem
mounting scenarios on fuse, especially during unmount operations:

1. Add `notify_inval_inode` support in fusedev, enabling user space to
   explicitly notify the kernel to invalidate inode page caches. This helps
 clear caches properly after unmounting.

2. Extend the VFS method `get_rootfs` to return both the mounted backend
   filesystem (Arc<BackFileSystem>) and its associated filesystem index
   (fs_idx). Although multi-filesystem mounting is already supported,
   returning fs_idx is necessary for proper unmount handling and cache
   invalidation.

The implementation follows fuse kernel and libfuse protocols and maintains
compatibility with existing patterns like notify_inval_entry.
