### PR TITLE
feat(fusedev): add `try_with_writer` on `FuseSession`; update

### DIFF
--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -16,6 +16,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use crate::transport::fusedev::FuseSessionExt;
 use mio::{Events, Poll, Token, Waker};
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
@@ -23,8 +24,6 @@ use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::poll::{poll, PollFd, PollFlags};
 use nix::sys::epoll::{epoll_ctl, EpollEvent, EpollFlags, EpollOp};
 use nix::unistd::{getgid, getuid, read};
-
-use crate::transport::fusedev::FuseSessionExt;
 
 use super::{
     super::pagesize,

--- a/src/transport/fusedev/macos_session.rs
+++ b/src/transport/fusedev/macos_session.rs
@@ -203,6 +203,16 @@ impl Drop for FuseSession {
     }
 }
 
+impl FuseSessionExt for FuseSession {
+    fn file(&self) -> Option<&File> {
+        self.file.as_ref()
+    }
+
+    fn bufsize(&self) -> usize {
+        self.bufsize
+    }
+}
+
 /// A fuse channel abstruction. Each session can hold multiple channels.
 pub struct FuseChannel {
     file: File,

--- a/src/transport/fusedev/macos_session.rs
+++ b/src/transport/fusedev/macos_session.rs
@@ -35,6 +35,7 @@ use super::{
     Error::IoError, Error::SessionFailure, FuseBuf, FuseDevWriter, Reader, Result,
     FUSE_HEADER_SIZE, FUSE_KERN_BUF_PAGES,
 };
+use crate::transport::fusedev::FuseSessionExt;
 use crate::transport::pagesize;
 
 const OSXFUSE_MOUNT_PROG: &str = "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse";

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -337,7 +337,6 @@ impl<S: BitmapSlice> Write for FuseDevWriter<'_, S> {
 
 /// Extension trait for FuseSession to provide helper methods.
 pub trait FuseSessionExt {
-
     /// Get the underlying file of the fuse session.
     fn file(&self) -> Option<&std::fs::File>;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -42,7 +42,7 @@ mod virtiofs;
 
 pub use self::fs_cache_req_handler::FsCacheReqHandler;
 #[cfg(feature = "fusedev")]
-pub use self::fusedev::{FuseBuf, FuseChannel, FuseDevWriter, FuseSession};
+pub use self::fusedev::{FuseBuf, FuseChannel, FuseDevWriter, FuseSession, FuseSessionExt};
 #[cfg(feature = "virtiofs")]
 pub use self::virtiofs::VirtioFsWriter;
 

--- a/tests/passthrough/src/main.rs
+++ b/tests/passthrough/src/main.rs
@@ -1,3 +1,4 @@
+use fuse_backend_rs::transport::FuseSessionExt as _;
 use log::{error, info, warn, LevelFilter};
 use std::env;
 use std::fs;


### PR DESCRIPTION
`with_writer` docs

- Introduce `try_with_writer<F, R, E>` that builds a `FuseDevWriter` and returns
  the closure’s `Result`, converting `super::Error` via `From`.
  - Return `SessionFailure("invalid fuse session")` when `self.file` is absent.
  - Tweak `with_writer` doc to clarify it passes a writer to the given closure.

example(passthrough): update example to show how to use try_with_writer