### PR TITLE
ci: fix YAML parsing of the benchmark baseline commit message

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -154,9 +154,7 @@ jobs:
         mkdir -p results
         cp merged/*.json results/
         git add results/*.json
-        git commit -m "benchmark: update baseline
-
-Source: ${GITHUB_SHA}
-
-Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        git commit -m "benchmark: update baseline" \
+            -m "Source: ${GITHUB_SHA}" \
+            -m "Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
         git push origin bench-results


### PR DESCRIPTION
The multi-line git commit -m string in the Update baseline step had its body lines at column 0, which terminated the run block scalar and leaked them as top-level mapping keys, making the whole workflow file invalid for GitHub ("Unexpected value 'Source'"). Use separate -m options instead so every shell line stays single-line.

Related-to: #188