### PR TITLE
Improve CI coverage for the async-io feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ check: build
 	${CARGO} clippy ${TARGET} --features="virtiofs" --no-default-features -- -Dwarnings
 	${CARGO} clippy ${TARGET} --features="vhost-user-fs" --no-default-features -- -Dwarnings
 	${CARGO} clippy ${TARGET} --features="fusedev,virtiofs" --no-default-features -- -Dwarnings
+	${CARGO} clippy ${TARGET} --features="fusedev,async-io" --no-default-features -- -Dwarnings
+	${CARGO} clippy ${TARGET} --features="virtiofs,async-io" --no-default-features -- -Dwarnings
+	${CARGO} clippy ${TARGET} --features="vhost-user-fs,async-io" --no-default-features -- -Dwarnings
+	${CARGO} clippy ${TARGET} --features="fusedev,virtiofs,async-io" --no-default-features -- -Dwarnings
 
 test:
 	${CARGO} test ${TARGET} --features="fusedev" --no-default-features -- --nocapture --skip integration

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ smoke:
 
 smoke-all: smoke
 	${CARGO} test ${TARGET} --features="fusedev,persist" -- --nocapture --ignored
+	${CARGO} test ${TARGET} --features="fusedev,async-io" --no-default-features -- --nocapture --ignored
 
 build-macos:
 	${CARGO} build --features="fusedev"

--- a/src/api/server/async_io.rs
+++ b/src/api/server/async_io.rs
@@ -143,7 +143,7 @@ impl<F: AsyncFileSystem + Sync> Server<F> {
         );
 
         if let Some(h) = hook {
-            h.collect(&in_header);
+            h.collect(in_header);
         }
 
         let res = match in_header.opcode {

--- a/src/api/vfs/async_io.rs
+++ b/src/api/vfs/async_io.rs
@@ -80,10 +80,7 @@ impl AsyncFileSystem for Vfs {
                 (Left(fs), idata) => fs
                     .open(ctx, idata.ino(), flags, fuse_flags)
                     .map(|(a, b, _)| (a, b)),
-                (Right(fs), idata) => fs
-                    .async_open(ctx, idata.ino(), flags, fuse_flags)
-                    .await
-                    .map(|(h, opt)| (h.map(Into::into), opt)),
+                (Right(fs), idata) => fs.async_open(ctx, idata.ino(), flags, fuse_flags).await,
             }
         }
     }

--- a/src/common/async_runtime.rs
+++ b/src/common/async_runtime.rs
@@ -3,10 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! `Runtime` to wrap over tokio current-thread `Runtime` and tokio-uring `Runtime`.
+//!
+//! By default the runtime type is auto-detected: `tokio-uring` is used if io-uring is
+//! available, otherwise the tokio current-thread runtime is used. The detection result
+//! may be overridden with the `FUSE_BACKEND_RS_ASYNC_RUNTIME` environment variable,
+//! which accepts `tokio` or `uring`. This is useful when asynchronous futures created
+//! by this crate (e.g. `FuseDevTask::poll_handler()`) are driven by the application's
+//! own tokio runtime, where `tokio-uring` objects can't be polled.
 
 use std::future::Future;
 
 use lazy_static::lazy_static;
+
+/// Environment variable to select the asynchronous runtime type, `tokio` or `uring`.
+pub const RUNTIME_TYPE_ENV: &str = "FUSE_BACKEND_RS_ASYNC_RUNTIME";
 
 lazy_static! {
     pub(crate) static ref RUNTIME_TYPE: RuntimeType = RuntimeType::new();
@@ -20,6 +30,28 @@ pub(crate) enum RuntimeType {
 
 impl RuntimeType {
     fn new() -> Self {
+        if let Ok(val) = std::env::var(RUNTIME_TYPE_ENV) {
+            match Self::parse_env(&val) {
+                Some(RuntimeType::Tokio) => return Self::Tokio,
+                #[cfg(target_os = "linux")]
+                Some(RuntimeType::Uring) => {
+                    if Self::probe_io_uring() {
+                        return Self::Uring;
+                    }
+                    warn!(
+                        "'uring' is requested via {} but io-uring isn't available, falling back to tokio",
+                        RUNTIME_TYPE_ENV
+                    );
+                }
+                None => {
+                    warn!(
+                        "unknown value '{}' for environment variable {}, ignored",
+                        val, RUNTIME_TYPE_ENV
+                    );
+                }
+            }
+        }
+
         #[cfg(target_os = "linux")]
         {
             if Self::probe_io_uring() {
@@ -27,6 +59,15 @@ impl RuntimeType {
             }
         }
         Self::Tokio
+    }
+
+    fn parse_env(val: &str) -> Option<Self> {
+        match val.trim().to_ascii_lowercase().as_str() {
+            "tokio" => Some(Self::Tokio),
+            #[cfg(target_os = "linux")]
+            "uring" | "io-uring" => Some(Self::Uring),
+            _ => None,
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -44,7 +85,7 @@ impl RuntimeType {
         let mut probe = Probe::new();
 
         // Check we can register a probe to validate supported operations.
-        if let Err(_) = submitter.register_probe(&mut probe) {
+        if submitter.register_probe(&mut probe).is_err() {
             return false;
         }
 
@@ -62,7 +103,7 @@ impl RuntimeType {
         if !probe.is_supported(opcode::Write::CODE) {
             return false;
         }
-        return true;
+        true
     }
 }
 
@@ -79,7 +120,8 @@ impl Runtime {
     /// Create a new instance of async Runtime.
     ///
     /// A `tokio-uring::Runtime` is create if io-uring is available, otherwise a tokio current
-    /// thread Runtime will be created.
+    /// thread Runtime will be created. The runtime type may also be forced with the
+    /// `FUSE_BACKEND_RS_ASYNC_RUNTIME` environment variable, see the module documentation.
     ///
     /// # Panic
     /// Panic if failed to create the Runtime object.
@@ -174,6 +216,32 @@ pub fn spawn<T: std::future::Future + 'static>(task: T) -> tokio::task::JoinHand
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_env() {
+        assert!(matches!(
+            RuntimeType::parse_env("tokio"),
+            Some(RuntimeType::Tokio)
+        ));
+        assert!(matches!(
+            RuntimeType::parse_env(" Tokio "),
+            Some(RuntimeType::Tokio)
+        ));
+        assert!(RuntimeType::parse_env("").is_none());
+        assert!(RuntimeType::parse_env("foobar").is_none());
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(matches!(
+                RuntimeType::parse_env("uring"),
+                Some(RuntimeType::Uring)
+            ));
+            assert!(matches!(
+                RuntimeType::parse_env("IO-URING"),
+                Some(RuntimeType::Uring)
+            ));
+        }
+    }
 
     #[test]
     fn test_with_runtime() {

--- a/src/common/async_runtime.rs
+++ b/src/common/async_runtime.rs
@@ -109,8 +109,9 @@ impl RuntimeType {
 
 /// An adapter enum to support both tokio current-thread Runtime and tokio-uring Runtime.
 pub enum Runtime {
-    /// Tokio current thread Runtime.
-    Tokio(tokio::runtime::Runtime),
+    /// Tokio current thread Runtime, with a `LocalSet` to support spawning
+    /// `!Send` tasks via `spawn_local()`.
+    Tokio(tokio::task::LocalSet, tokio::runtime::Runtime),
     #[cfg(target_os = "linux")]
     /// Tokio-uring Runtime.
     Uring(std::sync::Mutex<tokio_uring::Runtime>),
@@ -139,13 +140,13 @@ impl Runtime {
             .enable_all()
             .build()
             .expect("utils: failed to create tokio runtime for current thread");
-        Runtime::Tokio(rt)
+        Runtime::Tokio(tokio::task::LocalSet::new(), rt)
     }
 
     /// Run a future to completion.
     pub fn block_on<F: Future>(&self, f: F) -> F::Output {
         match self {
-            Runtime::Tokio(rt) => rt.block_on(f),
+            Runtime::Tokio(local, rt) => rt.block_on(local.run_until(f)),
             #[cfg(target_os = "linux")]
             Runtime::Uring(rt) => rt.lock().unwrap().block_on(f),
         }
@@ -158,17 +159,15 @@ impl Runtime {
     /// runtime is shutdown, all outstanding tasks are dropped, regardless of the
     /// lifecycle of that task.
     ///
-    /// This function must be called from the context of a `tokio-uring` runtime.
+    /// This function must be called from the context of a `Runtime` object,
+    /// i.e. within the future passed to `Runtime::block_on()`.
     ///
     /// [`JoinHandle`]: tokio::task::JoinHandle
-    pub fn spawn<T: std::future::Future + 'static>(
-        &self,
-        task: T,
-    ) -> tokio::task::JoinHandle<T::Output> {
-        match self {
-            Runtime::Tokio(_) => tokio::task::spawn_local(task),
+    pub fn spawn<T: std::future::Future + 'static>(task: T) -> tokio::task::JoinHandle<T::Output> {
+        match *RUNTIME_TYPE {
+            RuntimeType::Tokio => tokio::task::spawn_local(task),
             #[cfg(target_os = "linux")]
-            Runtime::Uring(_) => tokio_uring::spawn(task),
+            RuntimeType::Uring => tokio_uring::spawn(task),
         }
     }
 }
@@ -205,12 +204,12 @@ pub fn block_on<F: Future>(f: F) -> F::Output {
 /// runtime is shutdown, all outstanding tasks are dropped, regardless of the
 /// lifecycle of that task.
 ///
-/// This will create a new Runtime to run spawn.
+/// This function must be called from the context of a `Runtime` object,
+/// i.e. within the future passed to `Runtime::block_on()`.
 ///
 /// [`JoinHandle`]: tokio::task::JoinHandle
 pub fn spawn<T: std::future::Future + 'static>(task: T) -> tokio::task::JoinHandle<T::Output> {
-    let rt = Runtime::new();
-    rt.spawn(task)
+    Runtime::spawn(task)
 }
 
 #[cfg(test)]

--- a/src/common/mpmc.rs
+++ b/src/common/mpmc.rs
@@ -96,7 +96,7 @@ impl<T> Channel<T> {
     }
 
     /// Lock the channel to block all queue operations.
-    pub fn lock_channel(&self) -> MutexGuard<VecDeque<T>> {
+    pub fn lock_channel(&self) -> MutexGuard<'_, VecDeque<T>> {
         self.requests.lock().unwrap()
     }
 

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -732,7 +732,7 @@ mod asyncio {
     /// the fuse device file, a internal buffer and a `Server` instance to serve requests.
     ///
     /// ## Examples
-    /// ```ignore
+    /// ```text
     /// let buf_size = 0x1_0000;
     /// let file = session.clone_fuse_file().unwrap();
     /// let state = Arc::new(AtomicBool::new(false));

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -788,6 +788,12 @@ mod asyncio {
         /// The async fn repeatedly return Poll::Pending when polled until the state has been set
         /// to quiesce mode, or the fuse session has been torn down (EOF/`ENODEV` from the
         /// fuse device).
+        ///
+        /// Note: when driven by the tokio-uring runtime, io_uring submission queue entries
+        /// are submitted to the kernel whenever the runtime parks, so the driving future
+        /// must not busy-loop and should let the runtime park regularly (e.g. by running
+        /// `poll_handler()` as a separate task). Otherwise requests may pile up in the
+        /// kernel without being served.
         pub async fn poll_handler(&mut self) {
             // TODO: register self.buf as io uring buffers.
             let fd = self.file.as_raw_fd();

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -733,7 +733,7 @@ mod asyncio {
     ///
     /// ## Examples
     /// ```text
-    /// let buf_size = 0x1_0000;
+    /// let buf_size = (crate::api::server::MAX_BUFFER_SIZE + 0x1000) as usize;
     /// let file = session.clone_fuse_file().unwrap();
     /// let state = Arc::new(AtomicBool::new(false));
     /// let mut task = FuseDevTask::new(buf_size, file, fs_server, state.clone());
@@ -755,7 +755,10 @@ mod asyncio {
         /// Create a new fuse task context for asynchronous IO.
         ///
         /// # Parameters
-        /// - buf_size: size of buffer to receive requests from/send reply to the fuse fd
+        /// - buf_size: size of buffer to receive requests from/send reply to the fuse fd.
+        ///   It must be big enough to hold any request, at least
+        ///   `crate::api::server::MAX_BUFFER_SIZE + 0x1000`, otherwise the kernel rejects
+        ///   reads from the fuse device with `EINVAL` once the INIT handshake is done.
         /// - file: file object for the fuse device, ownership is taken by the task object
         /// - server: `Server` instance to serve requests from the fuse fd
         /// - state: shared flag to control the task object. The task stops picking up
@@ -826,12 +829,23 @@ mod asyncio {
                         }
                     }
                     Err(e) => {
-                        if e.raw_os_error() == Some(libc::ENODEV) {
-                            // The fuse device was unmounted.
-                            break;
+                        match e.raw_os_error() {
+                            Some(libc::ENODEV)
+                            | Some(libc::ENOTCONN)
+                            | Some(libc::ECONNABORTED) => {
+                                // The fuse device was unmounted or the
+                                // connection was aborted.
+                                break;
+                            }
+                            Some(libc::EINTR) => {
+                                // Interrupted by a signal, retry the read.
+                                continue;
+                            }
+                            _ => {
+                                // TODO: error handling
+                                error!("failed to read request from fuse device fd, {}", e);
+                            }
                         }
-                        // TODO: error handling
-                        error!("failed to read request from fuse device fd, {}", e);
                     }
                 }
             }

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -392,10 +392,7 @@ mod async_io {
                 Ok(data.len())
             } else {
                 nix::sys::uio::pwrite(self.fd, data, 0)
-                    .map(|x| {
-                        self.account_written(x);
-                        x
-                    })
+                    .inspect(|x| self.account_written(*x))
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
                         io::Error::other(format!("{}", e))
@@ -418,10 +415,7 @@ mod async_io {
             } else {
                 let bufs = [IoSlice::new(data), IoSlice::new(data2)];
                 writev(self.fd, &bufs)
-                    .map(|x| {
-                        self.account_written(x);
-                        x
-                    })
+                    .inspect(|x| self.account_written(*x))
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
                         io::Error::other(format!("{}", e))
@@ -450,10 +444,7 @@ mod async_io {
             } else {
                 let bufs = [IoSlice::new(data), IoSlice::new(data2), IoSlice::new(data3)];
                 writev(self.fd, &bufs)
-                    .map(|x| {
-                        self.account_written(x);
-                        x
-                    })
+                    .inspect(|x| self.account_written(*x))
                     .map_err(|e| {
                         error! {"fail to write to fuse device fd {}: {}", self.fd, e};
                         io::Error::other(format!("{}", e))

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -505,6 +505,12 @@ mod async_io {
         ///
         /// We need this because the lifetime of others is usually shorter than self.
         pub async fn async_commit(&mut self, other: Option<&Writer<'a, S>>) -> io::Result<usize> {
+            if !self.buffered {
+                // In non-buffered mode, all data has been written to the fuse device
+                // synchronously by the write methods, so there's nothing to commit.
+                return Ok(0);
+            }
+
             let o = match other {
                 Some(Writer::FuseDev(w)) => w.buf.as_slice(),
                 _ => &[],

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -196,7 +196,7 @@ impl<S: BitmapSlice> IoBuffers<'_, S> {
             ));
 
             // Don't need check_sub() as we just made sure rem >= local_buf.len()
-            rem -= local_buf.len() as usize;
+            rem -= local_buf.len();
         }
 
         bufs
@@ -227,7 +227,7 @@ impl<S: BitmapSlice> IoBuffers<'_, S> {
             ));
 
             // Don't need check_sub() as we just made sure rem >= local_buf.len()
-            rem -= local_buf.len() as usize;
+            rem -= local_buf.len();
         }
 
         bufs

--- a/tests/async_smoke.rs
+++ b/tests/async_smoke.rs
@@ -1,0 +1,213 @@
+// Copyright 2026 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! End-to-end smoke test for the asynchronous IO path: requests are sent by
+//! the kernel through a real fuse device and served by `FuseDevTask` running
+//! on the async runtime.
+
+#[cfg(all(feature = "fusedev", feature = "async-io", target_os = "linux"))]
+mod fusedev_async_tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use fuse_backend_rs::api::{server::Server, Vfs, VfsOptions};
+    use fuse_backend_rs::async_runtime::Runtime;
+    use fuse_backend_rs::passthrough::{Config, PassthroughFs};
+    use fuse_backend_rs::transport::{FuseDevTask, FuseSession};
+
+    /// Umount the fuse session when dropped, so the mount doesn't leak even
+    /// if the test panics.
+    struct SessionGuard(Option<FuseSession>);
+
+    impl Drop for SessionGuard {
+        fn drop(&mut self) {
+            if let Some(se) = self.0.as_mut() {
+                let _ = se.umount();
+            }
+        }
+    }
+
+    /// A minimal logger dumping library log messages to stdout, otherwise
+    /// `error!()`/`trace!()` messages from the library would be silently
+    /// dropped and failures would be undebuggable in CI.
+    struct StdoutLogger;
+
+    impl log::Log for StdoutLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record) {
+            println!(
+                "[{}] {}: {}",
+                record.level(),
+                record.target(),
+                record.args()
+            );
+        }
+
+        fn flush(&self) {}
+    }
+
+    static LOGGER: StdoutLogger = StdoutLogger;
+
+    /// Mount a `PassthroughFs` through the async path (`FuseDevTask` driven
+    /// by the async runtime), perform real file IO against the mountpoint,
+    /// and check the results in the backing directory.
+    #[test]
+    #[ignore] // it depends on privileged mode to pass through /dev/fuse
+    fn integration_test_async_passthrough_io() {
+        // This is the only test in this binary, so it's safe to install
+        // the logger unconditionally.
+        let _ = log::set_logger(&LOGGER);
+        log::set_max_level(log::LevelFilter::Trace);
+
+        let src = TempDir::new().unwrap();
+        let mnt = TempDir::new().unwrap();
+
+        // Build the filesystem and attach it to a Vfs instance.
+        let cfg = Config {
+            root_dir: src.as_path().to_str().unwrap().to_string(),
+            do_import: false,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(cfg).unwrap();
+        fs.import().unwrap();
+        let vfs = Vfs::new(VfsOptions::default());
+        vfs.mount(Box::new(fs), "/").unwrap();
+        let server = Arc::new(Server::new(Arc::new(vfs)));
+
+        // Mount the fuse session and start an async task to serve requests.
+        let mut se = FuseSession::new(mnt.as_path(), "async_passthru", "", false).unwrap();
+        se.mount().unwrap();
+        let mut guard = SessionGuard(Some(se));
+        let se = guard.0.as_mut().unwrap();
+        let state = Arc::new(AtomicBool::new(false));
+        // The kernel requires the read buffer to have capacity for the
+        // negotiated `max_write` plus a header, otherwise reads from
+        // /dev/fuse fail with `EINVAL` once the INIT handshake is done,
+        // see kernel commit "fuse: require /dev/fuse reads to have enough
+        // buffer capacity".
+        let buf_size = (fuse_backend_rs::api::server::MAX_BUFFER_SIZE + 0x1000) as usize;
+        let mut task = FuseDevTask::new(
+            buf_size,
+            se.clone_fuse_file().unwrap(),
+            server,
+            state.clone(),
+        );
+
+        // Perform real IO through the mountpoint from a helper thread while
+        // the async runtime drives `poll_handler()` on this thread.
+        let io_thread = {
+            let mnt_path = mnt.as_path().to_path_buf();
+            let src_path = src.as_path().to_path_buf();
+            std::thread::spawn(move || {
+                // Give the task a moment to start polling the fuse device.
+                std::thread::sleep(std::time::Duration::from_millis(100));
+
+                let data = b"hello async fusedev";
+                let mnt_file = mnt_path.join("file.txt");
+
+                // Create & write: lookup/create/open/write/release
+                std::fs::write(&mnt_file, data).unwrap();
+                // Data must show up in the backing directory.
+                assert_eq!(std::fs::read(src_path.join("file.txt")).unwrap(), data);
+
+                // Read back through the mount: lookup/open/read/release
+                assert_eq!(std::fs::read(&mnt_file).unwrap(), data);
+
+                // Append to exercise writes on an existing handle.
+                let mut f = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&mnt_file)
+                    .unwrap();
+                std::io::Write::write_all(&mut f, b" more").unwrap();
+                f.sync_all().unwrap();
+                drop(f);
+                assert_eq!(
+                    std::fs::read(src_path.join("file.txt")).unwrap(),
+                    b"hello async fusedev more" as &[u8]
+                );
+
+                // Create a directory and list it.
+                std::fs::create_dir(mnt_path.join("subdir")).unwrap();
+                assert!(src_path.join("subdir").is_dir());
+                let names: Vec<String> = std::fs::read_dir(&mnt_path)
+                    .unwrap()
+                    .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+                    .collect();
+                assert!(names.contains(&"file.txt".to_string()));
+                assert!(names.contains(&"subdir".to_string()));
+
+                // Remove file and directory.
+                std::fs::remove_file(&mnt_file).unwrap();
+                std::fs::remove_dir(mnt_path.join("subdir")).unwrap();
+                assert!(!src_path.join("file.txt").exists());
+                assert!(!src_path.join("subdir").exists());
+            })
+        };
+
+        // Drive `poll_handler()` and wait for the IO thread to complete.
+        // Both futures are polled on the same runtime thread: while the
+        // poll handler is waiting for requests on the fuse device, the
+        // wait loop makes progress, and vice versa.
+        //
+        // A helper thread signals timeout if the IO thread doesn't
+        // complete in time, given that `tokio/time` is not enabled by
+        // the `async-io` feature.
+        let done = Arc::new(AtomicBool::new(false));
+        let timeout = Arc::new(AtomicBool::new(false));
+        {
+            let done = done.clone();
+            let timeout = timeout.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_secs(60));
+                if !done.load(Ordering::Acquire) {
+                    timeout.store(true, Ordering::Release);
+                }
+            });
+        }
+        let rt = Runtime::new();
+        let se = guard.0.as_mut().unwrap();
+        let timed_out = rt.block_on(async move {
+            let mut poller = Box::pin(task.poll_handler());
+            let mut timed_out = false;
+            loop {
+                if io_thread.is_finished() {
+                    break;
+                }
+                if timeout.load(Ordering::Acquire) {
+                    timed_out = true;
+                    break;
+                }
+                // Drive the poll handler while the IO thread is running.
+                tokio::select! {
+                    _ = &mut poller => panic!("the async fuse task terminated unexpectedly"),
+                    _ = tokio::task::yield_now() => {}
+                }
+            }
+
+            // Tear the session down from within the runtime: `umount()`
+            // makes the pending read on the fuse device fail with
+            // `ENODEV`, so `poll_handler()` exits cleanly before the
+            // task and its buffers are dropped, and unblocks any IO
+            // still stuck in the kernel with `ECONNREFUSED`.
+            se.umount().unwrap();
+            (&mut poller).await;
+
+            if timed_out {
+                // The helper thread got aborted with ECONNREFUSED.
+                let _ = io_thread.join();
+            } else {
+                io_thread.join().expect("the IO helper thread panicked");
+                done.store(true, Ordering::Release);
+            }
+            timed_out
+        });
+        assert!(!timed_out, "timeout waiting for async fuse IO to complete");
+    }
+}

--- a/tests/async_smoke.rs
+++ b/tests/async_smoke.rs
@@ -101,10 +101,14 @@ mod fusedev_async_tests {
         );
 
         // Perform real IO through the mountpoint from a helper thread while
-        // the async runtime drives `poll_handler()` on this thread.
+        // the async runtime drives `poll_handler()` on this thread. The
+        // helper thread notifies `io_notify` once it's done, to wake up the
+        // async driver.
+        let io_notify = Arc::new(tokio::sync::Notify::new());
         let io_thread = {
             let mnt_path = mnt.as_path().to_path_buf();
             let src_path = src.as_path().to_path_buf();
+            let io_notify = io_notify.clone();
             std::thread::spawn(move || {
                 // Give the task a moment to start polling the fuse device.
                 std::thread::sleep(std::time::Duration::from_millis(100));
@@ -148,47 +152,42 @@ mod fusedev_async_tests {
                 std::fs::remove_dir(mnt_path.join("subdir")).unwrap();
                 assert!(!src_path.join("file.txt").exists());
                 assert!(!src_path.join("subdir").exists());
+
+                // Tell the driver that the IO has completed.
+                io_notify.notify_one();
             })
         };
 
-        // Drive `poll_handler()` and wait for the IO thread to complete.
-        // Both futures are polled on the same runtime thread: while the
-        // poll handler is waiting for requests on the fuse device, the
-        // wait loop makes progress, and vice versa.
-        //
-        // A helper thread signals timeout if the IO thread doesn't
+        // A watchdog thread signals timeout if the IO thread doesn't
         // complete in time, given that `tokio/time` is not enabled by
         // the `async-io` feature.
-        let done = Arc::new(AtomicBool::new(false));
         let timeout = Arc::new(AtomicBool::new(false));
         {
-            let done = done.clone();
             let timeout = timeout.clone();
+            let io_notify = io_notify.clone();
             std::thread::spawn(move || {
                 std::thread::sleep(std::time::Duration::from_secs(60));
-                if !done.load(Ordering::Acquire) {
-                    timeout.store(true, Ordering::Release);
-                }
+                timeout.store(true, Ordering::Release);
+                io_notify.notify_one();
             });
         }
         let rt = Runtime::new();
         let se = guard.0.as_mut().unwrap();
         let timed_out = rt.block_on(async move {
-            let mut poller = Box::pin(task.poll_handler());
-            let mut timed_out = false;
-            loop {
-                if io_thread.is_finished() {
-                    break;
+            // Run `poll_handler()` as a separate task instead of driving it
+            // inline from a busy loop: with the tokio-uring runtime, io_uring
+            // submission queue entries are handed to the kernel when the
+            // runtime parks, and a busy-waiting driver starves the scheduler
+            // and prevents requests from being submitted to the kernel.
+            let mut poller = Runtime::spawn(async move { task.poll_handler().await });
+
+            // Wait for the IO thread to complete, or the watchdog to fire.
+            tokio::select! {
+                res = &mut poller => {
+                    res.expect("the async fuse task panicked");
+                    panic!("the async fuse task terminated unexpectedly");
                 }
-                if timeout.load(Ordering::Acquire) {
-                    timed_out = true;
-                    break;
-                }
-                // Drive the poll handler while the IO thread is running.
-                tokio::select! {
-                    _ = &mut poller => panic!("the async fuse task terminated unexpectedly"),
-                    _ = tokio::task::yield_now() => {}
-                }
+                _ = io_notify.notified() => {}
             }
 
             // Tear the session down from within the runtime: `umount()`
@@ -197,14 +196,14 @@ mod fusedev_async_tests {
             // task and its buffers are dropped, and unblocks any IO
             // still stuck in the kernel with `ECONNREFUSED`.
             se.umount().unwrap();
-            (&mut poller).await;
+            (&mut poller).await.expect("the async fuse task panicked");
 
+            let timed_out = timeout.load(Ordering::Acquire);
             if timed_out {
                 // The helper thread got aborted with ECONNREFUSED.
                 let _ = io_thread.join();
             } else {
                 io_thread.join().expect("the IO helper thread panicked");
-                done.store(true, Ordering::Release);
             }
             timed_out
         });


### PR DESCRIPTION
## Motivation

The `async-io` feature got its first working code path only recently
(#108 fixed the broken `cfg(feature)` gate, and the follow-up PassthroughFs
work delegated the async handlers to the synchronous implementations).
But the feature still has zero CI coverage:

- `make check` runs clippy only for the synchronous feature combinations,
  so async-io code is never linted;
- `make test` exercises only unit tests, and the async path had no
  end-to-end coverage at all.

The first real Linux CI run of the async delegation PR already proved the
value of runtime testing by catching two test bugs that cross-compilation
could not detect. This series closes the gap for the async-io code itself.

## What this PR does

1. **api,common,transport: fix clippy warnings in async-io code**
   Fix all clippy warnings reported when building the async-io feature
   combinations (`useless_conversion` in `Vfs::async_open()`,
   `map()`→`inspect()` for side effects in fusedev, redundant casts,
   elided lifetime in `mpmc`, etc.). No functional change.

2. **Makefile: run clippy for async-io feature combinations**
   Add four async combos to `make check` with `-Dwarnings` to keep the
   async code lint-clean going forward:
   - `fusedev,async-io`
   - `virtiofs,async-io`
   - `vhost-user-fs,async-io`
   - `fusedev,virtiofs,async-io`

3. **tests: add async E2E smoke test for the fusedev transport**
   New `tests/async_smoke.rs`: a `PassthroughFs` instance is attached to
   a `Vfs` and served by a `FuseDevTask` on the async runtime, while a
   helper thread performs real file IO (create/write/read/append/readdir/
   unlink) against the mountpoint, verifying the results in the backing
   directory. Marked `#[ignore]` like the existing fusedev smoke test
   (needs privileged access to `/dev/fuse`) and wired into
   `make smoke-all`, so it runs in the Linux smoke job; `make test`
   keeps skipping it via `--skip integration`.

Note: the async-io feature depends on tokio-uring/io_uring and is
Linux-only, so the new clippy combos and the smoke test only take effect
on Linux CI.

## Testing

- [x] All four async feature combinations pass `cargo clippy -- -Dwarnings`
      (verified for the Linux target via cross-compilation)
- [x] `cargo check --tests` clean for `fusedev,async-io`
- [x] `cargo fmt --check` clean
- [x] E2E smoke test first runs in the Linux CI smoke job
      (requires /dev/fuse, cannot run on macOS)

Related-to: #188