### PR TITLE
fusedev: fix wrong feature name and port FuseDevTask to current async…

### DIFF
--- a/src/common/async_file.rs
+++ b/src/common/async_file.rs
@@ -48,6 +48,18 @@ impl File {
         }
     }
 
+    /// Wrap an existing `std::fs::File` object into an asynchronous `File` object.
+    ///
+    /// The returned object takes ownership of `file` and closes the underlying file
+    /// descriptor when dropped.
+    pub fn from_std_file(file: std::fs::File) -> Self {
+        match *RUNTIME_TYPE {
+            RuntimeType::Tokio => File::Tokio(tokio::fs::File::from_std(file)),
+            #[cfg(target_os = "linux")]
+            RuntimeType::Uring => File::Uring(tokio_uring::fs::File::from_std(file)),
+        }
+    }
+
     /// Asynchronously read data at `offset` into the buffer.
     pub async fn async_read_at(
         &self,
@@ -248,6 +260,27 @@ mod tests {
         let file = block_on(async { File::async_open(&path, false, false).await.unwrap() });
         assert!(file.as_raw_fd() >= 0);
         drop(file);
+    }
+
+    #[test]
+    fn test_from_std_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().to_path_buf().join("test.txt");
+        std::fs::write(&path, b"test").unwrap();
+
+        let file = File::from_std_file(std::fs::File::open(&path).unwrap());
+        assert!(file.as_raw_fd() >= 0);
+        let md = file.metadata().unwrap();
+        assert!(md.is_file());
+
+        block_on(async {
+            let mut buffer = [0u8; 4];
+            let buf = unsafe { FileVolatileBuf::new(&mut buffer) };
+            let (res, buf) = file.async_read_at(buf, 0).await;
+            assert_eq!(res.unwrap(), 4);
+            assert_eq!(buf.len(), 4);
+            assert_eq!(&buffer, b"test");
+        });
     }
 
     #[test]

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -710,40 +710,44 @@ mod tests {
     }
 }
 
-#[cfg(feature = "async_io")]
+#[cfg(feature = "async-io")]
 pub use asyncio::FuseDevTask;
 
-#[cfg(feature = "async_io")]
+#[cfg(feature = "async-io")]
 /// Task context to handle fuse request in asynchronous mode.
 mod asyncio {
-    use std::os::unix::io::RawFd;
+    use std::os::unix::io::AsRawFd;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
     use crate::api::filesystem::AsyncFileSystem;
     use crate::api::server::Server;
-    use crate::transport::{FuseBuf, Reader, Writer};
+    use crate::async_file::File as AsyncFile;
+    use crate::file_buf::FileVolatileBuf;
+    use crate::transport::{FuseBuf, FuseDevWriter, Reader};
 
     /// Task context to handle fuse request in asynchronous mode.
     ///
     /// This structure provides a context to handle fuse request in asynchronous mode, including
-    /// the fuse fd, a internal buffer and a `Server` instance to serve requests.
+    /// the fuse device file, a internal buffer and a `Server` instance to serve requests.
     ///
     /// ## Examples
     /// ```ignore
     /// let buf_size = 0x1_0000;
-    /// let state = AsyncExecutorState::new();
-    /// let mut task = FuseDevTask::new(buf_size, fuse_dev_fd, fs_server, state.clone());
+    /// let file = session.clone_fuse_file().unwrap();
+    /// let state = Arc::new(AtomicBool::new(false));
+    /// let mut task = FuseDevTask::new(buf_size, file, fs_server, state.clone());
     ///
     /// // Run the task
     /// executor.spawn(async move { task.poll_handler().await });
     ///
     /// // Stop the task
-    /// state.quiesce();
+    /// state.store(true, Ordering::Relaxed);
     /// ```
     pub struct FuseDevTask<F: AsyncFileSystem + Sync> {
-        fd: RawFd,
+        file: AsyncFile,
         buf: Vec<u8>,
-        state: AsyncExecutorState,
+        state: Arc<AtomicBool>,
         server: Arc<Server<F>>,
     }
 
@@ -752,20 +756,19 @@ mod asyncio {
         ///
         /// # Parameters
         /// - buf_size: size of buffer to receive requests from/send reply to the fuse fd
-        /// - fd: fuse device file descriptor
+        /// - file: file object for the fuse device, ownership is taken by the task object
         /// - server: `Server` instance to serve requests from the fuse fd
-        /// - state: shared state object to control the task object
-        ///
-        /// # Safety
-        /// The caller must ensure `fd` is valid during the lifetime of the returned task object.
+        /// - state: shared flag to control the task object. The task stops picking up
+        ///   new requests once it's set to `true`; a request being processed is
+        ///   completed first.
         pub fn new(
             buf_size: usize,
-            fd: RawFd,
+            file: std::fs::File,
             server: Arc<Server<F>>,
-            state: AsyncExecutorState,
+            state: Arc<AtomicBool>,
         ) -> Self {
             FuseDevTask {
-                fd,
+                file: AsyncFile::from_std_file(file),
                 server,
                 state,
                 buf: vec![0x0u8; buf_size],
@@ -776,18 +779,25 @@ mod asyncio {
         ///
         /// An async fn to handle requests from the fuse fd. It works in asynchronous IO mode when:
         /// - receiving request from fuse fd
-        /// - handling requests by calling Server::async_handle_requests()
+        /// - handling requests by calling Server::async_handle_message()
         /// - sending reply to fuse fd
         ///
         /// The async fn repeatedly return Poll::Pending when polled until the state has been set
-        /// to quiesce mode.
+        /// to quiesce mode, or the fuse session has been torn down (EOF/`ENODEV` from the
+        /// fuse device).
         pub async fn poll_handler(&mut self) {
             // TODO: register self.buf as io uring buffers.
-            let drive = AsyncDriver::default();
+            let fd = self.file.as_raw_fd();
 
-            while !self.state.quiescing() {
-                let result = AsyncUtil::read(drive.clone(), self.fd, &mut self.buf, 0).await;
+            while !self.state.load(Ordering::Acquire) {
+                // Safe because `vbuf` doesn't out-live `self.buf`.
+                let vbuf = unsafe { FileVolatileBuf::new(&mut self.buf) };
+                let (result, _vbuf) = self.file.async_read_at(vbuf, 0).await;
                 match result {
+                    Ok(0) => {
+                        // EOF, the fuse session has been torn down.
+                        break;
+                    }
                     Ok(len) => {
                         // ###############################################
                         // Note: it's a heavy hack to reuse the same underlying data
@@ -798,13 +808,15 @@ mod asyncio {
                         let buf = unsafe {
                             std::slice::from_raw_parts_mut(self.buf.as_mut_ptr(), self.buf.len())
                         };
-                        // Reader::new() and Writer::new() should always return success.
+                        // Reader::from_fuse_buffer() and FuseDevWriter::new() should always
+                        // return success.
                         let reader =
-                            Reader::<()>::new(FuseBuf::new(&mut self.buf[0..len])).unwrap();
-                        let writer = Writer::new(self.fd, buf).unwrap();
+                            Reader::<()>::from_fuse_buffer(FuseBuf::new(&mut self.buf[0..len]))
+                                .unwrap();
+                        let writer = FuseDevWriter::<()>::new(fd, buf).unwrap();
                         let result = unsafe {
                             self.server
-                                .async_handle_message(drive.clone(), reader, writer, None, None)
+                                .async_handle_message(reader, writer.into(), None, None)
                                 .await
                         };
 
@@ -814,6 +826,10 @@ mod asyncio {
                         }
                     }
                     Err(e) => {
+                        if e.raw_os_error() == Some(libc::ENODEV) {
+                            // The fuse device was unmounted.
+                            break;
+                        }
                         // TODO: error handling
                         error!("failed to read request from fuse device fd, {}", e);
                     }
@@ -821,20 +837,27 @@ mod asyncio {
             }
 
             // TODO: unregister self.buf as io uring buffers.
-
-            // Report that the task has been quiesced.
-            self.state.report();
         }
     }
 
-    impl<F: AsyncFileSystem + Sync> Clone for FuseDevTask<F> {
-        fn clone(&self) -> Self {
-            FuseDevTask {
-                fd: self.fd,
-                server: self.server.clone(),
-                state: self.state.clone(),
-                buf: vec![0x0u8; self.buf.capacity()],
-            }
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::async_runtime;
+        use crate::passthrough::{Config, PassthroughFs};
+        use vmm_sys_util::tempfile::TempFile;
+
+        #[test]
+        fn test_fuse_dev_task_quiesce() {
+            let fs = PassthroughFs::<()>::new(Config::default()).unwrap();
+            let server = Arc::new(Server::new(fs));
+            let file = TempFile::new().unwrap().into_file();
+            // Quiesce the task before polling it, so poll_handler() returns
+            // right away without touching the device.
+            let state = Arc::new(AtomicBool::new(true));
+            let mut task = FuseDevTask::new(0x1000, file, server, state);
+
+            async_runtime::block_on(task.poll_handler());
         }
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -41,6 +41,8 @@ mod fusedev;
 mod virtiofs;
 
 pub use self::fs_cache_req_handler::FsCacheReqHandler;
+#[cfg(all(target_os = "linux", feature = "fusedev", feature = "async-io"))]
+pub use self::fusedev::FuseDevTask;
 #[cfg(feature = "fusedev")]
 pub use self::fusedev::{FuseBuf, FuseChannel, FuseDevWriter, FuseSession, FuseSessionExt};
 #[cfg(feature = "virtiofs")]


### PR DESCRIPTION
… API

The async io support in linux_session.rs is gated on feature "async_io", but the Cargo feature is named "async-io", so the cfg never matched and FuseDevTask was silently left out of every build since it was introduced.

Fix the feature name and port FuseDevTask to the current async io framework, which moved from the vhost-user-backend executor to the tokio/tokio-uring runtime in the meantime:
- take ownership of the fuse device file instead of a raw fd, and read requests through crate::async_file::File (add File::from_std_file());
- replace the removed AsyncExecutorState quiesce state with a shared AtomicBool flag;
- build Reader/FuseDevWriter with from_fuse_buffer()/new() and invoke Server::async_handle_message() with its current signature;
- re-export FuseDevTask from the transport module, and drop the Clone impl which relied on sharing the raw fd.

Fixes: #108
Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>

Also add unit test cases for the async io parts touched:
- test_from_std_file() verifies File::from_std_file() with an async read;
- test_fuse_dev_task_quiesce() constructs a FuseDevTask around a Server and checks poll_handler() exits cleanly when quiesced before polling.