### PR TITLE
Reduce FUSE transport log level.

### DIFF
--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -18,7 +18,7 @@ use crate::api::filesystem::{
     AsyncFileSystem, AsyncZeroCopyReader, AsyncZeroCopyWriter, ZeroCopyReader, ZeroCopyWriter,
 };
 use crate::api::server::{
-    MetricsHook, Server, ServerUtil, SrvContext, BUFFER_HEADER_SIZE, MAX_BUFFER_SIZE,
+    InitParams, MetricsHook, Server, ServerUtil, SrvContext, BUFFER_HEADER_SIZE, MAX_BUFFER_SIZE,
 };
 use crate::file_traits::{AsyncFileReadWriteVolatile, FileReadWriteVolatile};
 use crate::transport::{FsCacheReqHandler, Reader, Writer};
@@ -169,7 +169,11 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
             x if x == Opcode::Listxattr as u32 => self.listxattr(ctx),
             x if x == Opcode::Removexattr as u32 => self.removexattr(ctx),
             x if x == Opcode::Flush as u32 => self.flush(ctx),
-            x if x == Opcode::Init as u32 => self.init(ctx),
+            x if x == Opcode::Init as u32 => self.init(ctx, |init_params: &InitParams| {
+                if let Some(h) = hook {
+                    h.on_init_params(init_params);
+                }
+            }),
             x if x == Opcode::Opendir as u32 => self.opendir(ctx),
             x if x == Opcode::Readdir as u32 => self.readdir(ctx),
             x if x == Opcode::Releasedir as u32 => self.releasedir(ctx),

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -112,10 +112,13 @@ impl<S: BitmapSlice> io::Write for ZcWriter<'_, S> {
     }
 }
 
-#[allow(dead_code)]
-struct ServerVersion {
-    major: u32,
-    minor: u32,
+/// The major and minor version number of the FUSE ABI
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerVersion {
+    /// The major version number of the FUSE ABI
+    pub major: u32,
+    /// The minor version number of the FUSE ABI
+    pub minor: u32,
 }
 
 struct ServerUtil();
@@ -158,10 +161,23 @@ impl ServerUtil {
     }
 }
 
+/// Holds information of the handshake that happened between kernel and
+/// userspace.
+pub struct InitParams {
+    /// Version of the FUSE ABI
+    pub version: ServerVersion,
+    /// Indicates the features supported by the kernel module
+    pub capable: FsOptions,
+    /// Indicates the features that we requested
+    pub want: FsOptions,
+}
+
 /// Provide concrete backend filesystem a way to catch information/metrics from fuse.
 pub trait MetricsHook {
     /// `collect()` will be invoked before the real request is processed
     fn collect(&self, ih: &InHeader);
+    /// `on_init_params()` will be called with some agreed connection parameters
+    fn on_init_params(&self, _init_params: &InitParams) {}
     /// `release()` will be invoked after the real request is processed
     fn release(&self, oh: Option<&OutHeader>);
 }

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -746,7 +746,7 @@ impl<F: FileSystem + Sync> Server<F> {
         match self.fs.init(capable) {
             Ok(want) => {
                 let enabled = capable & want;
-                info!(
+                debug!(
                     "FUSE INIT major {} minor {}\n in_opts: {:?}\nout_opts: {:?}",
                     major, minor, capable, enabled
                 );

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use vm_memory::ByteValued;
 
 use super::{
-    MetricsHook, Server, ServerUtil, ServerVersion, SrvContext, ZcReader, ZcWriter,
+    InitParams, MetricsHook, Server, ServerUtil, ServerVersion, SrvContext, ZcReader, ZcWriter,
     BUFFER_HEADER_SIZE, DIRENT_PADDING, MAX_BUFFER_SIZE, MAX_REQ_PAGES, MIN_READ_BUFFER,
 };
 use crate::abi::fuse_abi::*;
@@ -172,7 +172,11 @@ impl<F: FileSystem + Sync> Server<F> {
             x if x == Opcode::Listxattr as u32 => self.listxattr(ctx),
             x if x == Opcode::Removexattr as u32 => self.removexattr(ctx),
             x if x == Opcode::Flush as u32 => self.flush(ctx),
-            x if x == Opcode::Init as u32 => self.init(ctx),
+            x if x == Opcode::Init as u32 => self.init(ctx, |init_params: &InitParams| {
+                if let Some(h) = hook {
+                    h.on_init_params(init_params);
+                }
+            }),
             x if x == Opcode::Opendir as u32 => self.opendir(ctx),
             x if x == Opcode::Readdir as u32 => self.readdir(ctx),
             x if x == Opcode::Releasedir as u32 => self.releasedir(ctx),
@@ -708,7 +712,11 @@ impl<F: FileSystem + Sync> Server<F> {
         }
     }
 
-    pub(super) fn init<S: BitmapSlice>(&self, mut ctx: SrvContext<'_, F, S>) -> Result<usize> {
+    pub(super) fn init<S: BitmapSlice>(
+        &self,
+        mut ctx: SrvContext<'_, F, S>,
+        mut on_init_params: impl FnMut(&InitParams),
+    ) -> Result<usize> {
         let InitIn {
             major,
             minor,
@@ -745,11 +753,12 @@ impl<F: FileSystem + Sync> Server<F> {
 
         match self.fs.init(capable) {
             Ok(want) => {
-                let enabled = capable & want;
-                debug!(
-                    "FUSE INIT major {} minor {}\n in_opts: {:?}\nout_opts: {:?}",
-                    major, minor, capable, enabled
-                );
+                let version = ServerVersion { major, minor };
+                on_init_params(&InitParams {
+                    version: version.clone(),
+                    capable,
+                    want,
+                });
 
                 let readahead = if cfg!(target_os = "macos") {
                     0
@@ -757,6 +766,7 @@ impl<F: FileSystem + Sync> Server<F> {
                     max_readahead
                 };
 
+                let enabled = capable & want;
                 let enabled_flags = enabled.bits();
                 let mut out = InitOut {
                     major: KERNEL_VERSION,
@@ -778,8 +788,7 @@ impl<F: FileSystem + Sync> Server<F> {
                     out.max_pages = MAX_REQ_PAGES;
                     out.max_write = MAX_REQ_PAGES as u32 * pagesize() as u32; // 1MB
                 }
-                let vers = ServerVersion { major, minor };
-                self.vers.store(Arc::new(vers));
+                self.vers.store(Arc::new(version));
                 if minor < KERNEL_MINOR_VERSION_INIT_OUT_SIZE {
                     ctx.reply_ok(
                         Some(
@@ -1472,7 +1481,9 @@ mod tests {
             let mut write_buf = [0u8; 4096];
             let (ctx, _file) = prepare_srvcontext(&mut read_buf, &mut write_buf);
 
-            let res = server.init(ctx).unwrap();
+            let res = server
+                .init(ctx, |_| unreachable!("shouldn't be called"))
+                .unwrap();
             assert_eq!(res, 80);
 
             let mut read_buf1 = [
@@ -1484,7 +1495,16 @@ mod tests {
             let mut write_buf1 = [0u8; 4096];
             let (ctx1, _file) = prepare_srvcontext(&mut read_buf1, &mut write_buf1);
 
-            let res = server.init(ctx1).unwrap();
+            let mut init_params_called = false;
+            let res = server
+                .init(ctx1, |init_params| {
+                    assert_eq!(init_params.version.major, 0x0007);
+                    assert_eq!(init_params.version.minor, 0x0000);
+                    init_params_called = true
+                })
+                .unwrap();
+            assert!(init_params_called);
+
             assert_eq!(res, 24);
         }
 

--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -285,7 +285,7 @@ impl FuseChannel {
                         return Err(IoError(e.into()));
                     }
                     Errno::ENODEV => {
-                        info!("fuse filesystem umounted");
+                        debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                         return Ok(());
                     }
                     e => {

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -358,7 +358,7 @@ impl FuseChannel {
             // Handle wake up event first. We don't read the event fd so that a LEVEL triggered
             // event can still be delivered to other threads/daemons.
             if need_exit {
-                info!("Will exit from fuse service");
+                debug!("Will exit from fuse service");
                 return Ok(None);
             }
             if fusereq_available {
@@ -395,7 +395,7 @@ impl FuseChannel {
                             continue;
                         }
                         Errno::ENODEV => {
-                            info!("fuse filesystem umounted");
+                            debug!("got ENODEV when reading fuse fd, assuming fuse filesystem was umounted.");
                             return Ok(None);
                         }
                         e => {
@@ -460,7 +460,7 @@ fn fuse_kern_mount(
     }
 
     if let Some(mountpoint) = mountpoint.to_str() {
-        info!(
+        debug!(
             "mount source {} dest {} with fstype {} opts {} fd {}",
             fsname,
             mountpoint,


### PR DESCRIPTION
The FUSE init flags are unlikely to be of use unless one is debugging a problem with the filesystem.

The messages about channel status get printed for every thread, and it's rather confusing for end-users to have a FUSE filesystem terminate with:

fuse filesystem umounted
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!
FUSE channel already closed!

...when everything went well.

NOTE: This is a rebase of #200 