### PR TITLE
ci: benchmark pull requests against the master baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,162 @@
+# Benchmark the synchronous and asynchronous fusedev IO paths and compare
+# the results against the baseline recorded on the bench-results branch.
+#
+# Triggers:
+#   - pull requests: add the "run-benchmark" label to benchmark the PR.
+#     The report is written to the job summary of this workflow run.
+#   - pushes to master: the results become the new baseline, committed to
+#     the orphan branch bench-results (results/<mode>-<threads>threads.json).
+#   - workflow_dispatch: re-baseline manually; only dispatches from master
+#     update the baseline.
+#
+# Note that GitHub-hosted runners are shared VMs, so results are noisy.
+# The comparison is advisory and never fails the workflow; significant
+# regressions must be re-checked on bare metal.
+
+name: Benchmark
+
+on:
+  pull_request:
+    types: [labeled]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  bench:
+    if: github.event_name != 'pull_request' || github.event.label.name == 'run-benchmark'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        threads: [1, 8]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v2.2.0
+      with:
+        cache-on-failure: true
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install tools
+      run: |
+        if ! command -v fio >/dev/null || ! command -v jq >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y fio jq
+        fi
+
+    - name: Run benchmark
+      run: |
+        echo user_allow_other | sudo tee --append /etc/fuse.conf
+        mkdir -p "${GITHUB_WORKSPACE}/bench-results"
+        CARGO_HOME=${HOME}/.cargo
+        CARGO_BIN=$(which cargo)
+        sudo -E PATH="$(dirname "${CARGO_BIN}"):${PATH}" CARGO_HOME="${CARGO_HOME}" \
+            THREADS=${{ matrix.threads }} RUNTIME=30 MODES="sync async" \
+            RESULTS_DIR="${GITHUB_WORKSPACE}/bench-results" \
+            tests/scripts/bench_sync_async.sh
+        sudo chown -R $(id -u):$(id -g) "${HOME}/.cargo"
+
+    - name: Collect results
+      run: |
+        for mode in sync async; do
+            python3 tests/scripts/bench_compare.py collect \
+                "${GITHUB_WORKSPACE}/bench-results" "${mode}" \
+                "${GITHUB_WORKSPACE}/${mode}-${{ matrix.threads }}threads.json"
+        done
+
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: bench-${{ matrix.threads }}threads
+        path: |
+          sync-${{ matrix.threads }}threads.json
+          async-${{ matrix.threads }}threads.json
+
+  report:
+    needs: bench
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download results
+      uses: actions/download-artifact@v4
+      with:
+        pattern: bench-*threads
+        path: results
+
+    - name: Merge results
+      run: |
+        mkdir -p merged
+        for mode in sync async; do
+            for threads in 1 8; do
+                # Flatten the per-artifact directories into a single
+                # results/<mode>-<threads>threads.json layout.
+                cp "results/bench-${threads}threads/${mode}-${threads}threads.json" \
+                    "merged/${mode}-${threads}threads.json"
+            done
+        done
+
+    - name: Compare with baseline
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      run: |
+        if ! git ls-remote --exit-code --heads origin bench-results >/dev/null; then
+            echo "No baseline on the bench-results branch yet, skipping comparison." | tee -a "${GITHUB_STEP_SUMMARY}"
+            exit 0
+        fi
+        git fetch origin bench-results
+        git checkout -q FETCH_HEAD -- results || true
+        {
+            echo "## Benchmark results vs master baseline"
+            echo ""
+            for mode in sync async; do
+                for threads in 1 8; do
+                    baseline="results/${mode}-${threads}threads.json"
+                    if [ -f "${baseline}" ]; then
+                        python3 tests/scripts/bench_compare.py compare \
+                            "${baseline}" "merged/${mode}-${threads}threads.json"
+                    else
+                        echo "No baseline for ${mode} with ${threads} thread(s)."
+                        echo ""
+                    fi
+                done
+            done
+            echo "Regressions beyond the threshold (10%) are advisory: GitHub-hosted runners are noisy."
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: Update baseline
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        if git ls-remote --exit-code --heads origin bench-results >/dev/null; then
+            git fetch origin bench-results
+            git checkout -q -B bench-results FETCH_HEAD
+        else
+            git checkout -q --orphan bench-results
+            git rm -rfq .
+        fi
+        rm -rf results
+        mkdir -p results
+        cp merged/*.json results/
+        git add results/*.json
+        git commit -m "benchmark: update baseline
+
+Source: ${GITHUB_SHA}
+
+Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        git push origin bench-results

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -44,10 +44,42 @@ build once as a regular user first (`cd tests/benchmark && cargo build
 --release`) to avoid root-owned artifacts in the workspace `target/`
 directory.
 
-Raw fio output is written to a temporary results directory (printed at the
-start), and a side-by-side summary is printed at the end. The default
-execution order is sync then async; the second mode benefits from a warmer
-page cache, so cross-check with `MODES="async sync"`.
+The fio results are written in JSON format to a temporary results directory
+(printed at the start, `<dir>/<mode>-<workload>.json`), and a side-by-side
+summary is printed at the end. The default execution order is sync then
+async; the second mode benefits from a warmer page cache, so cross-check
+with `MODES="async sync"`.
+
+## 3. Continuous benchmarking in CI
+
+The `Benchmark` workflow (`.github/workflows/benchmark.yml`) runs the fio
+comparison on GitHub-hosted runners for a matrix of sync/async modes and
+1/8 threads:
+
+- Pull requests: add the `run-benchmark` label to trigger a benchmark run.
+  The results are compared against the baseline recorded on the
+  `bench-results` branch, and the comparison table is written to the job
+  summary of the workflow run (Actions tab).
+- Pushes to master: the results become the new baseline and are committed
+  to the orphan branch `bench-results`
+  (`results/<mode>-<threads>threads.json`).
+- Manual re-baselining: trigger the workflow via `workflow_dispatch` from
+  master, e.g. when the runner image changes.
+
+`tests/scripts/bench_compare.py` normalizes the fio JSON files
+(`collect`) and prints the markdown comparison table (`compare`); it can
+also be used to compare two local runs:
+
+```sh
+python3 tests/scripts/bench_compare.py collect /tmp/run1 sync run1-sync.json
+python3 tests/scripts/bench_compare.py compare base.json run1-sync.json
+```
+
+Note that GitHub-hosted runners are shared VMs with significant noise, so
+the comparison is advisory and never blocks merging. Regressions beyond
+the threshold (10%) should be re-checked on bare metal before acting on
+them; a dedicated runner may be used later by changing the workflow
+`runs-on` value.
 
 ## Interpretation
 

--- a/tests/scripts/bench_compare.py
+++ b/tests/scripts/bench_compare.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright 2026 Alibaba Cloud. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect and compare fio benchmark results of fuse-backend-rs.
+
+The benchmark script (tests/scripts/bench_sync_async.sh) stores one fio
+JSON file per mode and workload (<results-dir>/<mode>-<workload>.json).
+This tool normalizes those files into a single result file, and compares
+two result files to detect performance changes, e.g. a pull request run
+against the baseline recorded on the bench-results branch.
+
+Usage:
+    bench_compare.py collect <results-dir> <mode> <out.json>
+    bench_compare.py compare <baseline.json> <current.json>
+                             [--threshold PERCENT]
+
+The collected format is:
+    {"<workload>": {"bw_kib": float, "iops": float, "runtime_ms": int}}
+where the metrics are taken from the read side of the fio job if it
+transferred data, otherwise from the write side. `runtime_ms` is only
+meaningful for the fixed-amount workloads (filecreate/filedelete).
+
+`compare` prints a markdown table and always exits with 0: shared CI
+runners are noisy, so the report is advisory and not a merge gate.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def collect(results_dir, mode, out_path):
+    """Normalize the fio JSON files of one mode into a single result file."""
+    prefix = mode + "-"
+    results = {}
+    for name in sorted(os.listdir(results_dir)):
+        if not name.startswith(prefix) or not name.endswith(".json"):
+            continue
+        workload = name[len(prefix):-len(".json")]
+        with open(os.path.join(results_dir, name), encoding="utf-8") as f:
+            data = json.load(f)
+        job = data["jobs"][0]
+        # Pick the side that actually did the work: the data workloads
+        # report on the side selected by --rw, while the filecreate and
+        # filedelete engines are only active on one side too. Fall back
+        # to comparing iops for engines that transfer no data.
+        read, write = job["read"], job["write"]
+
+        def activity(side):
+            return (side["io_bytes"], side["iops"])
+
+        side = read if activity(read) >= activity(write) else write
+        results[workload] = {
+            "bw_kib": side["bw"],
+            "iops": side["iops"],
+            "runtime_ms": side["runtime"],
+        }
+    if not results:
+        raise RuntimeError(
+            "no fio results for mode '%s' in %s" % (mode, results_dir)
+        )
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def delta(base, cur):
+    """Relative change of `cur` against `base`, in percent."""
+    if base == 0:
+        return 0.0
+    return (cur - base) / base * 100.0
+
+
+def fmt(value):
+    if value >= 10000 and value == int(value):
+        return format(int(value), ",")
+    return "%.4g" % value
+
+
+def compare(baseline_path, current_path, threshold):
+    """Print a markdown table comparing two collected result files."""
+    with open(baseline_path, encoding="utf-8") as f:
+        baseline = json.load(f)
+    with open(current_path, encoding="utf-8") as f:
+        current = json.load(f)
+
+    title = os.path.basename(current_path)
+    print("### %s (baseline: %s)" % (title, os.path.basename(baseline_path)))
+    print()
+    print("| workload | metric | baseline | current | delta | |")
+    print("| --- | --- | ---: | ---: | ---: | --- |")
+    for workload in sorted(set(baseline) | set(current)):
+        base = baseline.get(workload)
+        cur = current.get(workload)
+        if base is None or cur is None:
+            print("| %s | - | - | - | - | MISSING |" % workload)
+            continue
+        for metric in ("bw_kib", "iops"):
+            d = delta(base[metric], cur[metric])
+            # For the fixed-amount metadata workloads a lower bandwidth or
+            # IOPS means the same amount of work took longer, which is the
+            # interesting signal; runtime is reported for reference only.
+            flag = "REGRESSION" if d < -threshold else ""
+            label = "BW(KiB/s)" if metric == "bw_kib" else "IOPS"
+            print(
+                "| %s | %s | %s | %s | %+.1f%% | %s |"
+                % (workload, label, fmt(base[metric]), fmt(cur[metric]), d, flag)
+            )
+        if base["runtime_ms"] > 0 and cur["runtime_ms"] > 0:
+            d = delta(base["runtime_ms"], cur["runtime_ms"])
+            print(
+                "| %s | runtime(ms) | %s | %s | %+.1f%% | |"
+                % (workload, fmt(base["runtime_ms"]), fmt(cur["runtime_ms"]), d)
+            )
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_collect = sub.add_parser("collect", help="normalize fio JSON results")
+    p_collect.add_argument("results_dir", help="directory with <mode>-<workload>.json files")
+    p_collect.add_argument("mode", help="mode to collect, e.g. sync or async")
+    p_collect.add_argument("out", help="output file")
+
+    p_compare = sub.add_parser("compare", help="compare two collected result files")
+    p_compare.add_argument("baseline", help="baseline result file")
+    p_compare.add_argument("current", help="result file to evaluate")
+    p_compare.add_argument(
+        "--threshold",
+        type=float,
+        default=10.0,
+        help="flag regressions beyond this percent (default: %(default)s)",
+    )
+
+    args = parser.parse_args()
+    if args.cmd == "collect":
+        collect(args.results_dir, args.mode, args.out)
+    else:
+        compare(args.baseline, args.current, args.threshold)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/bench_sync_async.sh
+++ b/tests/scripts/bench_sync_async.sh
@@ -8,10 +8,12 @@
 #
 # For each mode (sync: N worker threads, async: one FuseDevTask on the
 # async runtime), the script mounts the benchmark daemon and runs the same
-# fio workloads against the mountpoint. Raw fio output is stored under
-# $RESULTS_DIR for further analysis.
+# fio workloads against the mountpoint. The fio results are stored in JSON
+# format ($RESULTS_DIR/<mode>-<workload>.json) under $RESULTS_DIR for
+# further analysis, see tests/scripts/bench_compare.py.
 #
-# Requirements: Linux, fio, permission to mount fuse (root or fusermount).
+# Requirements: Linux, fio, jq, permission to mount fuse (root or
+# fusermount).
 #
 # Tunables (environment variables):
 #   THREADS  number of sync worker threads / fio jobs (default 4)
@@ -43,6 +45,7 @@ MNT_DIR="${RESULTS_DIR}/mount"
 mkdir -p "${SRC_DIR}" "${MNT_DIR}"
 
 command -v fio >/dev/null 2>&1 || { echo "error: fio is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
 
 echo "results directory: ${RESULTS_DIR}"
 
@@ -90,11 +93,18 @@ run_workload() {
     echo "--- [${mode}] ${name}: $*"
     fio --name="${name}" --directory="${MNT_DIR}" --group_reporting \
         --time_based --runtime="${RUNTIME}" "$@" \
-        >"${RESULTS_DIR}/${mode}-${name}.out" 2>&1 || {
-            echo "error: fio workload ${name} failed, see ${RESULTS_DIR}/${mode}-${name}.out" >&2
+        --output-format=json \
+        --output="${RESULTS_DIR}/${mode}-${name}.json" || {
+            echo "error: fio workload ${name} failed" >&2
             exit 1
         }
-    grep -E "^  (read|write):" "${RESULTS_DIR}/${mode}-${name}.out" || true
+    # Select the active side like bench_compare.py does: the data
+    # workloads are active on exactly one side, and the filecreate and
+    # filedelete engines may transfer no data at all, so compare iops.
+    jq -r '.jobs[0] | if .read.iops >= .write.iops
+           then "  read: bw=\(.read.bw)KiB/s iops=\(.read.iops | round)"
+           else "  write: bw=\(.write.bw)KiB/s iops=\(.write.iops | round)"
+           end' "${RESULTS_DIR}/${mode}-${name}.json" || true
 }
 
 # run_fixed_workload <mode> <name> <fio args...>
@@ -108,11 +118,15 @@ run_fixed_workload() {
     shift 2
     echo "--- [${mode}] ${name}: $*"
     fio --name="${name}" --directory="${MNT_DIR}" --group_reporting "$@" \
-        >"${RESULTS_DIR}/${mode}-${name}.out" 2>&1 || {
-            echo "error: fio workload ${name} failed, see ${RESULTS_DIR}/${mode}-${name}.out" >&2
+        --output-format=json \
+        --output="${RESULTS_DIR}/${mode}-${name}.json" || {
+            echo "error: fio workload ${name} failed" >&2
             exit 1
         }
-    grep -E "^  (read|write):" "${RESULTS_DIR}/${mode}-${name}.out" || true
+    jq -r '.jobs[0] | if .read.iops >= .write.iops
+           then "  read: iops=\(.read.iops | round) runtime=\(.read.runtime)ms"
+           else "  write: iops=\(.write.iops | round) runtime=\(.write.runtime)ms"
+           end' "${RESULTS_DIR}/${mode}-${name}.json" || true
 }
 
 # shellcheck disable=SC2086
@@ -148,15 +162,22 @@ for mode in ${MODES}; do
 done
 
 # Print a side-by-side summary of the collected results.
+summarize() {
+    jq -r '.jobs[0] | if .read.iops >= .write.iops
+           then "read: bw=\(.read.bw)KiB/s iops=\(.read.iops | round)"
+           else "write: bw=\(.write.bw)KiB/s iops=\(.write.iops | round)"
+           end' "$1" 2>/dev/null || echo "n/a"
+}
+
 echo ""
 echo "############ summary ############"
-printf "%-32s %-24s %-24s\n" "workload" "sync" "async"
-for f in "${RESULTS_DIR}"/sync-*.out; do
-    name=$(basename "${f}" .out)
+printf "%-32s %-36s %-36s\n" "workload" "sync" "async"
+for f in "${RESULTS_DIR}"/sync-*.json; do
+    name=$(basename "${f}" .json)
     name=${name#sync-}
-    sync_line=$(grep -E "^  (read|write):" "${f}" | head -1 | sed 's/^ *//')
-    async_line=$(grep -E "^  (read|write):" "${RESULTS_DIR}/async-${name}.out" 2>/dev/null | head -1 | sed 's/^ *//')
-    printf "%-32s %-24s %-24s\n" "${name}" "${sync_line:-n/a}" "${async_line:-n/a}"
+    printf "%-32s %-36s %-36s\n" "${name}" \
+        "$(summarize "${f}")" \
+        "$(summarize "${RESULTS_DIR}/async-${name}.json")"
 done
 echo ""
 echo "full fio output: ${RESULTS_DIR}"


### PR DESCRIPTION
## Context

Follow-up to the fio-based sync vs async comparison tooling merged in
#<bench PR 号>. The script now produces machine-readable results; this PR
adds the consumption side: a per-PR benchmark pipeline that records a
master baseline and flags performance regressions, giving the async-io
roadmap (#188) continuous performance visibility.

## Changes

### 1. JSON result format (`tests/scripts/bench_sync_async.sh`)

fio workloads now run with `--output-format=json`, storing one result
file per mode and workload (`<results-dir>/<mode>-<workload>.json`)
instead of human-readable text. The per-workload progress lines and the
final side-by-side summary are extracted from the JSON with jq,
selecting the active read/write side by comparing iops (the data
workloads are active on exactly one side, and the filecreate/filedelete
engines may transfer no data at all).

### 2. Result collector and comparator (`tests/scripts/bench_compare.py`)

- `collect <results-dir> <mode> <out.json>`: normalizes the fio JSON
  files of one mode into `{workload: {bw_kib, iops, runtime_ms}}`.
- `compare <baseline> <current> [--threshold N]`: prints a markdown
  table with per-metric deltas; degradations beyond the threshold
  (default 10%) are flagged `REGRESSION`. Always exits 0 — see Notes.

### 3. Benchmark workflow (`.github/workflows/benchmark.yml`)

Runs the fio comparison for a matrix of 1/8 threads (each job runs
sync then async) on GitHub-hosted runners:

- `run-benchmark` label on a PR triggers a run; the results are
  compared against the baseline and the tables are written to the job
  summary of the workflow run.
- Pushes to master update the baseline by committing the collected
  results to the orphan branch `bench-results`
  (`results/<mode>-<threads>threads.json`, auto-created on first run).
- `workflow_dispatch` from master re-baselines manually, e.g. after a
  runner image change.

The PR job uses no secrets and performs no writes, so fork PRs are
safe; the report goes to the job summary to avoid the read-only token
restriction on fork PR comments.

### 4. Docs

`tests/benchmark/README.md` gains a CI section: how to trigger, where
to read the report, baseline branch layout, and noise caveats.

## Notes

- GitHub-hosted runners are shared VMs with significant noise, so the
  comparison is advisory and never blocks merging; flagged regressions
  should be re-checked on bare metal. A dedicated runner can be
  adopted later by changing the workflow's `runs-on` value.
- The `bench-results` branch is created automatically by the first
  master push; until then PR reports state that no baseline exists yet.

## Testing done

- `bash -n` on the script; jq side-selection verified against sample
  fio JSON for read-active, write-active, and metadata workloads.
- `bench_compare.py` collect/compare verified end-to-end with sample
  data (-25% flagged REGRESSION, +4% not flagged).
- Workflow YAML validated; end-to-end fio runs to be exercised by the
  first CI runs after merge (or via `workflow_dispatch` on this branch
  before merge, since dispatch reads the workflow from the selected
  ref).

Related-to: #188