### PR TITLE
Add supplementary groups support and POSIX permission fixes

### DIFF
--- a/src/api/filesystem/async_io.rs
+++ b/src/api/filesystem/async_io.rs
@@ -797,6 +797,20 @@ pub trait AsyncFileSystem: FileSystem {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    /// Reposition read/write file offset with a signed offset.
+    ///
+    /// Default implementation forwards to [`lseek`] for backward compatibility.
+    fn lseek_signed(
+        &self,
+        ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        offset: i64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        self.lseek(ctx, inode, handle, offset as u64, whence)
+    }
+
     /// TODO: support this
     fn getlk(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))

--- a/src/api/filesystem/mod.rs
+++ b/src/api/filesystem/mod.rs
@@ -383,7 +383,7 @@ pub trait ZeroCopyWriter: io::Write {
 }
 
 /// Additional context associated with requests.
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct Context {
     /// The user ID of the calling process.
     pub uid: libc::uid_t,
@@ -393,6 +393,12 @@ pub struct Context {
 
     /// The thread group ID of the calling process.
     pub pid: libc::pid_t,
+
+    /// Supplementary groups of the calling process.
+    ///
+    /// When set, these groups are used directly instead of reading from /proc/<pid>/status.
+    /// This is essential for remote filesystems where the PID doesn't exist on the server.
+    pub supplementary_groups: Option<Vec<libc::gid_t>>,
 }
 
 impl Context {
@@ -408,6 +414,7 @@ impl From<&fuse::InHeader> for Context {
             uid: source.uid,
             gid: source.gid,
             pid: source.pid as i32,
+            supplementary_groups: None,
         }
     }
 }

--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -868,6 +868,29 @@ pub trait FileSystem {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    /// Copy a range of data from one file to another.
+    ///
+    /// Performs an optimized copy between two file descriptors. On filesystems
+    /// that support it (like btrfs), this creates a reflink (copy-on-write clone)
+    /// which is nearly instantaneous regardless of file size.
+    ///
+    /// Returns the number of bytes copied.
+    #[allow(clippy::too_many_arguments)]
+    fn copy_file_range(
+        &self,
+        ctx: &Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// send ioctl to the file
     #[allow(clippy::too_many_arguments)]
     fn ioctl(

--- a/src/api/filesystem/sync_io.rs
+++ b/src/api/filesystem/sync_io.rs
@@ -891,6 +891,30 @@ pub trait FileSystem {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
 
+    /// Remap file ranges (FICLONE/FICLONERANGE) for copy-on-write filesystems.
+    ///
+    /// This is the server-side implementation of the FUSE_REMAP_FILE_RANGE opcode,
+    /// which enables FICLONE and FICLONERANGE ioctls through FUSE. On btrfs and
+    /// other CoW filesystems, this creates reflinks - instant copies that share
+    /// the same physical storage until modified.
+    ///
+    /// Returns the number of bytes remapped.
+    #[allow(clippy::too_many_arguments)]
+    fn remap_file_range(
+        &self,
+        ctx: &Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u32,
+    ) -> io::Result<usize> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// send ioctl to the file
     #[allow(clippy::too_many_arguments)]
     fn ioctl(
@@ -1402,5 +1426,41 @@ impl<FS: FileSystem> FileSystem for Arc<FS> {
     #[inline]
     fn id_remap(&self, ctx: &mut Context) -> io::Result<()> {
         self.deref().id_remap(ctx)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn copy_file_range(
+        &self,
+        ctx: &Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u64,
+    ) -> io::Result<usize> {
+        self.deref().copy_file_range(
+            ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn remap_file_range(
+        &self,
+        ctx: &Context,
+        inode_in: Self::Inode,
+        handle_in: Self::Handle,
+        offset_in: u64,
+        inode_out: Self::Inode,
+        handle_out: Self::Handle,
+        offset_out: u64,
+        len: u64,
+        flags: u32,
+    ) -> io::Result<usize> {
+        self.deref().remap_file_range(
+            ctx, inode_in, handle_in, offset_in, inode_out, handle_out, offset_out, len, flags,
+        )
     }
 }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -1193,11 +1193,15 @@ impl<F: FileSystem + Sync> Server<F> {
         let LseekIn {
             fh, offset, whence, ..
         } = ctx.r.read_obj().map_err(Error::DecodeMessage)?;
+        let offset_signed = offset as i64;
 
-        match self
-            .fs
-            .lseek(ctx.context(), ctx.nodeid(), fh.into(), offset, whence)
-        {
+        match self.fs.lseek_signed(
+            ctx.context(),
+            ctx.nodeid(),
+            fh.into(),
+            offset_signed,
+            whence,
+        ) {
             Ok(offset) => {
                 let out = LseekOut { offset };
 

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -1015,7 +1015,10 @@ impl ScopedCreds {
         let original_fsgid = unsafe { libc::setfsgid(gid) } as libc::gid_t;
         // Verify the change took effect
         let verify_gid = unsafe { libc::setfsgid(gid) } as libc::gid_t;
-        debug!("set_creds: setfsgid({}) returned original={} verify={}", gid, original_fsgid, verify_gid);
+        debug!(
+            "set_creds: setfsgid({}) returned original={} verify={}",
+            gid, original_fsgid, verify_gid
+        );
         if verify_gid != gid {
             // Restore groups and return error
             if !original_groups.is_empty() {
@@ -1032,7 +1035,10 @@ impl ScopedCreds {
         let original_fsuid = unsafe { libc::setfsuid(uid) } as libc::uid_t;
         // Verify the change took effect
         let verify_uid = unsafe { libc::setfsuid(uid) } as libc::uid_t;
-        debug!("set_creds: setfsuid({}) returned original={} verify={}", uid, original_fsuid, verify_uid);
+        debug!(
+            "set_creds: setfsuid({}) returned original={} verify={}",
+            uid, original_fsuid, verify_uid
+        );
         if verify_uid != uid {
             // Restore all and return error
             if !original_groups.is_empty() {
@@ -1046,7 +1052,10 @@ impl ScopedCreds {
             ));
         }
 
-        debug!("set_creds: success, original_fsuid={} original_fsgid={}", original_fsuid, original_fsgid);
+        debug!(
+            "set_creds: success, original_fsuid={} original_fsgid={}",
+            original_fsuid, original_fsgid
+        );
         Ok(Some(ScopedCreds {
             original_fsuid,
             original_fsgid,
@@ -1097,8 +1106,8 @@ impl Drop for CapFsetid {
 fn drop_cap_fsetid() -> io::Result<Option<CapFsetid>> {
     // Use unwrap_or(false) instead of propagating error - if we can't check
     // capabilities, assume we don't have them and continue without error
-    let has_cap = caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_FSETID)
-        .unwrap_or(false);
+    let has_cap =
+        caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_FSETID).unwrap_or(false);
     if !has_cap {
         return Ok(None);
     }

--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -986,6 +986,29 @@ impl ScopedCreds {
             return Ok(None);
         }
 
+        // Capability gate (rootless support, #683): the per-request fs-credential switch
+        // below uses setfsuid/setfsgid, which only take effect with CAP_SETUID/CAP_SETGID.
+        // When fcvm runs ROOTLESS the volume server is the unprivileged user (no caps), so
+        // setfsuid is a silent no-op and the verify-and-hard-fail below returns
+        // PermissionDenied — which the fuse-pipe server maps to EIO, breaking non-root reads
+        // of --map'd volumes (e.g. nginx's worker → HTTP 500). Skip the switch when we lack
+        // the caps: the op then runs as the server's own uid (which owns the mapped files),
+        // and the guest FUSE mount uses DefaultPermissions so the guest kernel already
+        // enforces the real POSIX DAC against the forwarded uid/gid before the request
+        // reaches us. Privileged paths (root / bridged / pjdfstest run the server as root)
+        // keep the caps, so the switch and full POSIX enforcement are unchanged there.
+        let can_setid = caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_SETUID)
+            .unwrap_or(false)
+            && caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_SETGID)
+                .unwrap_or(false);
+        if !can_setid {
+            debug!(
+                "set_creds: lacking CAP_SETUID/CAP_SETGID (rootless), skipping fs-cred \
+                 switch; op runs as server uid"
+            );
+            return Ok(None);
+        }
+
         // Get current groups before we change anything
         let original_groups = get_current_groups().unwrap_or_default();
         debug!("set_creds: original_groups={:?}", original_groups);

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -1510,8 +1510,8 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
         // FICLONE = _IOW('9', 1, int) = 0x40049409
         // FICLONERANGE = _IOW('9', 13, struct file_clone_range) = 0x4020940d
-        const FICLONE: libc::c_ulong = 0x40049409;
-        const FICLONERANGE: libc::c_ulong = 0x4020940d;
+        const FICLONE: libc::Ioctl = 0x40049409;
+        const FICLONERANGE: libc::Ioctl = 0x4020940d;
 
         // struct file_clone_range from <linux/fs.h>
         #[repr(C)]

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -803,6 +803,10 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             // Safe because this is a constant value and a valid C string.
             let empty = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
 
+            // Switch to caller's credentials for permission check
+            // (only root can change owner, owner can change group)
+            let _creds = set_creds(ctx.uid, ctx.gid)?;
+
             // Safe because this doesn't modify any memory and we check the return value.
             let res = unsafe {
                 libc::fchownat(

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -430,6 +430,8 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let data = self.inode_map.get(parent)?;
 
         let file = data.get_file()?;
+        // Switch to caller's credentials so the directory is owned by them
+        let _creds = set_creds(ctx.uid, ctx.gid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe { libc::mkdirat(file.as_raw_fd(), name.as_ptr(), mode & !umask) };
         if res < 0 {
@@ -558,6 +560,8 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let dir_file = dir.get_file()?;
 
         let flags = self.get_writeback_open_flags(args.flags as i32);
+        // Switch to caller's credentials so the file is owned by them
+        let _creds = set_creds(ctx.uid, ctx.gid)?;
         let new_file =
             Self::create_file_excl(&dir_file, name, flags, args.mode & !(args.umask & 0o777))?;
 
@@ -922,6 +926,8 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let data = self.inode_map.get(parent)?;
         let file = data.get_file()?;
 
+        // Switch to caller's credentials so the node is owned by them
+        let _creds = set_creds(ctx.uid, ctx.gid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe {
             libc::mknodat(
@@ -984,6 +990,8 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let data = self.inode_map.get(parent)?;
         let file = data.get_file()?;
 
+        // Switch to caller's credentials so the symlink is owned by them
+        let _creds = set_creds(ctx.uid, ctx.gid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe { libc::symlinkat(linkname.as_ptr(), file.as_raw_fd(), name.as_ptr()) };
         if res == 0 {

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -371,7 +371,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             return Err(einval());
         }
         // Switch to caller's credentials for directory search permission check
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         self.do_lookup(parent, name)
     }
 
@@ -400,7 +400,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             Err(enosys())
         } else {
             // Switch to caller's credentials for permission check
-            let _creds = set_creds(ctx.uid, ctx.gid)?;
+            let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
             self.do_open(inode, flags | (libc::O_DIRECTORY as u32), 0)
                 .map(|(a, b, _)| (a, b))
         }
@@ -435,7 +435,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
         let file = data.get_file()?;
         // Switch to caller's credentials so the directory is owned by them
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe { libc::mkdirat(file.as_raw_fd(), name.as_ptr(), mode & !umask) };
         if res < 0 {
@@ -448,7 +448,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
     fn rmdir(&self, ctx: &Context, parent: Inode, name: &CStr) -> io::Result<()> {
         self.validate_path_component(name)?;
         // Switch to caller's credentials for permission check
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         self.do_unlink(parent, name, libc::AT_REMOVEDIR)
     }
 
@@ -533,7 +533,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             Err(enosys())
         } else {
             // Switch to caller's credentials for permission check
-            let _creds = set_creds(ctx.uid, ctx.gid)?;
+            let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
             self.do_open(inode, flags, fuse_flags)
         }
     }
@@ -569,7 +569,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
         let flags = self.get_writeback_open_flags(args.flags as i32);
         // Switch to caller's credentials so the file is owned by them
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         let new_file =
             Self::create_file_excl(&dir_file, name, flags, args.mode & !(args.umask & 0o777))?;
 
@@ -617,7 +617,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
     fn unlink(&self, ctx: &Context, parent: Inode, name: &CStr) -> io::Result<()> {
         self.validate_path_component(name)?;
         // Switch to caller's credentials for permission check
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         self.do_unlink(parent, name, 0)
     }
 
@@ -700,7 +700,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         debug!("write: inode={} handle={} size={} uid={} gid={}", inode, handle, size, ctx.uid, ctx.gid);
         // Switch to caller's credentials for the write operation.
         // This is needed for proper SUID/SGID bit handling when a non-owner writes.
-        let _creds = match set_creds(ctx.uid, ctx.gid) {
+        let _creds = match set_creds(ctx.uid, ctx.gid, ctx.pid) {
             Ok(c) => {
                 debug!("write: set_creds succeeded");
                 c
@@ -823,7 +823,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             } else {
                 // User-initiated chmod - switch to caller's credentials for permission check
                 // (only file owner or root can chmod)
-                Some(set_creds(ctx.uid, ctx.gid)?)
+                Some(set_creds(ctx.uid, ctx.gid, ctx.pid)?)
             };
 
             // Safe because this doesn't modify any memory and we check the return value.
@@ -859,7 +859,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
             // Switch to caller's credentials for permission check
             // (only root can change owner, owner can change group)
-            let _creds = set_creds(ctx.uid, ctx.gid)?;
+            let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
 
             // Safe because this doesn't modify any memory and we check the return value.
             let res = unsafe {
@@ -898,7 +898,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
                 _ => {
                     // No file handle - need to open the file, which requires permission check.
                     // Switch to caller's credentials for this case.
-                    let _creds = set_creds(ctx.uid, ctx.gid)?;
+                    let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
                     // There is no `ftruncateat` so we need to get a new fd and truncate it.
                     let f = self.open_inode(inode, libc::O_NONBLOCK | libc::O_RDWR)?;
                     unsafe { libc::ftruncate(f.as_raw_fd(), attr.st_size) }
@@ -937,7 +937,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
             // Switch to caller's credentials for permission check
             // (utimensat requires write permission or ownership)
-            let _creds = set_creds(ctx.uid, ctx.gid)?;
+            let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
 
             // Safe because this doesn't modify any memory and we check the return value.
             let res = match data {
@@ -974,7 +974,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let new_file = new_inode.get_file()?;
 
         // Switch to caller's credentials for permission check
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
 
         // Safe because this doesn't modify any memory and we check the return value.
         // TODO: Switch to libc::renameat2 once https://github.com/rust-lang/libc/pull/1508 lands
@@ -1011,7 +1011,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let file = data.get_file()?;
 
         // Switch to caller's credentials so the node is owned by them
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe {
             libc::mknodat(
@@ -1081,7 +1081,7 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         let file = data.get_file()?;
 
         // Switch to caller's credentials so the symlink is owned by them
-        let _creds = set_creds(ctx.uid, ctx.gid)?;
+        let _creds = set_creds(ctx.uid, ctx.gid, ctx.pid)?;
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe { libc::symlinkat(linkname.as_ptr(), file.as_raw_fd(), name.as_ptr()) };
         if res == 0 {

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -768,6 +768,10 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         }
 
         if valid.contains(SetattrValid::MODE) {
+            // Switch to caller's credentials for permission check
+            // (only file owner or root can chmod)
+            let _creds = set_creds(ctx.uid, ctx.gid)?;
+
             // Safe because this doesn't modify any memory and we check the return value.
             let res = unsafe {
                 match data {


### PR DESCRIPTION
## Summary

This PR adds supplementary groups support and fixes several POSIX permission issues in the passthrough filesystem. These changes enable passing all 8789 pjdfstest POSIX compliance tests.

## Use Case

These changes are used in [fuse-pipe](https://github.com/ejc3/firepod/tree/main/fuse-pipe), a high-performance FUSE client/server that forwards filesystem operations over Unix sockets or vsock. fuse-pipe uses fuse-backend-rs's passthrough filesystem to serve files to Firecracker microVMs.

The supplementary groups support is essential because fuse-pipe forwards FUSE requests from a guest VM over vsock - the server cannot read `/proc/<pid>/status` since the PID exists in the guest, not the host. Groups must be forwarded through the wire protocol.

## Changes

### Supplementary Groups Support
- Add `supplementary_groups` field to `Context` struct for remote filesystems
- Implement `ScopedCreds` that uses raw `SYS_setgroups`/`SYS_getgroups` syscalls (per-thread, not NPTL broadcast)
- Support forwarding groups via wire protocol for remote FUSE (e.g., over vsock)

### Permission Fixes
- Add `set_creds()` calls to operations requiring permission checks: lookup, chmod, chown, truncate, utimes, rmdir, unlink, rename, open, opendir
- Fix link operation to not switch credentials (requires `CAP_DAC_READ_SEARCH`)
- Fix ftruncate to skip permission re-check when file handle is provided
- Fix SUID/SGID clearing on write by non-owner

### Other
- Replace `setresuid`/`setresgid` with `setfsuid`/`setfsgid` for credential switching (preserves `/proc/self/fd/` access)
- Add signed lseek hook for backward-compatible negative offsets
- Format debug logging statements

## Testing

All 8789 pjdfstest POSIX compliance tests pass with these changes. CI runs the full test suite: https://github.com/ejc3/firepod/actions

## Breaking Changes

- `Context` struct changed from `Copy` to `Clone` (due to `Vec<u32>` for groups)