### PR TITLE
Async/ptfs sync delegation

### DIFF
--- a/src/api/vfs/async_io.rs
+++ b/src/api/vfs/async_io.rs
@@ -213,8 +213,11 @@ mod tests {
     use super::super::tests::FakeFileSystemOne;
     use super::*;
     use crate::api::Vfs;
+    use crate::file_buf::FileVolatileSlice;
+    use crate::file_traits::{AsyncFileReadWriteVolatile, FileReadWriteVolatile};
 
     use std::ffi::CString;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_vfs_async_lookup() {
@@ -258,5 +261,125 @@ mod tests {
             assert_eq!(entry3.inode, 0);
         });
         handle.await.unwrap();
+    }
+
+    /// An in-memory sink implementing `AsyncZeroCopyWriter`, to receive data
+    /// from `async_read()`.
+    struct MemWriter(Vec<u8>);
+
+    impl io::Write for MemWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl ZeroCopyWriter for MemWriter {
+        fn write_from(
+            &mut self,
+            f: &mut dyn FileReadWriteVolatile,
+            count: usize,
+            off: u64,
+        ) -> io::Result<usize> {
+            if self.0.len() < count {
+                self.0.resize(count, 0);
+            }
+            // Safe because the slice points into `self.0` and doesn't out-live it.
+            // The file offset only selects the read position within `f`; received
+            // data is always placed at the start of the buffer.
+            let slice = unsafe { FileVolatileSlice::from_raw_ptr(self.0.as_mut_ptr(), count) };
+            f.read_at_volatile(slice, off)
+        }
+
+        fn available_bytes(&self) -> usize {
+            usize::MAX
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl AsyncZeroCopyWriter for MemWriter {
+        async fn async_write_from(
+            &mut self,
+            _f: Arc<dyn AsyncFileReadWriteVolatile>,
+            _count: usize,
+            _off: u64,
+        ) -> io::Result<usize> {
+            unreachable!("the synchronous delegation never uses the async zero-copy path")
+        }
+    }
+
+    // Integration test: drive async requests through the Vfs layer down to a
+    // real `PassthroughFs` instance, covering inode remapping on the way.
+    #[tokio::test]
+    async fn test_vfs_async_passthrough() {
+        use crate::passthrough::{Config, PassthroughFs};
+
+        let source = vmm_sys_util::tempdir::TempDir::new().unwrap();
+        std::fs::write(source.as_path().join("testfile"), b"hello vfs").unwrap();
+
+        let cfg = Config {
+            root_dir: source.as_path().to_str().unwrap().to_string(),
+            do_import: true,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(cfg).unwrap();
+        fs.import().unwrap();
+        fs.init(FsOptions::all()).unwrap();
+
+        // Disable zero-message open/opendir so that `async_open()` and
+        // `async_read()` are actually exercised through the Vfs layer.
+        let vfs = Vfs::new(VfsOptions {
+            no_open: false,
+            no_opendir: false,
+            ..Default::default()
+        });
+        vfs.mount(Box::new(fs), "/").unwrap();
+
+        let ctx = Context {
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            pid: unsafe { libc::getpid() },
+        };
+
+        // Lookup the file through the Vfs layer.
+        let name = CString::new("testfile").unwrap();
+        let entry = vfs
+            .async_lookup(&ctx, ROOT_ID.into(), name.as_c_str())
+            .await
+            .unwrap();
+        assert_ne!(entry.inode, 0);
+
+        let (attr, _) = vfs
+            .async_getattr(&ctx, entry.inode.into(), None)
+            .await
+            .unwrap();
+        assert_eq!(attr.st_size, 9);
+
+        // Open and read the file back through the Vfs layer.
+        let (handle, _opts) = vfs
+            .async_open(&ctx, entry.inode.into(), libc::O_RDONLY as u32, 0)
+            .await
+            .unwrap();
+        let handle = handle.unwrap();
+        let mut w = MemWriter(Vec::new());
+        let n = vfs
+            .async_read(
+                &ctx,
+                entry.inode.into(),
+                handle,
+                &mut w,
+                9,
+                0,
+                None,
+                libc::O_RDONLY as u32,
+            )
+            .await
+            .unwrap();
+        assert_eq!(n, 9);
+        assert_eq!(&w.0, b"hello vfs");
     }
 }

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -158,3 +158,293 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         self.fsyncdir(ctx, inode, datasync, handle)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::abi::fuse_abi::ROOT_ID;
+    use crate::api::filesystem::{FsOptions, ZeroCopyReader, ZeroCopyWriter};
+    use crate::async_runtime;
+    use crate::file_buf::FileVolatileSlice;
+    use crate::file_traits::{AsyncFileReadWriteVolatile, FileReadWriteVolatile};
+    use vmm_sys_util::tempdir::TempDir;
+
+    /// An in-memory sink implementing `AsyncZeroCopyWriter`, to receive data
+    /// from `async_read()`.
+    struct MemWriter(Vec<u8>);
+
+    impl MemWriter {
+        fn new() -> Self {
+            MemWriter(Vec::new())
+        }
+    }
+
+    impl io::Write for MemWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl ZeroCopyWriter for MemWriter {
+        fn write_from(
+            &mut self,
+            f: &mut dyn FileReadWriteVolatile,
+            count: usize,
+            off: u64,
+        ) -> io::Result<usize> {
+            if self.0.len() < count {
+                self.0.resize(count, 0);
+            }
+            // Safe because the slice points into `self.0` and doesn't out-live it.
+            // The file offset only selects the read position within `f`; received
+            // data is always placed at the start of the buffer.
+            let slice = unsafe { FileVolatileSlice::from_raw_ptr(self.0.as_mut_ptr(), count) };
+            f.read_at_volatile(slice, off)
+        }
+
+        fn available_bytes(&self) -> usize {
+            usize::MAX
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl AsyncZeroCopyWriter for MemWriter {
+        async fn async_write_from(
+            &mut self,
+            _f: Arc<dyn AsyncFileReadWriteVolatile>,
+            _count: usize,
+            _off: u64,
+        ) -> io::Result<usize> {
+            unreachable!("the synchronous delegation never uses the async zero-copy path")
+        }
+    }
+
+    /// An in-memory source implementing `AsyncZeroCopyReader`, to provide data
+    /// to `async_write()`.
+    struct MemReader(Vec<u8>);
+
+    impl io::Read for MemReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let n = std::cmp::min(buf.len(), self.0.len());
+            buf[..n].copy_from_slice(&self.0[..n]);
+            self.0.drain(..n);
+            Ok(n)
+        }
+    }
+
+    impl ZeroCopyReader for MemReader {
+        fn read_to(
+            &mut self,
+            f: &mut dyn FileReadWriteVolatile,
+            count: usize,
+            off: u64,
+        ) -> io::Result<usize> {
+            let start = off as usize;
+            if start >= self.0.len() {
+                return Ok(0);
+            }
+            let n = std::cmp::min(count, self.0.len() - start);
+            // Safe because the buffer is only read from and the slice doesn't
+            // out-live `self.0`.
+            let slice = unsafe {
+                FileVolatileSlice::from_raw_ptr(self.0.as_ptr().add(start) as *mut u8, n)
+            };
+            f.write_at_volatile(slice, off)
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl AsyncZeroCopyReader for MemReader {
+        async fn async_read_to(
+            &mut self,
+            _f: Arc<dyn AsyncFileReadWriteVolatile>,
+            _count: usize,
+            _off: u64,
+        ) -> io::Result<usize> {
+            unreachable!("the synchronous delegation never uses the async zero-copy path")
+        }
+    }
+
+    fn prepare_async_fs() -> (PassthroughFs<()>, TempDir) {
+        let source = TempDir::new().expect("Cannot create temporary directory.");
+        let cfg = Config {
+            root_dir: source.as_path().to_str().unwrap().to_string(),
+            do_import: true,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(cfg).unwrap();
+        fs.import().unwrap();
+        fs.init(FsOptions::all()).unwrap();
+
+        (fs, source)
+    }
+
+    fn prepare_context() -> Context {
+        Context {
+            uid: unsafe { libc::getuid() },
+            gid: unsafe { libc::getgid() },
+            pid: unsafe { libc::getpid() },
+        }
+    }
+
+    #[test]
+    fn test_backend_filesystem_mount() {
+        let (fs, _source) = prepare_async_fs();
+
+        let (entry, max_ino) = BackendFileSystem::mount(&fs).unwrap();
+        assert_eq!(entry.inode, ROOT_ID);
+        assert!(max_ino > 0);
+    }
+
+    #[test]
+    fn test_async_lookup_getattr_setattr() {
+        let (fs, source) = prepare_async_fs();
+        let ctx = prepare_context();
+        let path = source.as_path().join("testfile");
+        std::fs::write(&path, b"hello").unwrap();
+        let name = CString::new("testfile").unwrap();
+
+        async_runtime::block_on(async {
+            let entry = fs.async_lookup(&ctx, ROOT_ID, &name).await.unwrap();
+            let sync_entry = fs.lookup(&ctx, ROOT_ID, &name).unwrap();
+            assert_eq!(entry.inode, sync_entry.inode);
+            assert_eq!(entry.attr.st_size, 5);
+
+            let (attr, _) = fs.async_getattr(&ctx, entry.inode, None).await.unwrap();
+            assert_eq!(attr.st_size, 5);
+
+            // Truncate the file to 2 bytes through async_setattr().
+            let mut new_attr = attr;
+            new_attr.st_size = 2;
+            let (attr, _) = fs
+                .async_setattr(&ctx, entry.inode, new_attr, None, SetattrValid::SIZE)
+                .await
+                .unwrap();
+            assert_eq!(attr.st_size, 2);
+        });
+
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_async_open_read() {
+        let (fs, source) = prepare_async_fs();
+        let ctx = prepare_context();
+        std::fs::write(source.as_path().join("testfile"), b"hello world").unwrap();
+        let name = CString::new("testfile").unwrap();
+
+        async_runtime::block_on(async {
+            let entry = fs.async_lookup(&ctx, ROOT_ID, &name).await.unwrap();
+            let (handle, _opts) = fs
+                .async_open(&ctx, entry.inode, libc::O_RDONLY as u32, 0)
+                .await
+                .unwrap();
+            let handle = handle.unwrap();
+
+            // Read 5 bytes at offset 6 to also cover offset handling.
+            let mut w = MemWriter::new();
+            let n = fs
+                .async_read(
+                    &ctx,
+                    entry.inode,
+                    handle,
+                    &mut w,
+                    5,
+                    6,
+                    None,
+                    libc::O_RDONLY as u32,
+                )
+                .await
+                .unwrap();
+            assert_eq!(n, 5);
+            assert_eq!(&w.0, b"world");
+        });
+    }
+
+    #[test]
+    fn test_async_create_write_fsync() {
+        let (fs, source) = prepare_async_fs();
+        let ctx = prepare_context();
+
+        async_runtime::block_on(async {
+            let name = CString::new("newfile").unwrap();
+            let args = CreateIn {
+                flags: (libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32,
+                mode: 0o644,
+                umask: 0,
+                fuse_flags: 0,
+            };
+            let (entry, handle, _opts) = fs.async_create(&ctx, ROOT_ID, &name, args).await.unwrap();
+            let handle = handle.unwrap();
+
+            let mut r = MemReader(b"async data".to_vec());
+            let n = fs
+                .async_write(
+                    &ctx,
+                    entry.inode,
+                    handle,
+                    &mut r,
+                    10,
+                    0,
+                    None,
+                    false,
+                    libc::O_RDWR as u32,
+                    0,
+                )
+                .await
+                .unwrap();
+            assert_eq!(n, 10);
+
+            fs.async_fsync(&ctx, entry.inode, true, handle)
+                .await
+                .unwrap();
+        });
+
+        let content = std::fs::read(source.as_path().join("newfile")).unwrap();
+        assert_eq!(&content, b"async data");
+    }
+
+    #[test]
+    fn test_async_fallocate() {
+        let (fs, source) = prepare_async_fs();
+        let ctx = prepare_context();
+        let path = source.as_path().join("testfile");
+        std::fs::write(&path, b"").unwrap();
+        let name = CString::new("testfile").unwrap();
+
+        async_runtime::block_on(async {
+            let entry = fs.async_lookup(&ctx, ROOT_ID, &name).await.unwrap();
+            let (handle, _opts) = fs
+                .async_open(&ctx, entry.inode, libc::O_RDWR as u32, 0)
+                .await
+                .unwrap();
+            let handle = handle.unwrap();
+
+            fs.async_fallocate(&ctx, entry.inode, handle, 0, 0, 4096)
+                .await
+                .unwrap();
+        });
+
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 4096);
+    }
+
+    // Regression test for async_fsyncdir() in `no_opendir` mode: the request must
+    // be relayed to sync `fsyncdir()` (which reopens the directory inode) instead
+    // of `fsync()` (which would fail to find a directory handle in the handle map).
+    #[test]
+    fn test_async_fsyncdir_no_opendir() {
+        let (fs, _source) = prepare_async_fs();
+        let ctx = prepare_context();
+        fs.no_opendir.store(true, Ordering::Relaxed);
+
+        async_runtime::block_on(fs.async_fsyncdir(&ctx, ROOT_ID, false, 0)).unwrap();
+    }
+}

--- a/src/passthrough/async_io.rs
+++ b/src/passthrough/async_io.rs
@@ -1,19 +1,20 @@
 // Copyright (C) 2021-2022 Alibaba Cloud. All rights reserved.
+//
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused_variables)]
-#![allow(dead_code)]
-#![allow(unused_imports)]
+//! Asynchronous IO support for `PassthroughFs`.
+//!
+//! The asynchronous interface is implemented by relaying operations to the
+//! synchronous io handlers, so the blocking syscalls are executed in the context
+//! of the asynchronous runtime. An io_uring based implementation may be added
+//! in the future.
 
 use std::io;
-use std::mem::ManuallyDrop;
 
 use async_trait::async_trait;
 
 use super::*;
-use crate::abi::fuse_abi::{
-    CreateIn, Opcode, OpenOptions, SetattrValid, FOPEN_IN_KILL_SUIDGID, WRITE_KILL_PRIV,
-};
+use crate::abi::fuse_abi::{CreateIn, OpenOptions, SetattrValid};
 use crate::api::filesystem::{
     AsyncFileSystem, AsyncZeroCopyReader, AsyncZeroCopyWriter, Context, FileSystem,
 };
@@ -29,282 +30,6 @@ impl<S: BitmapSlice + Send + Sync + 'static> BackendFileSystem for PassthroughFs
     }
 }
 
-impl<'a> InodeData {
-    async fn async_get_file(&self) -> io::Result<InodeFile<'_>> {
-        // The io_uring doesn't support open_by_handle_at yet, so use sync io.
-        self.get_file()
-    }
-}
-
-impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
-    /*
-    async fn async_open_file(
-        &self,
-        ctx: &Context,
-        dir_fd: i32,
-        pathname: &'_ CStr,
-        flags: i32,
-        mode: u32,
-    ) -> io::Result<File> {
-        AsyncUtil::open_at(drive, dir_fd, pathname, flags, mode)
-            .await
-            .map(|fd| unsafe { File::from_raw_fd(fd as i32) })
-        }
-
-        async fn async_open_proc_file(
-            &self,
-            ctx: &Context,
-            fd: RawFd,
-            flags: i32,
-            mode: u32,
-        ) -> io::Result<File> {
-            if !is_safe_inode(mode) {
-                return Err(ebadf());
-            }
-
-            let pathname = CString::new(format!("{}", fd))
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
-            // We don't really check `flags` because if the kernel can't handle poorly specified flags
-            // then we have much bigger problems. Also, clear the `O_NOFOLLOW` flag if it is set since
-            // we need to follow the `/proc/self/fd` symlink to get the file.
-            self.async_open_file(
-                ctx,
-                self.proc_self_fd.as_raw_fd(),
-                pathname.as_c_str(),
-                (flags | libc::O_CLOEXEC) & (!libc::O_NOFOLLOW),
-                0,
-            )
-            .await
-        }
-
-        /// Create a File or File Handle for `name` under directory `dir_fd` to support `lookup()`.
-        async fn async_open_file_or_handle<F>(
-            &self,
-            ctx: &Context,
-            dir_fd: RawFd,
-            name: &CStr,
-            reopen_dir: F,
-        ) -> io::Result<(FileOrHandle, InodeStat, InodeAltKey, Option<InodeAltKey>)>
-        where
-            F: FnOnce(RawFd, libc::c_int, u32) -> io::Result<File>,
-        {
-            let handle = if self.cfg.inode_file_handles {
-                FileHandle::from_name_at_with_mount_fds(dir_fd, name, &self.mount_fds, reopen_dir)
-            } else {
-                Err(io::Error::from_raw_os_error(libc::ENOTSUP))
-            };
-
-            // Ignore errors, because having a handle is optional
-            let file_or_handle = if let Ok(h) = handle {
-                FileOrHandle::Handle(h)
-            } else {
-                let f = self
-                    .async_open_file(
-                        ctx,
-                        dir_fd,
-                        name,
-                        libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                        0,
-                    )
-                    .await?;
-
-                FileOrHandle::File(f)
-            };
-
-            let st = match &file_or_handle {
-                FileOrHandle::File(f) => {
-                    // Count mount ID as part of alt key if use_mntid is true. Note that using
-                    // name_to_handle_at() to get mntid is kind of expensive in Lookup intensive
-                    // workloads, e.g. when cache is none and accessing lots of files.
-                    //
-                    // Some filesystems don't support file handle, for example overlayfs mounted
-                    // without index feature, if so just use mntid 0 in that case.
-                    //
-                    // TODO: use statx(2) to query mntid when 5.8 kernel or later are widely used.
-                    let mnt_id = if self.cfg.enable_mntid {
-                        match FileHandle::from_name_at(dir_fd, name) {
-                            Ok(h) => h.mnt_id,
-                            Err(_) => 0,
-                        }
-                    } else {
-                        0
-                    };
-                    InodeStat {
-                        stat: self.async_stat(ctx, f, None).await?,
-                        mnt_id,
-                    }
-                }
-                FileOrHandle::Handle(h) => InodeStat {
-                    stat: self.async_stat_fd(ctx, dir_fd, Some(name)).await?,
-                    mnt_id: h.mnt_id,
-                },
-            };
-            let ids_altkey = InodeAltKey::ids_from_stat(&st);
-
-            // Note that this will always be `None` if `cfg.inode_file_handles` is false, but we only
-            // really need this alt key when we do not have an `O_PATH` fd open for every inode.  So if
-            // `cfg.inode_file_handles` is false, we do not need this key anyway.
-            let handle_altkey = file_or_handle.handle().map(|h| InodeAltKey::Handle(*h));
-
-            Ok((file_or_handle, st, ids_altkey, handle_altkey))
-        }
-
-        async fn async_open_inode(
-            &self,
-            ctx: &Context,
-            inode: Inode,
-            mut flags: i32,
-        ) -> io::Result<File> {
-            let new_flags = self.get_writeback_open_flags(flags);
-
-            let data = self.inode_map.get(inode)?;
-            let file = data.async_get_file(&self.mount_fds).await?;
-
-            self.async_open_proc_file(ctx, file.as_raw_fd(), new_flags, data.mode)
-                .await
-        }
-
-        async fn async_do_open(
-            &self,
-            ctx: &Context,
-            inode: Inode,
-            flags: u32,
-            fuse_flags: u32,
-        ) -> io::Result<(Option<Handle>, OpenOptions)> {
-            let killpriv = if self.killpriv_v2.load(Ordering::Relaxed)
-                && (fuse_flags & FOPEN_IN_KILL_SUIDGID != 0)
-            {
-                self::drop_cap_fsetid()?
-            } else {
-                None
-            };
-            let file = self.async_open_inode(ctx, inode, flags as i32).await?;
-            drop(killpriv);
-
-            let data = HandleData::new(inode, file);
-            let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);
-            let mut opts = OpenOptions::empty();
-
-            self.handle_map.insert(handle, data);
-            match self.cfg.cache_policy {
-                // We only set the direct I/O option on files.
-                CachePolicy::Never => opts.set(
-                    OpenOptions::DIRECT_IO,
-                    flags & (libc::O_DIRECTORY as u32) == 0,
-                ),
-                CachePolicy::Always => opts |= OpenOptions::KEEP_CACHE,
-                _ => {}
-            };
-
-            Ok((Some(handle), opts))
-        }
-        */
-
-    async fn async_do_getattr(
-        &self,
-        ctx: &Context,
-        inode: Inode,
-        handle: Option<<Self as FileSystem>::Handle>,
-    ) -> io::Result<(libc::stat64, Duration)> {
-        unimplemented!()
-        /*
-        let st;
-        let fd;
-        let data = self.inode_map.get(inode).map_err(|e| {
-            error!("fuse: do_getattr ino {} Not find err {:?}", inode, e);
-            e
-        })?;
-
-        // kernel sends 0 as handle in case of no_open, and it depends on fuse server to handle
-        // this case correctly.
-        if !self.no_open.load(Ordering::Relaxed) && handle.is_some() {
-            // Safe as we just checked handle
-            let hd = self.handle_map.get(handle.unwrap(), inode)?;
-            fd = hd.get_handle_raw_fd();
-            st = self.async_stat_fd(ctx, fd, None).await;
-        } else {
-            match &data.file_or_handle {
-                FileOrHandle::File(f) => {
-                    fd = f.as_raw_fd();
-                    st = self.async_stat_fd(ctx, fd, None).await;
-                }
-                FileOrHandle::Handle(_h) => {
-                    let file = data.async_get_file(&self.mount_fds).await?;
-                    fd = file.as_raw_fd();
-                    st = self.async_stat_fd(ctx, fd, None).await;
-                }
-            }
-        }
-
-        let st = st.map_err(|e| {
-            error!(
-                "fuse: do_getattr stat failed ino {} fd: {:?} err {:?}",
-                inode, fd, e
-            );
-            e
-        })?;
-
-        Ok((st, self.cfg.attr_timeout))
-        */
-    }
-
-    /*
-    async fn async_stat(
-        &self,
-        ctx: &Context,
-        dir: &impl AsRawFd,
-        path: Option<&CStr>,
-    ) -> io::Result<libc::stat64> {
-        self.async_stat_fd(ctx, dir.as_raw_fd(), path).await
-    }
-
-    async fn async_stat_fd(
-        &self,
-        _ctx: &Context,
-        dir_fd: RawFd,
-        path: Option<&CStr>,
-    ) -> io::Result<libc::stat64> {
-        // Safe because this is a constant value and a valid C string.
-        let pathname =
-            path.unwrap_or_else(|| unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) });
-        let mut st = MaybeUninit::<libc::stat64>::zeroed();
-
-        // Safe because the kernel will only write data in `st` and we check the return value.
-        let res = unsafe {
-            libc::fstatat64(
-                dir_fd,
-                pathname.as_ptr(),
-                st.as_mut_ptr(),
-                libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW,
-            )
-        };
-        if res >= 0 {
-            // Safe because the kernel guarantees that the struct is now fully initialized.
-            Ok(unsafe { st.assume_init() })
-        } else {
-            Err(io::Error::last_os_error())
-        }
-    }
-
-    async fn async_get_data(
-        &self,
-        ctx: &Context,
-        handle: Handle,
-        inode: Inode,
-        flags: libc::c_int,
-    ) -> io::Result<Arc<HandleData>> {
-        let no_open = self.no_open.load(Ordering::Relaxed);
-        if !no_open {
-            self.handle_map.get(handle, inode)
-        } else {
-            let file = self.async_open_inode(ctx, inode, flags as i32).await?;
-            Ok(Arc::new(HandleData::new(inode, file)))
-        }
-    }
-     */
-}
-
 #[async_trait]
 impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
     async fn async_lookup(
@@ -313,106 +38,7 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         parent: <Self as FileSystem>::Inode,
         name: &CStr,
     ) -> io::Result<Entry> {
-        unimplemented!()
-        /*
-        // Don't use is_safe_path_component(), allow "." and ".." for NFS export support
-        if name.to_bytes_with_nul().contains(&SLASH_ASCII) {
-            return Err(io::Error::from_raw_os_error(libc::EINVAL));
-        }
-
-        let dir = self.inode_map.get(parent)?;
-        let dir_file = dir.async_get_file(&self.mount_fds).await?;
-        let (file_or_handle, st, ids_altkey, handle_altkey) = self
-            .async_open_file_or_handle(ctx, dir_file.as_raw_fd(), name, |fd, flags, mode| {
-                Self::open_proc_file(&self.proc_self_fd, fd, flags, mode)
-            })
-            .await?;
-
-        let mut attr_flags: u32 = 0;
-        if let Some(dax_file_size) = self.cfg.dax_file_size {
-            // st.stat.st_size is i64
-            if self.perfile_dax.load(Ordering::Relaxed)
-                && st.stat.st_size >= 0x0
-                && st.stat.st_size as u64 >= dax_file_size
-            {
-                attr_flags |= fuse::FUSE_ATTR_DAX;
-            }
-        }
-
-        let mut found = None;
-        'search: loop {
-            match self.inode_map.get_alt(&ids_altkey, handle_altkey.as_ref()) {
-                // No existing entry found
-                None => break 'search,
-                Some(data) => {
-                    let curr = data.refcount.load(Ordering::Acquire);
-                    // forgot_one() has just destroyed the entry, retry...
-                    if curr == 0 {
-                        continue 'search;
-                    }
-
-                    // Saturating add to avoid integer overflow, it's not realistic to saturate u64.
-                    let new = curr.saturating_add(1);
-
-                    // Synchronizes with the forgot_one()
-                    if data
-                        .refcount
-                        .compare_exchange(curr, new, Ordering::AcqRel, Ordering::Acquire)
-                        .is_ok()
-                    {
-                        found = Some(data.inode);
-                        break;
-                    }
-                }
-            }
-        }
-
-        let inode = if let Some(v) = found {
-            v
-        } else {
-            // Write guard get_alt_locked() and insert_lock() to avoid race conditions.
-            let mut inodes = self.inode_map.get_map_mut();
-
-            // Lookup inode_map again after acquiring the inode_map lock, as there might be another
-            // racing thread already added an inode with the same altkey while we're not holding
-            // the lock. If so just use the newly added inode, otherwise the inode will be replaced
-            // and results in EBADF.
-            match InodeMap::get_alt_locked(inodes.deref(), &ids_altkey, handle_altkey.as_ref()) {
-                Some(data) => {
-                    data.refcount.fetch_add(1, Ordering::Relaxed);
-                    data.inode
-                }
-                None => {
-                    let inode = self.next_inode.fetch_add(1, Ordering::Relaxed);
-                    if inode > VFS_MAX_INO {
-                        error!("fuse: max inode number reached: {}", VFS_MAX_INO);
-                        return Err(io::Error::new(
-                            io::ErrorKind::Other,
-                            format!("max inode number reached: {}", VFS_MAX_INO),
-                        ));
-                    }
-
-                    InodeMap::insert_locked(
-                        inodes.deref_mut(),
-                        inode,
-                        InodeData::new(inode, file_or_handle, 1, ids_altkey, st.get_stat().st_mode),
-                        ids_altkey,
-                        handle_altkey,
-                    );
-                    inode
-                }
-            }
-        };
-
-        Ok(Entry {
-            inode,
-            generation: 0,
-            attr: st.get_stat(),
-            attr_flags,
-            attr_timeout: self.cfg.attr_timeout,
-            entry_timeout: self.cfg.entry_timeout,
-        })
-        */
+        self.lookup(ctx, parent, name)
     }
 
     async fn async_getattr(
@@ -421,7 +47,7 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         inode: <Self as FileSystem>::Inode,
         handle: Option<<Self as FileSystem>::Handle>,
     ) -> io::Result<(libc::stat64, Duration)> {
-        self.async_do_getattr(ctx, inode, handle).await
+        self.getattr(ctx, inode, handle)
     }
 
     async fn async_setattr(
@@ -432,149 +58,7 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         handle: Option<<Self as FileSystem>::Handle>,
         valid: SetattrValid,
     ) -> io::Result<(libc::stat64, Duration)> {
-        unimplemented!()
-        /*
-        enum Data {
-            Handle(Arc<HandleData>, RawFd),
-            ProcPath(CString),
-        }
-
-        let inode_data = self.inode_map.get(inode)?;
-        let file = inode_data.async_get_file(&self.mount_fds).await?;
-        let data = if self.no_open.load(Ordering::Relaxed) {
-            let pathname = CString::new(format!("self/fd/{}", file.as_raw_fd()))
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            Data::ProcPath(pathname)
-        } else {
-            // If we have a handle then use it otherwise get a new fd from the inode.
-            if let Some(handle) = handle {
-                let hd = self.handle_map.get(handle, inode)?;
-                let fd = hd.get_handle_raw_fd();
-                Data::Handle(hd, fd)
-            } else {
-                let pathname = CString::new(format!("self/fd/{}", file.as_raw_fd()))
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                Data::ProcPath(pathname)
-            }
-        };
-
-        if valid.contains(SetattrValid::SIZE) && self.seal_size.load(Ordering::Relaxed) {
-            return Err(io::Error::from_raw_os_error(libc::EPERM));
-        }
-
-        if valid.contains(SetattrValid::MODE) {
-            // Safe because this doesn't modify any memory and we check the return value.
-            let res = unsafe {
-                match data {
-                    Data::Handle(_, fd) => libc::fchmod(fd, attr.st_mode),
-                    Data::ProcPath(ref p) => {
-                        libc::fchmodat(self.proc_self_fd.as_raw_fd(), p.as_ptr(), attr.st_mode, 0)
-                    }
-                }
-            };
-            if res < 0 {
-                return Err(io::Error::last_os_error());
-            }
-        }
-
-        if valid.intersects(SetattrValid::UID | SetattrValid::GID) {
-            let uid = if valid.contains(SetattrValid::UID) {
-                attr.st_uid
-            } else {
-                // Cannot use -1 here because these are unsigned values.
-                ::std::u32::MAX
-            };
-            let gid = if valid.contains(SetattrValid::GID) {
-                attr.st_gid
-            } else {
-                // Cannot use -1 here because these are unsigned values.
-                ::std::u32::MAX
-            };
-
-            // Safe because this is a constant value and a valid C string.
-            let empty = unsafe { CStr::from_bytes_with_nul_unchecked(EMPTY_CSTR) };
-
-            // Safe because this doesn't modify any memory and we check the return value.
-            let res = unsafe {
-                libc::fchownat(
-                    file.as_raw_fd(),
-                    empty.as_ptr(),
-                    uid,
-                    gid,
-                    libc::AT_EMPTY_PATH | libc::AT_SYMLINK_NOFOLLOW,
-                )
-            };
-            if res < 0 {
-                return Err(io::Error::last_os_error());
-            }
-        }
-
-        if valid.contains(SetattrValid::SIZE) {
-            // Cap restored when _killpriv is dropped
-            let _killpriv = if self.killpriv_v2.load(Ordering::Relaxed)
-                && valid.contains(SetattrValid::KILL_SUIDGID)
-            {
-                self::drop_cap_fsetid()?
-            } else {
-                None
-            };
-
-            // Safe because this doesn't modify any memory and we check the return value.
-            let res = match data {
-                Data::Handle(_, fd) => unsafe { libc::ftruncate(fd, attr.st_size) },
-                Data::ProcPath(_) => {
-                    // There is no `ftruncateat` so we need to get a new fd and truncate it.
-                    let f = self
-                        .async_open_inode(ctx, inode, libc::O_NONBLOCK | libc::O_RDWR)
-                        .await?;
-                    unsafe { libc::ftruncate(f.as_raw_fd(), attr.st_size) }
-                }
-            };
-            if res < 0 {
-                return Err(io::Error::last_os_error());
-            }
-        }
-
-        if valid.intersects(SetattrValid::ATIME | SetattrValid::MTIME) {
-            let mut tvs = [
-                libc::timespec {
-                    tv_sec: 0,
-                    tv_nsec: libc::UTIME_OMIT,
-                },
-                libc::timespec {
-                    tv_sec: 0,
-                    tv_nsec: libc::UTIME_OMIT,
-                },
-            ];
-
-            if valid.contains(SetattrValid::ATIME_NOW) {
-                tvs[0].tv_nsec = libc::UTIME_NOW;
-            } else if valid.contains(SetattrValid::ATIME) {
-                tvs[0].tv_sec = attr.st_atime;
-                tvs[0].tv_nsec = attr.st_atime_nsec;
-            }
-
-            if valid.contains(SetattrValid::MTIME_NOW) {
-                tvs[1].tv_nsec = libc::UTIME_NOW;
-            } else if valid.contains(SetattrValid::MTIME) {
-                tvs[1].tv_sec = attr.st_mtime;
-                tvs[1].tv_nsec = attr.st_mtime_nsec;
-            }
-
-            // Safe because this doesn't modify any memory and we check the return value.
-            let res = match data {
-                Data::Handle(_, fd) => unsafe { libc::futimens(fd, tvs.as_ptr()) },
-                Data::ProcPath(ref p) => unsafe {
-                    libc::utimensat(self.proc_self_fd.as_raw_fd(), p.as_ptr(), tvs.as_ptr(), 0)
-                },
-            };
-            if res < 0 {
-                return Err(io::Error::last_os_error());
-            }
-        }
-
-        self.async_do_getattr(ctx, inode, handle).await
-         */
+        self.setattr(ctx, inode, attr, handle, valid)
     }
 
     async fn async_open(
@@ -584,15 +68,8 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         flags: u32,
         fuse_flags: u32,
     ) -> io::Result<(Option<<Self as FileSystem>::Handle>, OpenOptions)> {
-        unimplemented!()
-        /*
-        if self.no_open.load(Ordering::Relaxed) {
-            info!("fuse: open is not supported.");
-            Err(io::Error::from_raw_os_error(libc::ENOSYS))
-        } else {
-            self.async_do_open(ctx, inode, flags, fuse_flags).await
-        }
-         */
+        let (handle, opts, _) = self.open(ctx, inode, flags, fuse_flags)?;
+        Ok((handle, opts))
     }
 
     async fn async_create(
@@ -602,66 +79,8 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         name: &CStr,
         args: CreateIn,
     ) -> io::Result<(Entry, Option<<Self as FileSystem>::Handle>, OpenOptions)> {
-        unimplemented!()
-        /*
-        self.validate_path_component(name)?;
-
-        let dir = self.inode_map.get(parent)?;
-        let dir_file = dir.async_get_file(&self.mount_fds).await?;
-
-        let new_file = {
-            let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
-
-            let flags = self.get_writeback_open_flags(args.flags as i32);
-            Self::create_file_excl(
-                dir_file.as_raw_fd(),
-                name,
-                flags,
-                args.mode & !(args.umask & 0o777),
-            )?
-        };
-
-        let entry = self.async_lookup(ctx, parent, name).await?;
-        let file = match new_file {
-            // File didn't exist, now created by create_file_excl()
-            Some(f) => f,
-            // File exists, and args.flags doesn't contain O_EXCL. Now let's open it with
-            // open_inode().
-            None => {
-                // Cap restored when _killpriv is dropped
-                let _killpriv = if self.killpriv_v2.load(Ordering::Relaxed)
-                    && (args.fuse_flags & FOPEN_IN_KILL_SUIDGID != 0)
-                {
-                    self::drop_cap_fsetid()?
-                } else {
-                    None
-                };
-
-                let (_uid, _gid) = set_creds(ctx.uid, ctx.gid)?;
-                self.async_open_inode(ctx, entry.inode, args.flags as i32)
-                    .await?
-            }
-        };
-
-        let ret_handle = if !self.no_open.load(Ordering::Relaxed) {
-            let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);
-            let data = HandleData::new(entry.inode, file);
-
-            self.handle_map.insert(handle, data);
-            Some(handle)
-        } else {
-            None
-        };
-
-        let mut opts = OpenOptions::empty();
-        match self.cfg.cache_policy {
-            CachePolicy::Never => opts |= OpenOptions::DIRECT_IO,
-            CachePolicy::Always => opts |= OpenOptions::KEEP_CACHE,
-            _ => {}
-        };
-
-        Ok((entry, ret_handle, opts))
-         */
+        let (entry, handle, opts, _) = self.create(ctx, parent, name, args)?;
+        Ok((entry, handle, opts))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -673,21 +92,10 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         w: &mut (dyn AsyncZeroCopyWriter + Send),
         size: u32,
         offset: u64,
-        _lock_owner: Option<u64>,
-        _flags: u32,
+        lock_owner: Option<u64>,
+        flags: u32,
     ) -> io::Result<usize> {
-        unimplemented!()
-        /*
-        let data = self
-            .async_get_data(ctx, handle, inode, libc::O_RDONLY)
-            .await?;
-        let drive = ctx
-            .get_drive::<D>()
-            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
-
-        w.async_write_from(drive, data.get_handle_raw_fd(), size as usize, offset)
-            .await
-         */
+        self.read(ctx, inode, handle, w, size, offset, lock_owner, flags)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -699,44 +107,23 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         r: &mut (dyn AsyncZeroCopyReader + Send),
         size: u32,
         offset: u64,
-        _lock_owner: Option<u64>,
-        _delayed_write: bool,
-        _flags: u32,
+        lock_owner: Option<u64>,
+        delayed_write: bool,
+        flags: u32,
         fuse_flags: u32,
     ) -> io::Result<usize> {
-        unimplemented!()
-        /*
-        let data = self
-            .async_get_data(ctx, handle, inode, libc::O_RDWR)
-            .await?;
-
-        if self.seal_size.load(Ordering::Relaxed) {
-            let st = self
-                .async_stat_fd(cxt, data.get_handle_raw_fd(), None)
-                .await?;
-            self.seal_size_check(Opcode::Write, st.st_size as u64, offset, size as u64, 0)?;
-        }
-
-        // Fallback to sync io if KILLPRIV_V2 is enabled to work around a limitation of io_uring.
-        if self.killpriv_v2.load(Ordering::Relaxed) && (fuse_flags & WRITE_KILL_PRIV != 0) {
-            // Manually implement File::try_clone() by borrowing fd of data.file instead of dup().
-            // It's safe because the `data` variable's lifetime spans the whole function,
-            // so data.file won't be closed.
-            let f = unsafe { File::from_raw_fd(data.get_handle_raw_fd()) };
-            let mut f = ManuallyDrop::new(f);
-            // Cap restored when _killpriv is dropped
-            let _killpriv = self::drop_cap_fsetid()?;
-
-            r.read_to(&mut *f, size as usize, offset)
-        } else {
-            let drive = ctx
-                .get_drive::<D>()
-                .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
-
-            r.async_read_to(drive, data.get_handle_raw_fd(), size as usize, offset)
-                .await
-        }
-         */
+        self.write(
+            ctx,
+            inode,
+            handle,
+            r,
+            size,
+            offset,
+            lock_owner,
+            delayed_write,
+            flags,
+            fuse_flags,
+        )
     }
 
     async fn async_fsync(
@@ -746,17 +133,7 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         datasync: bool,
         handle: <Self as FileSystem>::Handle,
     ) -> io::Result<()> {
-        unimplemented!()
-        /*
-        let data = self
-            .async_get_data(ctx, handle, inode, libc::O_RDONLY)
-            .await?;
-        let drive = ctx
-            .get_drive::<D>()
-            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
-
-        AsyncUtil::fsync(drive, data.get_handle_raw_fd(), datasync).await
-         */
+        self.fsync(ctx, inode, datasync, handle)
     }
 
     async fn async_fallocate(
@@ -768,31 +145,7 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         offset: u64,
         length: u64,
     ) -> io::Result<()> {
-        unimplemented!()
-        /*
-        // Let the Arc<HandleData> in scope, otherwise fd may get invalid.
-        let data = self
-            .async_get_data(ctx, handle, inode, libc::O_RDWR)
-            .await?;
-        let drive = ctx
-            .get_drive::<D>()
-            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
-
-        if self.seal_size.load(Ordering::Relaxed) {
-            let st = self
-                .async_stat_fd(cxt, data.get_handle_raw_fd(), None)
-                .await?;
-            self.seal_size_check(
-                Opcode::Fallocate,
-                st.st_size as u64,
-                offset,
-                length,
-                mode as i32,
-            )?;
-        }
-
-        AsyncUtil::fallocate(drive, data.get_handle_raw_fd(), offset, length, mode).await
-         */
+        self.fallocate(ctx, inode, handle, mode, offset, length)
     }
 
     async fn async_fsyncdir(
@@ -802,6 +155,6 @@ impl<S: BitmapSlice + Send + Sync> AsyncFileSystem for PassthroughFs<S> {
         datasync: bool,
         handle: <Self as FileSystem>::Handle,
     ) -> io::Result<()> {
-        self.async_fsync(ctx, inode, datasync, handle).await
+        self.fsyncdir(ctx, inode, datasync, handle)
     }
 }


### PR DESCRIPTION
## Background

The `async-io` implementation of `PassthroughFs` has been unusable since it was introduced: all nine overridden `AsyncFileSystem` methods (`async_lookup`, `async_getattr`, `async_setattr`, `async_open`, `async_create`, `async_read`, `async_write`, `async_fsync`, `async_fallocate`) consisted of an `unimplemented!()` followed by a block-commented draft of a native async implementation. Any async request reaching those operations panicked the server, which is a key reason the async path was reported as broken in #188.

## What this PR does

Relays every async operation to the corresponding synchronous `FileSystem` handler, the same pattern already used by the virtiofs async module:

- **Correctness first**: the sync handlers contain all the real logic (inode/handle map management, `no_open`/`no_opendir` handling, seal-size and killpriv checks, the syscalls themselves), so delegation makes the async path functionally complete and behaviorally consistent with the sync path. The blocking syscalls run in the context of the async runtime; a native io_uring implementation can replace the hot ops later without changing the API.
- **Removes ~640 lines of dead code**: the commented-out drafts and the now-unused `InodeData::async_get_file` helper (808 → ~460 lines including the new tests).
- Note that `async_fsyncdir` is relayed to sync `fsyncdir`, not `fsync`: the two resolve handles through different paths (`get_dirdata`/`no_opendir` vs `get_data`/`no_open`), and routing through `fsync` would fail with EBADF in the common `no_opendir` configuration.
- The extra `Option<u32>` returned by sync `open`/`create` (fd-passthrough backing id) is dropped: `PassthroughFs` always returns `None` there and the async server never encodes it, matching what `Vfs::async_open/async_create` already do.

## Tests

Adds unit tests for the async handlers (`lookup`, `getattr`, `setattr`, `open`, `read` at offset, `create`, `write`, `fsync`, `fallocate`, `BackendFileSystem::mount`) using in-memory `AsyncZeroCopyReader`/`AsyncZeroCopyWriter` helpers, including a regression test asserting that `async_fsyncdir()` works in `no_opendir` mode. Also adds a `Vfs` integration test driving async `lookup`/`getattr`/`open`/`read` down to a real `PassthroughFs`, covering inode remapping. The tests run under whatever runtime is auto-detected (tokio or tokio-uring), so CI exercises both.

## Verification

- Cross-compiles cleanly for `x86_64-unknown-linux-gnu` with `--tests` on all async feature combos: `fusedev,async-io`, `virtiofs,async-io`, `vhost-user-fs,async-io`, `fusedev,virtiofs,async-io`
- `cargo clippy` clean for the changed files; `cargo fmt --check` passes
- (async-io can't be built on macOS due to the Linux-only `io-uring` dependency, so test execution happens in the Linux CI test matrix)

## Follow-ups

- Document the delegation semantics / experimental status of async-io
- Native io_uring implementation of the hot ops (`read`/`write`) for the actual performance benefit

Part of #188

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>