### PR TITLE
tests/ci: add sync vs async benchmark tooling and per-PR benchmark pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ build = "build.rs"
 members = [
     "tests/passthrough",
     "tests/overlay",
+    "tests/benchmark",
 ]
 
 [workspace.dependencies]

--- a/tests/benchmark/Cargo.toml
+++ b/tests/benchmark/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "fuse-backend-rs-benchmark"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Benchmark tooling for comparing the synchronous and asynchronous IO
+# paths of fuse-backend-rs. This is a standalone crate (like
+# tests/passthrough) so that the benchmark dependencies don't leak into
+# the main crate's dependency tree or the CI test jobs.
+
+[dependencies]
+fuse-backend-rs = { path = "../../", default-features = false, features = ["fusedev", "async-io"] }
+log = ">=0.4.6"
+libc = ">=0.2.68"
+simple_logger = ">=1.13.0"
+signal-hook = ">=0.3.10"
+
+[dev-dependencies]
+async-trait = "0.1.42"
+criterion = "0.5"
+vmm-sys-util = "0.15.0"
+
+[[bench]]
+name = "sync_vs_async_microbench"
+harness = false

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,0 +1,65 @@
+# fuse-backend-rs benchmark tooling
+
+Tooling to compare the performance of the synchronous and asynchronous IO
+paths, complementing the functional tests. Two levels are provided:
+
+## 1. Micro-benchmark (framework overhead)
+
+`benches/sync_vs_async_microbench.rs` measures per-operation latency of
+`PassthroughFs` through the synchronous `FileSystem` interface versus the
+delegated `AsyncFileSystem` interface, without the kernel fuse transport in
+the loop.
+
+Covered operations: `lookup`, `getattr`, `open+read(4KB)+release`,
+`open+write(4KB)+release`, `create+release+unlink`.
+
+```sh
+cd tests/benchmark
+cargo bench
+```
+
+Note that the async numbers include the runtime dispatch cost
+(`Runtime::block_on()` per operation). These numbers quantify the overhead
+of delegation itself; they do not predict end-to-end throughput, because the
+fuse transport and request concurrency dominate there.
+
+## 2. End-to-end comparison with fio
+
+`tests/scripts/bench_sync_async.sh` mounts the `fuse-backend-rs-benchmark`
+daemon twice — once in sync mode (N worker threads, one fuse channel each)
+and once in async mode (a single `FuseDevTask` driven by the async runtime,
+tokio-uring when io_uring is available) — and runs identical fio workloads:
+
+- sequential read/write with 1MB requests
+- random read/write with 4KB requests
+- metadata operations (file create/delete)
+
+```sh
+sudo tests/scripts/bench_sync_async.sh      # needs fio + fuse mount rights
+THREADS=8 RUNTIME=60 sudo -E tests/scripts/bench_sync_async.sh
+```
+
+The script builds the daemon in release mode; when invoking it with `sudo`,
+build once as a regular user first (`cd tests/benchmark && cargo build
+--release`) to avoid root-owned artifacts in the workspace `target/`
+directory.
+
+Raw fio output is written to a temporary results directory (printed at the
+start), and a side-by-side summary is printed at the end. The default
+execution order is sync then async; the second mode benefits from a warmer
+page cache, so cross-check with `MODES="async sync"`.
+
+## Interpretation
+
+The async path currently delegates all operations to the synchronous
+handlers and processes requests sequentially with a single task/buffer,
+while the sync path serves requests from multiple worker threads. Expect
+the async mode to be competitive on single-stream latency but behind the
+sync mode on highly concurrent workloads; a native io_uring hot path is
+tracked as follow-up work (#188).
+
+## Limitations
+
+- Linux only: the `async-io` feature depends on io-uring/tokio.
+- The benchmark daemon disables `no_open`/`no_opendir` to exercise the
+  full open/handle paths.

--- a/tests/benchmark/benches/sync_vs_async_microbench.rs
+++ b/tests/benchmark/benches/sync_vs_async_microbench.rs
@@ -1,0 +1,386 @@
+// Copyright 2026 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Micro-benchmarks comparing the synchronous `FileSystem` interface with
+//! the delegated `AsyncFileSystem` interface of `PassthroughFs`.
+//!
+//! These numbers quantify the framework overhead of the async path
+//! (runtime dispatch + delegation) on a per-operation basis, without the
+//! kernel fuse transport in the loop. For end-to-end numbers including the
+//! fuse transport, use the fio-based comparison in
+//! `tests/scripts/bench_sync_async.sh`.
+//!
+//! Run with: `cargo bench` from this directory (Linux only).
+
+use std::ffi::CString;
+use std::io;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use vmm_sys_util::tempdir::TempDir;
+
+use fuse_backend_rs::abi::fuse_abi::{CreateIn, ROOT_ID};
+use fuse_backend_rs::api::filesystem::{
+    AsyncFileSystem, AsyncZeroCopyReader, AsyncZeroCopyWriter, Context, FileSystem, FsOptions,
+    ZeroCopyReader, ZeroCopyWriter,
+};
+use fuse_backend_rs::async_runtime::Runtime;
+use fuse_backend_rs::file_buf::FileVolatileSlice;
+use fuse_backend_rs::file_traits::{AsyncFileReadWriteVolatile, FileReadWriteVolatile};
+use fuse_backend_rs::passthrough::{Config, PassthroughFs};
+
+const DATA_SIZE: u32 = 4096;
+const TEST_FILE: &str = "benchfile";
+
+/// An in-memory sink implementing `ZeroCopyWriter`/`AsyncZeroCopyWriter`,
+/// to receive data from `read()`/`async_read()`.
+struct MemWriter(Vec<u8>);
+
+impl MemWriter {
+    fn new() -> Self {
+        MemWriter(Vec::new())
+    }
+}
+
+impl io::Write for MemWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl ZeroCopyWriter for MemWriter {
+    fn write_from(
+        &mut self,
+        f: &mut dyn FileReadWriteVolatile,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        if self.0.len() < count {
+            self.0.resize(count, 0);
+        }
+        // Safe because the slice points into `self.0` and doesn't out-live it.
+        // The file offset only selects the read position within `f`; received
+        // data is always placed at the start of the buffer.
+        let slice = unsafe { FileVolatileSlice::from_raw_ptr(self.0.as_mut_ptr(), count) };
+        f.read_at_volatile(slice, off)
+    }
+
+    fn available_bytes(&self) -> usize {
+        usize::MAX
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AsyncZeroCopyWriter for MemWriter {
+    async fn async_write_from(
+        &mut self,
+        _f: Arc<dyn AsyncFileReadWriteVolatile>,
+        _count: usize,
+        _off: u64,
+    ) -> io::Result<usize> {
+        unreachable!("the synchronous delegation never uses the async zero-copy path")
+    }
+}
+
+/// An in-memory source implementing `ZeroCopyReader`/`AsyncZeroCopyReader`,
+/// to provide data to `write()`/`async_write()`.
+struct MemReader(Vec<u8>);
+
+impl io::Read for MemReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = std::cmp::min(buf.len(), self.0.len());
+        buf[..n].copy_from_slice(&self.0[..n]);
+        self.0.drain(..n);
+        Ok(n)
+    }
+}
+
+impl ZeroCopyReader for MemReader {
+    fn read_to(
+        &mut self,
+        f: &mut dyn FileReadWriteVolatile,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        let start = off as usize;
+        if start >= self.0.len() {
+            return Ok(0);
+        }
+        let n = std::cmp::min(count, self.0.len() - start);
+        // Safe because the buffer is only read from and the slice doesn't
+        // out-live `self.0`.
+        let slice =
+            unsafe { FileVolatileSlice::from_raw_ptr(self.0.as_ptr().add(start) as *mut u8, n) };
+        f.write_at_volatile(slice, off)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl AsyncZeroCopyReader for MemReader {
+    async fn async_read_to(
+        &mut self,
+        _f: Arc<dyn AsyncFileReadWriteVolatile>,
+        _count: usize,
+        _off: u64,
+    ) -> io::Result<usize> {
+        unreachable!("the synchronous delegation never uses the async zero-copy path")
+    }
+}
+
+/// Create a `PassthroughFs` backed by a fresh temporary directory holding a
+/// single `DATA_SIZE`-byte file.
+fn prepare_fs() -> (PassthroughFs<()>, TempDir) {
+    let source = TempDir::new().unwrap();
+    std::fs::write(
+        source.as_path().join(TEST_FILE),
+        vec![0xa5u8; DATA_SIZE as usize],
+    )
+    .unwrap();
+
+    let cfg = Config {
+        root_dir: source.as_path().to_str().unwrap().to_string(),
+        do_import: true,
+        ..Default::default()
+    };
+    let fs = PassthroughFs::<()>::new(cfg).unwrap();
+    fs.import().unwrap();
+    fs.init(FsOptions::all()).unwrap();
+    (fs, source)
+}
+
+fn prepare_context() -> Context {
+    Context {
+        uid: unsafe { libc::getuid() },
+        gid: unsafe { libc::getgid() },
+        pid: unsafe { libc::getpid() },
+    }
+}
+
+fn bench_lookup_getattr(c: &mut Criterion) {
+    let (fs, _source) = prepare_fs();
+    let ctx = prepare_context();
+    let name = CString::new(TEST_FILE).unwrap();
+    let rt = Runtime::new();
+
+    c.bench_function("lookup+forget/sync", |b| {
+        b.iter(|| {
+            let entry = fs.lookup(&ctx, ROOT_ID, &name).unwrap();
+            fs.forget(&ctx, entry.inode, 1);
+        })
+    });
+    c.bench_function("lookup+forget/async", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let entry = fs.async_lookup(&ctx, ROOT_ID, &name).await.unwrap();
+                fs.forget(&ctx, entry.inode, 1);
+            });
+        })
+    });
+
+    // Lookup once and benchmark getattr on the resulting inode.
+    let entry = fs.lookup(&ctx, ROOT_ID, &name).unwrap();
+    let inode = entry.inode;
+    c.bench_function("getattr/sync", |b| {
+        b.iter(|| fs.getattr(&ctx, inode, None).unwrap())
+    });
+    c.bench_function("getattr/async", |b| {
+        b.iter(|| rt.block_on(fs.async_getattr(&ctx, inode, None)).unwrap())
+    });
+    fs.forget(&ctx, inode, 1);
+}
+
+fn bench_read(c: &mut Criterion) {
+    let (fs, _source) = prepare_fs();
+    let ctx = prepare_context();
+    let name = CString::new(TEST_FILE).unwrap();
+    let rt = Runtime::new();
+
+    let entry = fs.lookup(&ctx, ROOT_ID, &name).unwrap();
+    let inode = entry.inode;
+    let mut w = MemWriter::new();
+
+    c.bench_function("open+read4k+release/sync", |b| {
+        b.iter(|| {
+            let (handle, _opts, _) = fs.open(&ctx, inode, libc::O_RDONLY as u32, 0).unwrap();
+            let handle = handle.unwrap();
+            fs.read(
+                &ctx,
+                inode,
+                handle,
+                &mut w,
+                DATA_SIZE,
+                0,
+                None,
+                libc::O_RDONLY as u32,
+            )
+            .unwrap();
+            fs.release(
+                &ctx,
+                inode,
+                libc::O_RDONLY as u32,
+                handle,
+                false,
+                false,
+                None,
+            )
+            .unwrap();
+        })
+    });
+    c.bench_function("open+read4k+release/async", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let (handle, _opts) = fs
+                    .async_open(&ctx, inode, libc::O_RDONLY as u32, 0)
+                    .await
+                    .unwrap();
+                let handle = handle.unwrap();
+                fs.async_read(
+                    &ctx,
+                    inode,
+                    handle,
+                    &mut w,
+                    DATA_SIZE,
+                    0,
+                    None,
+                    libc::O_RDONLY as u32,
+                )
+                .await
+                .unwrap();
+                fs.release(
+                    &ctx,
+                    inode,
+                    libc::O_RDONLY as u32,
+                    handle,
+                    false,
+                    false,
+                    None,
+                )
+                .unwrap();
+            });
+        })
+    });
+    fs.forget(&ctx, inode, 1);
+}
+
+fn bench_write(c: &mut Criterion) {
+    let (fs, _source) = prepare_fs();
+    let ctx = prepare_context();
+    let name = CString::new(TEST_FILE).unwrap();
+    let rt = Runtime::new();
+
+    let entry = fs.lookup(&ctx, ROOT_ID, &name).unwrap();
+    let inode = entry.inode;
+
+    c.bench_function("open+write4k+release/sync", |b| {
+        b.iter_batched(
+            || MemReader(vec![0x5au8; DATA_SIZE as usize]),
+            |mut r| {
+                let (handle, _opts, _) = fs.open(&ctx, inode, libc::O_RDWR as u32, 0).unwrap();
+                let handle = handle.unwrap();
+                fs.write(
+                    &ctx,
+                    inode,
+                    handle,
+                    &mut r,
+                    DATA_SIZE,
+                    0,
+                    None,
+                    false,
+                    libc::O_RDWR as u32,
+                    0,
+                )
+                .unwrap();
+                fs.release(&ctx, inode, libc::O_RDWR as u32, handle, false, false, None)
+                    .unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    c.bench_function("open+write4k+release/async", |b| {
+        b.iter_batched(
+            || MemReader(vec![0x5au8; DATA_SIZE as usize]),
+            |mut r| {
+                rt.block_on(async {
+                    let (handle, _opts) = fs
+                        .async_open(&ctx, inode, libc::O_RDWR as u32, 0)
+                        .await
+                        .unwrap();
+                    let handle = handle.unwrap();
+                    fs.async_write(
+                        &ctx,
+                        inode,
+                        handle,
+                        &mut r,
+                        DATA_SIZE,
+                        0,
+                        None,
+                        false,
+                        libc::O_RDWR as u32,
+                        0,
+                    )
+                    .await
+                    .unwrap();
+                    fs.release(&ctx, inode, libc::O_RDWR as u32, handle, false, false, None)
+                        .unwrap();
+                });
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    fs.forget(&ctx, inode, 1);
+}
+
+fn bench_create_unlink(c: &mut Criterion) {
+    let (fs, _source) = prepare_fs();
+    let ctx = prepare_context();
+    let name = CString::new("benchtmp").unwrap();
+    let args = CreateIn {
+        flags: (libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32,
+        mode: 0o644,
+        umask: 0,
+        fuse_flags: 0,
+    };
+    let rt = Runtime::new();
+
+    c.bench_function("create+release+unlink/sync", |b| {
+        b.iter(|| {
+            let (entry, handle, _opts, _) = fs.create(&ctx, ROOT_ID, &name, args).unwrap();
+            if let Some(handle) = handle {
+                fs.release(&ctx, entry.inode, args.flags, handle, false, false, None)
+                    .unwrap();
+            }
+            fs.forget(&ctx, entry.inode, 1);
+            fs.unlink(&ctx, ROOT_ID, &name).unwrap();
+        })
+    });
+    c.bench_function("create+release+unlink/async", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let (entry, handle, _opts) =
+                    fs.async_create(&ctx, ROOT_ID, &name, args).await.unwrap();
+                if let Some(handle) = handle {
+                    fs.release(&ctx, entry.inode, args.flags, handle, false, false, None)
+                        .unwrap();
+                }
+                fs.forget(&ctx, entry.inode, 1);
+                fs.unlink(&ctx, ROOT_ID, &name).unwrap();
+            });
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_lookup_getattr,
+    bench_read,
+    bench_write,
+    bench_create_unlink,
+);
+criterion_main!(benches);

--- a/tests/benchmark/src/main.rs
+++ b/tests/benchmark/src/main.rs
@@ -1,0 +1,266 @@
+// Copyright 2026 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A minimal fusedev passthrough daemon used to benchmark the synchronous
+//! and asynchronous IO paths with external tools such as fio.
+//!
+//! Usage: `fuse-backend-rs-benchmark <src> <mountpoint> [--async] [--threads N]`
+//!
+//! - default (sync) mode: requests are served by `N` worker threads, each
+//!   reading from its own fuse channel (the classic multi-threaded design).
+//! - `--async` mode: requests are served by a single `FuseDevTask` running
+//!   on the async runtime (tokio-uring when io_uring is available).
+
+#[cfg(target_os = "linux")]
+mod daemon {
+    use std::env;
+    use std::fs;
+    use std::io::{Error, Result};
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+
+    use log::{error, info, warn, LevelFilter};
+    use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
+    use simple_logger::SimpleLogger;
+
+    use fuse_backend_rs::api::{
+        server::{Server, MAX_BUFFER_SIZE},
+        Vfs, VfsOptions,
+    };
+    use fuse_backend_rs::async_runtime::Runtime;
+    use fuse_backend_rs::passthrough::{Config, PassthroughFs};
+    use fuse_backend_rs::transport::{FuseChannel, FuseDevTask, FuseSession};
+
+    struct Args {
+        src: String,
+        dest: String,
+        as_async: bool,
+        thread_cnt: u32,
+        threads_set: bool,
+    }
+
+    fn help() {
+        println!(
+            "Usage:\n   fuse-backend-rs-benchmark <src> <mountpoint> [--async] [--threads N]\n"
+        );
+    }
+
+    fn parse_args() -> Result<Args> {
+        let args = env::args().collect::<Vec<String>>();
+        if args.len() < 3 {
+            help();
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+        let mut res = Args {
+            src: args[1].clone(),
+            dest: args[2].clone(),
+            as_async: false,
+            thread_cnt: 4,
+            threads_set: false,
+        };
+        let mut idx = 3;
+        while idx < args.len() {
+            match args[idx].as_str() {
+                "--async" => res.as_async = true,
+                "--threads" => {
+                    idx += 1;
+                    if idx >= args.len() {
+                        help();
+                        return Err(Error::from_raw_os_error(libc::EINVAL));
+                    }
+                    res.thread_cnt = args[idx].parse().map_err(|_| {
+                        help();
+                        Error::from_raw_os_error(libc::EINVAL)
+                    })?;
+                    res.threads_set = true;
+                }
+                _ => {
+                    help();
+                    return Err(Error::from_raw_os_error(libc::EINVAL));
+                }
+            }
+            idx += 1;
+        }
+        if res.src.is_empty() || res.dest.is_empty() || res.thread_cnt == 0 {
+            help();
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(res)
+    }
+
+    fn create_server(src: &str) -> Arc<Server<Arc<Vfs>>> {
+        let vfs = Vfs::new(VfsOptions {
+            no_open: false,
+            no_opendir: false,
+            ..Default::default()
+        });
+
+        let cfg = Config {
+            root_dir: src.to_string(),
+            do_import: false,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(cfg).unwrap();
+        fs.import().unwrap();
+
+        vfs.mount(Box::new(fs), "/").unwrap();
+        Arc::new(Server::new(Arc::new(vfs)))
+    }
+
+    struct FuseServer {
+        server: Arc<Server<Arc<Vfs>>>,
+        ch: FuseChannel,
+    }
+
+    impl FuseServer {
+        fn svc_loop(&mut self) -> Result<()> {
+            // Given error EBADF, it means kernel has shut down this session.
+            let _ebadf = std::io::Error::from_raw_os_error(libc::EBADF);
+            loop {
+                if let Some((reader, writer)) = self
+                    .ch
+                    .get_request()
+                    .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?
+                {
+                    if let Err(e) = self
+                        .server
+                        .handle_message(reader, writer.into(), None, None)
+                    {
+                        match e {
+                            fuse_backend_rs::Error::EncodeMessage(_ebadf) => {
+                                break;
+                            }
+                            _ => {
+                                error!("Handling fuse message failed");
+                                continue;
+                            }
+                        }
+                    }
+                } else {
+                    info!("fuse server exits");
+                    break;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Serve requests with `thread_cnt` synchronous worker threads until a
+    /// termination signal is received.
+    fn run_sync(server: Arc<Server<Arc<Vfs>>>, mut se: FuseSession, thread_cnt: u32) {
+        for _ in 0..thread_cnt {
+            let mut worker = FuseServer {
+                server: server.clone(),
+                ch: se.new_channel().unwrap(),
+            };
+            thread::Builder::new()
+                .name("fuse_server".to_string())
+                .spawn(move || {
+                    let _ = worker.svc_loop();
+                    warn!("fuse service thread exits");
+                })
+                .unwrap();
+        }
+
+        let mut signals = Signals::new(TERM_SIGNALS).unwrap();
+        signals.forever().next();
+        se.umount().unwrap();
+        se.wake().unwrap();
+    }
+
+    /// Serve requests with a single asynchronous `FuseDevTask` until a
+    /// termination signal is received.
+    fn run_async(server: Arc<Server<Arc<Vfs>>>, mut se: FuseSession) {
+        let fuse_file = se.clone_fuse_file().unwrap();
+
+        // The signal handler thread tears the session down: umounting makes
+        // the pending read on the fuse device fail with ENODEV, which
+        // terminates the async task. The thread is detached on purpose:
+        // poll_handler() may return without a signal (e.g. the session is
+        // unmounted externally) while the thread is still waiting for one.
+        let _shutdown = thread::spawn(move || {
+            let mut signals = Signals::new(TERM_SIGNALS).unwrap();
+            signals.forever().next();
+            if let Err(e) = se.umount() {
+                error!("failed to umount fuse session: {}", e);
+            }
+        });
+
+        let state = Arc::new(AtomicBool::new(false));
+        // The buffer must be able to hold the largest request (the
+        // negotiated `max_write` plus a header), otherwise reads from
+        // /dev/fuse fail with EINVAL once the INIT handshake is done,
+        // see kernel commit "fuse: require /dev/fuse reads to have
+        // enough buffer capacity".
+        let mut task = FuseDevTask::new(
+            (MAX_BUFFER_SIZE + 0x1000) as usize,
+            fuse_file,
+            server,
+            state.clone(),
+        );
+        Runtime::new().block_on(task.poll_handler());
+        info!("async fuse task exited");
+
+        state.store(true, Ordering::Release);
+    }
+
+    pub fn main() -> Result<()> {
+        SimpleLogger::new()
+            .with_level(LevelFilter::Info)
+            .init()
+            .unwrap();
+        let args = parse_args()?;
+
+        for dir in [&args.src, &args.dest] {
+            let path = Path::new(dir);
+            if path.exists() {
+                if !path.is_dir() {
+                    error!("{} is not a directory", dir);
+                    return Err(Error::from_raw_os_error(libc::EINVAL));
+                }
+            } else {
+                fs::create_dir_all(path)?;
+            }
+        }
+        info!(
+            "passthrough src {} mountpoint {} mode {} threads {}",
+            args.src,
+            args.dest,
+            if args.as_async { "async" } else { "sync" },
+            args.thread_cnt,
+        );
+
+        let server = create_server(&args.src);
+        let mut se = FuseSession::new(Path::new(&args.dest), "bench_passthru", "", false).unwrap();
+        se.mount().unwrap();
+
+        if args.as_async && args.threads_set {
+            warn!(
+                "--threads {} is ignored in async mode, requests are served by a single task",
+                args.thread_cnt
+            );
+        }
+
+        if args.as_async {
+            run_async(server, se);
+        } else {
+            run_sync(server, se, args.thread_cnt);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn main() -> std::io::Result<()> {
+    daemon::main()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("the benchmark daemon only works on Linux");
+}

--- a/tests/scripts/bench_sync_async.sh
+++ b/tests/scripts/bench_sync_async.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Copyright 2026 Alibaba Cloud. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Compare the synchronous and asynchronous fusedev IO paths of
+# fuse-backend-rs using fio.
+#
+# For each mode (sync: N worker threads, async: one FuseDevTask on the
+# async runtime), the script mounts the benchmark daemon and runs the same
+# fio workloads against the mountpoint. Raw fio output is stored under
+# $RESULTS_DIR for further analysis.
+#
+# Requirements: Linux, fio, permission to mount fuse (root or fusermount).
+#
+# Tunables (environment variables):
+#   THREADS  number of sync worker threads / fio jobs (default 4)
+#   SIZE     file size for the sequential workloads (default 256M)
+#   RUNTIME  seconds per time-based workload (default 30)
+#   NRFILES  number of files for the metadata workloads (default 10000)
+#   MODES    execution order of the modes (default "sync async"); the
+#            second mode benefits from a warmer page cache, so run both
+#            orders to cross-check the results
+#   RESULTS_DIR where to store results (default a fresh mktemp directory)
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+BENCH_DIR="${REPO_DIR}/tests/benchmark"
+# tests/benchmark is a member of the root workspace, so build artifacts
+# land in the workspace target directory, not under tests/benchmark.
+DAEMON="${REPO_DIR}/target/release/fuse-backend-rs-benchmark"
+
+THREADS=${THREADS:-4}
+SIZE=${SIZE:-256M}
+RUNTIME=${RUNTIME:-30}
+NRFILES=${NRFILES:-10000}
+MODES=${MODES:-"sync async"}
+RESULTS_DIR=${RESULTS_DIR:-$(mktemp -d /tmp/fuse-bench-results.XXXXXX)}
+SRC_DIR="${RESULTS_DIR}/source"
+MNT_DIR="${RESULTS_DIR}/mount"
+mkdir -p "${SRC_DIR}" "${MNT_DIR}"
+
+command -v fio >/dev/null 2>&1 || { echo "error: fio is required" >&2; exit 1; }
+
+echo "results directory: ${RESULTS_DIR}"
+
+# Build the benchmark daemon in release mode.
+(cd "${BENCH_DIR}" && cargo build --release)
+
+DAEMON_PID=
+cleanup() {
+    if [ -n "${DAEMON_PID}" ]; then
+        kill -TERM "${DAEMON_PID}" 2>/dev/null || true
+        wait "${DAEMON_PID}" 2>/dev/null || true
+    fi
+    umount "${MNT_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+start_daemon() {
+    local mode_args=$1
+    # shellcheck disable=SC2086
+    "${DAEMON}" "${SRC_DIR}" "${MNT_DIR}" ${mode_args} --threads "${THREADS}" &
+    DAEMON_PID=$!
+    for _ in $(seq 50); do
+        if mountpoint -q "${MNT_DIR}"; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    echo "error: daemon did not mount ${MNT_DIR}" >&2
+    exit 1
+}
+
+stop_daemon() {
+    kill -TERM "${DAEMON_PID}" 2>/dev/null || true
+    wait "${DAEMON_PID}" 2>/dev/null || true
+    DAEMON_PID=
+    sleep 1
+}
+
+# run_workload <mode> <name> <fio args...>
+# Runs a time-based workload for ${RUNTIME} seconds.
+run_workload() {
+    local mode=$1
+    local name=$2
+    shift 2
+    echo "--- [${mode}] ${name}: $*"
+    fio --name="${name}" --directory="${MNT_DIR}" --group_reporting \
+        --time_based --runtime="${RUNTIME}" "$@" \
+        >"${RESULTS_DIR}/${mode}-${name}.out" 2>&1 || {
+            echo "error: fio workload ${name} failed, see ${RESULTS_DIR}/${mode}-${name}.out" >&2
+            exit 1
+        }
+    grep -E "^  (read|write):" "${RESULTS_DIR}/${mode}-${name}.out" || true
+}
+
+# run_fixed_workload <mode> <name> <fio args...>
+# Runs a workload for a fixed amount of work instead of ${RUNTIME} seconds.
+# The filecreate/filedelete engines cannot be restarted by --time_based:
+# filedelete hits ENOENT on the second round because the files created in
+# the first round have already been deleted.
+run_fixed_workload() {
+    local mode=$1
+    local name=$2
+    shift 2
+    echo "--- [${mode}] ${name}: $*"
+    fio --name="${name}" --directory="${MNT_DIR}" --group_reporting "$@" \
+        >"${RESULTS_DIR}/${mode}-${name}.out" 2>&1 || {
+            echo "error: fio workload ${name} failed, see ${RESULTS_DIR}/${mode}-${name}.out" >&2
+            exit 1
+        }
+    grep -E "^  (read|write):" "${RESULTS_DIR}/${mode}-${name}.out" || true
+}
+
+# shellcheck disable=SC2086
+for mode in ${MODES}; do
+    mode_args=""
+    [ "${mode}" = "async" ] && mode_args="--async"
+
+    echo ""
+    echo "############ mode: ${mode} ############"
+    start_daemon "${mode_args}"
+
+    # Sequential IO with large requests (throughput oriented).
+    run_workload "${mode}" seqwrite --rw=write --bs=1M --size="${SIZE}" \
+        --numjobs="${THREADS}" --ioengine=psync
+    run_workload "${mode}" seqread --rw=read --bs=1M --size="${SIZE}" \
+        --numjobs="${THREADS}" --ioengine=psync
+
+    # Random IO with small requests (latency/metadata oriented).
+    run_workload "${mode}" randwrite-4k --rw=randwrite --bs=4k --size=64M \
+        --numjobs="${THREADS}" --ioengine=psync
+    run_workload "${mode}" randread-4k --rw=randread --bs=4k --size=64M \
+        --numjobs="${THREADS}" --ioengine=psync
+
+    # Metadata operations: create and delete lots of small files. These run
+    # for a fixed number of files instead of ${RUNTIME} seconds, see
+    # run_fixed_workload().
+    run_fixed_workload "${mode}" filecreate --ioengine=filecreate \
+        --nrfiles="${NRFILES}" --numjobs=1 --filesize=4K
+    run_fixed_workload "${mode}" filedelete --ioengine=filedelete \
+        --nrfiles="${NRFILES}" --numjobs=1 --filesize=4K
+
+    stop_daemon
+done
+
+# Print a side-by-side summary of the collected results.
+echo ""
+echo "############ summary ############"
+printf "%-32s %-24s %-24s\n" "workload" "sync" "async"
+for f in "${RESULTS_DIR}"/sync-*.out; do
+    name=$(basename "${f}" .out)
+    name=${name#sync-}
+    sync_line=$(grep -E "^  (read|write):" "${f}" | head -1 | sed 's/^ *//')
+    async_line=$(grep -E "^  (read|write):" "${RESULTS_DIR}/async-${name}.out" 2>/dev/null | head -1 | sed 's/^ *//')
+    printf "%-32s %-24s %-24s\n" "${name}" "${sync_line:-n/a}" "${async_line:-n/a}"
+done
+echo ""
+echo "full fio output: ${RESULTS_DIR}"


### PR DESCRIPTION
## Context

Follow-up work for the async-io roadmap (#188): the async serving path is
evolving step by step (multi-task transport, spawn_blocking offloading,
native async handlers), and we need a repeatable way to measure how each
change affects performance relative to the synchronous path — both locally
and on every pull request.

## What's included

### 1. Benchmark crate (`tests/benchmark`, commit 1/3)

A standalone workspace member (like `tests/passthrough`, keeping criterion
out of the main crate's dependency tree) providing:

- a minimal fusedev passthrough daemon serving requests either with
  multiple synchronous worker threads (default) or with a single
  asynchronous `FuseDevTask` (`--async`), for use with external tools
  such as fio;
- a criterion micro-benchmark comparing per-operation latency of the
  synchronous `FileSystem` interface against the delegated
  `AsyncFileSystem` interface (lookup, getattr, open+read+release,
  open+write+release, create+unlink).

### 2. End-to-end fio comparison script (commit 2/3)

`tests/scripts/bench_sync_async.sh` mounts the daemon in both modes and
runs identical workloads against each mount: sequential 1MB read/write,
random 4KB read/write, and file create/delete. fio results are stored in
JSON format (one file per mode and workload) for tooling consumption, and
a side-by-side summary is printed at the end. `tests/benchmark/README.md`
documents usage and how to interpret the numbers.

### 3. Per-PR benchmark CI pipeline (commit 3/3)

A `Benchmark` workflow running the fio comparison for a matrix of
sync/async modes and 1/8 threads on GitHub-hosted runners:

- Adding the `run-benchmark` label to a PR triggers a benchmark run; the
  results are compared against the baseline recorded on the `bench-results`
  branch and the comparison table is written to the job summary.
- Pushes to master update the baseline (orphan branch `bench-results`,
  auto-created on first run).
- `tests/scripts/bench_compare.py` normalizes the fio JSON results and
  prints the markdown comparison; regressions beyond the threshold (10%
  by default) are flagged but never fail the workflow.

## Notes

- Linux only, like the `async-io` feature itself.
- GitHub-hosted runners are shared VMs with significant noise, so the CI
  comparison is advisory and never blocks merging; flagged regressions
  should be re-checked on bare metal. A dedicated runner can be adopted
  later by changing the workflow's `runs-on` value.
- No changes to library code; all additions are under `tests/` and
  `.github/`.

## Testing done

- `bash -n` on the script; jq extraction and `bench_compare.py`
  collect/compare verified end-to-end against sample fio JSON output
  (regression flagging at -25%, no false positives at +4%).
- Workflow YAML validated; end-to-end fio runs to be exercised on the
  first CI run after merge.
- Local full runs on bare metal: `THREADS=8 RUNTIME=60 sudo -E
  tests/scripts/bench_sync_async.sh`.

Related-to: #188