### PR TITLE
fix: satisfy newer Clippy lints to pass CI on latest Rust

### DIFF
--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -863,7 +863,7 @@ pub trait FileSystem {
         cmd: u32,
         data: IoctlData,
         out_size: u32,
-    ) -> io::Result<IoctlData> {
+    ) -> io::Result<IoctlData<'_>> {
         // Rather than ENOSYS, let's return ENOTTY so simulate that the ioctl call is implemented
         // but no ioctl number is supported.
         Err(io::Error::from_raw_os_error(libc::ENOTTY))
@@ -1313,7 +1313,7 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
         cmd: u32,
         data: IoctlData,
         out_size: u32,
-    ) -> io::Result<IoctlData> {
+    ) -> io::Result<IoctlData<'_>> {
         self.deref()
             .ioctl(ctx, inode, handle, flags, cmd, data, out_size)
     }

--- a/src/api/vfs/mod.rs
+++ b/src/api/vfs/mod.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt;
 use std::io;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
@@ -535,10 +535,9 @@ impl Vfs {
             return Ok(inode);
         }
         if inode > VFS_MAX_INO {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!("Inode number {inode} too large, max supported {VFS_MAX_INO}"),
-            ));
+            return Err(Error::other(format!(
+                "Inode number {inode} too large, max supported {VFS_MAX_INO}"
+            )));
         }
         let ino: u64 = ((fs_idx as u64) << VFS_INDEX_SHIFT) | inode;
         trace!(
@@ -630,10 +629,7 @@ impl Vfs {
             }
         }
 
-        Err(Error::new(
-            ErrorKind::Other,
-            "vfs maximum mountpoints reached",
-        ))
+        Err(Error::other("vfs maximum mountpoints reached"))
     }
 
     fn get_fs_by_idx(&self, fs_idx: VfsIndex) -> Result<Arc<BackFileSystem>> {

--- a/src/common/file_buf.rs
+++ b/src/common/file_buf.rs
@@ -315,13 +315,13 @@ impl FileVolatileBuf {
     }
 
     /// Generate an `IoSlice` object to read data from the buffer.
-    pub fn io_slice(&self) -> IoSlice {
+    pub fn io_slice(&self) -> IoSlice<'_> {
         let buf = unsafe { slice::from_raw_parts(self.addr as *const u8, self.size) };
         IoSlice::new(buf)
     }
 
     /// Generate an `IoSliceMut` object to write data into the buffer.
-    pub fn io_slice_mut(&self) -> IoSliceMut {
+    pub fn io_slice_mut(&self) -> IoSliceMut<'_> {
         let buf = unsafe {
             let ptr = (self.addr as *mut u8).add(self.size);
             let sz = self.cap - self.size;

--- a/src/overlayfs/inode_store.rs
+++ b/src/overlayfs/inode_store.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Ant Group. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::{
     collections::HashMap,
     sync::{atomic::Ordering, Arc},
@@ -45,10 +45,10 @@ impl InodeStore {
             ino += 1;
         }
         error!("reached maximum inode number: {}", VFS_MAX_INO);
-        Err(Error::new(
-            ErrorKind::Other,
-            format!("maximum inode number {} reached", VFS_MAX_INO),
-        ))
+        Err(Error::other(format!(
+            "maximum inode number {} reached",
+            VFS_MAX_INO
+        )))
     }
 
     pub(crate) fn alloc_inode(&mut self, path: &String) -> Result<Inode> {

--- a/src/overlayfs/mod.rs
+++ b/src/overlayfs/mod.rs
@@ -701,7 +701,7 @@ impl OverlayInode {
         let pnode = if let Some(n) = self.parent.lock().unwrap().upgrade() {
             Arc::clone(&n)
         } else {
-            return Err(Error::new(ErrorKind::Other, "no parent?"));
+            return Err(Error::other("no parent?"));
         };
 
         if !pnode.in_upper_layer() {
@@ -818,13 +818,10 @@ impl OverlayInode {
                     f(None)
                 }
             }
-            None => Err(Error::new(
-                ErrorKind::Other,
-                format!(
-                    "BUG: dangling OverlayInode {} without any backend inode",
-                    self.inode
-                ),
-            )),
+            None => Err(Error::other(format!(
+                "BUG: dangling OverlayInode {} without any backend inode",
+                self.inode
+            ))),
         }
     }
 }
@@ -1119,7 +1116,7 @@ impl OverlayFs {
                 let all_inodes = ovi.real_inodes.lock().unwrap();
                 let real_inode = all_inodes
                     .first()
-                    .ok_or(Error::new(ErrorKind::Other, "backend inode not found"))?;
+                    .ok_or(Error::other("backend inode not found"))?;
                 real_inode.layer.statfs(ctx, real_inode.inode)
             }
             None => Err(Error::from_raw_os_error(libc::ENOENT)),
@@ -1694,7 +1691,7 @@ impl OverlayFs {
         let parent_node = if let Some(ref n) = node.parent.lock().unwrap().upgrade() {
             Arc::clone(n)
         } else {
-            return Err(Error::new(ErrorKind::Other, "no parent?"));
+            return Err(Error::other("no parent?"));
         };
 
         let (self_layer, _, self_inode) = node.first_layer_inode();
@@ -1736,7 +1733,7 @@ impl OverlayFs {
         let parent_node = if let Some(ref n) = node.parent.lock().unwrap().upgrade() {
             Arc::clone(n)
         } else {
-            return Err(Error::new(ErrorKind::Other, "no parent?"));
+            return Err(Error::other("no parent?"));
         };
 
         let st = node.stat64(ctx)?;
@@ -2027,8 +2024,8 @@ impl OverlayFs {
             .childrens
             .lock()
             .unwrap()
-            .iter()
-            .map(|(_, v)| v.clone())
+            .values()
+            .cloned()
             .collect::<Vec<_>>();
 
         for child in iter {

--- a/src/overlayfs/sync_io.rs
+++ b/src/overlayfs/sync_io.rs
@@ -16,7 +16,7 @@ use crate::api::filesystem::{
 };
 
 use libc;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 
 impl FileSystem for OverlayFs {
     type Inode = Inode;
@@ -350,7 +350,7 @@ impl FileSystem for OverlayFs {
             let rh = if let Some(ref h) = hd.real_handle {
                 h
             } else {
-                return Err(Error::new(ErrorKind::Other, "no handle"));
+                return Err(Error::other("no handle"));
             };
             let real_handle = rh.handle.load(Ordering::Relaxed);
             let real_inode = rh.inode;

--- a/src/passthrough/mount_fd.rs
+++ b/src/passthrough/mount_fd.rs
@@ -24,7 +24,7 @@ pub struct MountFd {
 }
 
 impl AsFd for MountFd {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.file.as_fd()
     }
 }

--- a/src/passthrough/util.rs
+++ b/src/passthrough/util.rs
@@ -53,8 +53,7 @@ impl UniqueInodeGenerator {
                 btree_map::Entry::Occupied(v) => *v.get(),
                 btree_map::Entry::Vacant(v) => {
                     if self.next_unique_id.load(Ordering::Relaxed) == u8::MAX {
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
+                        return Err(io::Error::other(
                             "the number of combinations of dev and mntid exceeds 255",
                         ));
                     }
@@ -69,10 +68,10 @@ impl UniqueInodeGenerator {
             id.ino
         } else {
             if self.next_virtual_inode.load(Ordering::Relaxed) > MAX_HOST_INO {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("the virtual inode excess {}", MAX_HOST_INO),
-                ));
+                return Err(io::Error::other(format!(
+                    "the virtual inode excess {}",
+                    MAX_HOST_INO
+                )));
             }
             self.next_virtual_inode.fetch_add(1, Ordering::Relaxed) | VIRTUAL_INODE_FLAG
         };

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -329,7 +329,7 @@ impl FuseChannel {
     /// - Ok(None): signal has pending on the exiting event channel
     /// - Ok(Some((reader, writer))): reader to receive request and writer to send reply
     /// - Err(e): error message
-    pub fn get_request(&mut self) -> Result<Option<(Reader, FuseDevWriter)>> {
+    pub fn get_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
         let mut events = Events::with_capacity(POLL_EVENTS_CAPACITY);
         let mut need_exit = false;
         loop {

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -283,7 +283,7 @@ impl<'a, S: BitmapSlice> FuseDevWriter<'a, S> {
     fn do_write(fd: RawFd, data: &[u8]) -> io::Result<usize> {
         write(fd, data).map_err(|e| {
             error! {"fail to write to fuse device fd {}: {}, {:?}", fd, e, data};
-            io::Error::new(io::ErrorKind::Other, format!("{e}"))
+            io::Error::other(format!("{e}"))
         })
     }
 }
@@ -322,7 +322,7 @@ impl<S: BitmapSlice> Write for FuseDevWriter<'_, S> {
                 })
                 .map_err(|e| {
                     error! {"fail to write to fuse device on commit: {}", e};
-                    io::Error::new(io::ErrorKind::Other, format!("{e}"))
+                    io::Error::other(format!("{e}"))
                 })
         }
     }
@@ -330,10 +330,7 @@ impl<S: BitmapSlice> Write for FuseDevWriter<'_, S> {
     /// As this writer can associate multiple writers by splitting, `flush()` can't
     /// flush them all. Disable it!
     fn flush(&mut self) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Writer does not support flush buffer.",
-        ))
+        Err(io::Error::other("Writer does not support flush buffer."))
     }
 }
 
@@ -362,7 +359,7 @@ mod async_io {
                     })
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                        io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                        io::Error::other(format!("{}", e))
                     })
             }
         }
@@ -388,7 +385,7 @@ mod async_io {
                     })
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                        io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                        io::Error::other(format!("{}", e))
                     })
             }
         }
@@ -420,7 +417,7 @@ mod async_io {
                     })
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                        io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                        io::Error::other(format!("{}", e))
                     })
             }
         }
@@ -466,7 +463,7 @@ mod async_io {
                         // write to fd, can only happen once per instance
                         nix::sys::uio::pwrite(self.fd, &self.buf[..cnt], 0).map_err(|e| {
                             error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                            io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                            io::Error::other(format!("{}", e))
                         })
                     }
                 }
@@ -487,17 +484,17 @@ mod async_io {
                 (0, 0) => Ok(0),
                 (0, _) => nix::sys::uio::pwrite(self.fd, o, 0).map_err(|e| {
                     error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                    io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                    io::Error::other(format!("{}", e))
                 }),
                 (_, 0) => nix::sys::uio::pwrite(self.fd, self.buf.as_slice(), 0).map_err(|e| {
                     error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                    io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                    io::Error::other(format!("{}", e))
                 }),
                 (_, _) => {
                     let bufs = [IoSlice::new(self.buf.as_slice()), IoSlice::new(o)];
                     writev(self.fd, &bufs).map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
-                        io::Error::new(io::ErrorKind::Other, format!("{}", e))
+                        io::Error::other(format!("{}", e))
                     })
                 }
             };

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -142,7 +142,7 @@ impl<S: BitmapSlice> IoBuffers<'_, S> {
         self.bytes_consumed
     }
 
-    fn allocate_file_volatile_slice(&self, count: usize) -> Vec<FileVolatileSlice> {
+    fn allocate_file_volatile_slice(&self, count: usize) -> Vec<FileVolatileSlice<'_>> {
         let mut rem = count;
         let mut bufs: Vec<FileVolatileSlice> = Vec::with_capacity(self.buffers.len());
 


### PR DESCRIPTION
- replace Error::new(ErrorKind::Other, ...) with Error::other(...)
- replace iter().map(|(_, v)| v.clone()) with values().map(|v| v.clone())
- add explicit `'_` lifetime in return type
