### PR TITLE
Fix fuse out header len in notify_resend

### DIFF
--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -67,9 +67,9 @@ impl<F: FileSystem + Sync> Server<F> {
         let mut buffer_writer = w.split_at(0).map_err(Error::FailedToSplitWriter)?;
         let header = {
             OutHeader {
+                len: std::mem::size_of::<OutHeader>() as u32,
                 unique: 0,
                 error: NotifyOpcode::Resend as i32,
-                ..Default::default()
             }
         };
         buffer_writer


### PR DESCRIPTION
This PR fixes the len of OutHeader when notifying kernel to resend fuse requests. The original code can cause an EINVAL error.