### PR TITLE
api: remove redundant handle conversion in Vfs::async_open()

### DIFF
--- a/src/api/vfs/async_io.rs
+++ b/src/api/vfs/async_io.rs
@@ -80,10 +80,7 @@ impl AsyncFileSystem for Vfs {
                 (Left(fs), idata) => fs
                     .open(ctx, idata.ino(), flags, fuse_flags)
                     .map(|(a, b, _)| (a, b)),
-                (Right(fs), idata) => fs
-                    .async_open(ctx, idata.ino(), flags, fuse_flags)
-                    .await
-                    .map(|(h, opt)| (h.map(Into::into), opt)),
+                (Right(fs), idata) => fs.async_open(ctx, idata.ino(), flags, fuse_flags).await,
             }
         }
     }


### PR DESCRIPTION
AsyncFileSystem inherits its Handle associated type from FileSystem, which defaults to u64, the same type Vfs uses. The h.map(Into::into) conversion on the async_open() result is therefore an identity conversion; drop it to match the style of the synchronous path.

Related-to: #188