### PR TITLE
tests: benchmark the PR against its merge base on the same runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,15 +1,16 @@
-# Benchmark the synchronous and asynchronous fusedev IO paths and compare
-# the results against the baseline recorded on the bench-results branch.
+# Benchmark the synchronous and asynchronous fusedev IO paths.
 #
 # Triggers:
 #   - pull requests: add the "run-benchmark" label to benchmark the PR.
-#     The report is written to the job summary of this workflow run.
-#   - pushes to master: the results become the new baseline, committed to
-#     the orphan branch bench-results (results/<mode>-<threads>threads.json).
-#   - workflow_dispatch: re-baseline manually; only dispatches from master
-#     update the baseline.
+#     Both the merge base and the PR are built and benchmarked back to
+#     back IN THE SAME JOB, on the same runner, and the two result sets
+#     are compared. Comparing against a baseline recorded on a different
+#     runner turned out to be useless: GitHub-hosted runners are shared
+#     VMs whose performance fluctuates by tens of percent, which even
+#     produced "regressions" on code paths the PR did not touch.
+#   - pushes to master / workflow_dispatch: a single run, the collected
+#     results are written to the job summary for reference.
 #
-# Note that GitHub-hosted runners are shared VMs, so results are noisy.
 # The comparison is advisory and never fails the workflow; significant
 # regressions must be re-checked on bare metal.
 
@@ -23,7 +24,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,12 +34,16 @@ jobs:
   bench:
     if: github.event_name != 'pull_request' || github.event.label.name == 'run-benchmark'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         threads: [1, 8]
     steps:
     - uses: actions/checkout@v3
+      with:
+        # Full history so that the merge base can be checked out below for
+        # the A/B comparison (pull_request checkouts are shallow by default).
+        fetch-depth: 0
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2.2.0
       with:
@@ -58,103 +63,98 @@ jobs:
             sudo apt-get install -y fio jq
         fi
 
-    - name: Run benchmark
+    - name: Check out the baseline variant
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base-src
+
+    - name: Build the baseline daemon
+      if: github.event_name == 'pull_request'
+      run: |
+        # Same workspace target directory, so dependencies are built once.
+        (cd base-src/tests/benchmark && cargo build --release)
+        mkdir -p variants
+        cp target/release/fuse-backend-rs-benchmark variants/daemon-base
+
+    - name: Build the current daemon
+      run: |
+        (cd tests/benchmark && cargo build --release)
+        mkdir -p variants
+        cp target/release/fuse-backend-rs-benchmark variants/daemon-current
+
+    - name: Run benchmarks
       run: |
         echo user_allow_other | sudo tee --append /etc/fuse.conf
-        mkdir -p "${GITHUB_WORKSPACE}/bench-results"
         CARGO_HOME=${HOME}/.cargo
         CARGO_BIN=$(which cargo)
-        sudo -E PATH="$(dirname "${CARGO_BIN}"):${PATH}" CARGO_HOME="${CARGO_HOME}" \
-            THREADS=${{ matrix.threads }} RUNTIME=30 MODES="sync async" \
-            RESULTS_DIR="${GITHUB_WORKSPACE}/bench-results" \
-            tests/scripts/bench_sync_async.sh
-        sudo chown -R $(id -u):$(id -g) "${HOME}/.cargo"
+        # Both variants are measured with this very script of the PR,
+        # so the workload definition is identical.
+        SCRIPT=tests/scripts/bench_sync_async.sh
+        run_variant() {
+            sudo -E PATH="$(dirname "${CARGO_BIN}"):${PATH}" CARGO_HOME="${CARGO_HOME}" \
+                THREADS=${{ matrix.threads }} RUNTIME=30 MODES="sync async" \
+                DAEMON="${GITHUB_WORKSPACE}/variants/daemon-$1" \
+                RESULTS_DIR="${GITHUB_WORKSPACE}/bench-$1" \
+                "${SCRIPT}"
+            sudo chown -R $(id -u):$(id -g) "${HOME}/.cargo"
+        }
+        if [ "${{ github.event_name }}" = pull_request ]; then
+            # Alternate the execution order between the thread counts to
+            # spread runner drift (warmup, thermals) across the variants.
+            if [ "${{ matrix.threads }}" = 1 ]; then
+                run_variant base
+                run_variant current
+            else
+                run_variant current
+                run_variant base
+            fi
+        else
+            run_variant current
+        fi
 
     - name: Collect results
       run: |
-        for mode in sync async; do
-            python3 tests/scripts/bench_compare.py collect \
-                "${GITHUB_WORKSPACE}/bench-results" "${mode}" \
-                "${GITHUB_WORKSPACE}/${mode}-${{ matrix.threads }}threads.json"
+        for variant in current base; do
+            [ -d "bench-${variant}" ] || continue
+            for mode in sync async; do
+                python3 tests/scripts/bench_compare.py collect \
+                    "${GITHUB_WORKSPACE}/bench-${variant}" "${mode}" \
+                    "${GITHUB_WORKSPACE}/${variant}-${mode}-${{ matrix.threads }}threads.json"
+            done
         done
+
+    - name: Compare variants
+      if: github.event_name == 'pull_request'
+      run: |
+        {
+            echo "## Benchmark: PR vs merge base (same runner, ${{ matrix.threads }} thread(s))"
+            echo ""
+            for mode in sync async; do
+                python3 tests/scripts/bench_compare.py compare \
+                    "base-${mode}-${{ matrix.threads }}threads.json" \
+                    "current-${mode}-${{ matrix.threads }}threads.json"
+            done
+            echo "Both variants were measured back to back on the same runner;"
+            echo "regressions beyond the threshold (10%) are still advisory,"
+            echo "GitHub-hosted runners drift over time even within one job."
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+    - name: Show results
+      if: github.event_name != 'pull_request'
+      run: |
+        {
+            echo "## Benchmark results (${{ matrix.threads }} thread(s))"
+            echo ""
+            echo "Single run on the merge target, no comparison. See the"
+            echo "artifacts for the raw fio results."
+        } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Upload results
       uses: actions/upload-artifact@v4
       with:
         name: bench-${{ matrix.threads }}threads
         path: |
-          sync-${{ matrix.threads }}threads.json
-          async-${{ matrix.threads }}threads.json
-
-  report:
-    needs: bench
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Download results
-      uses: actions/download-artifact@v4
-      with:
-        pattern: bench-*threads
-        path: results
-
-    - name: Merge results
-      run: |
-        mkdir -p merged
-        for mode in sync async; do
-            for threads in 1 8; do
-                # Flatten the per-artifact directories into a single
-                # results/<mode>-<threads>threads.json layout.
-                cp "results/bench-${threads}threads/${mode}-${threads}threads.json" \
-                    "merged/${mode}-${threads}threads.json"
-            done
-        done
-
-    - name: Compare with baseline
-      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      run: |
-        if ! git ls-remote --exit-code --heads origin bench-results >/dev/null; then
-            echo "No baseline on the bench-results branch yet, skipping comparison." | tee -a "${GITHUB_STEP_SUMMARY}"
-            exit 0
-        fi
-        git fetch origin bench-results
-        git checkout -q FETCH_HEAD -- results || true
-        {
-            echo "## Benchmark results vs master baseline"
-            echo ""
-            for mode in sync async; do
-                for threads in 1 8; do
-                    baseline="results/${mode}-${threads}threads.json"
-                    if [ -f "${baseline}" ]; then
-                        python3 tests/scripts/bench_compare.py compare \
-                            "${baseline}" "merged/${mode}-${threads}threads.json"
-                    else
-                        echo "No baseline for ${mode} with ${threads} thread(s)."
-                        echo ""
-                    fi
-                done
-            done
-            echo "Regressions beyond the threshold (10%) are advisory: GitHub-hosted runners are noisy."
-        } >> "${GITHUB_STEP_SUMMARY}"
-
-    - name: Update baseline
-      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        if git ls-remote --exit-code --heads origin bench-results >/dev/null; then
-            git fetch origin bench-results
-            git checkout -q -B bench-results FETCH_HEAD
-        else
-            git checkout -q --orphan bench-results
-            git rm -rfq .
-        fi
-        rm -rf results
-        mkdir -p results
-        cp merged/*.json results/
-        git add results/*.json
-        git commit -m "benchmark: update baseline" \
-            -m "Source: ${GITHUB_SHA}" \
-            -m "Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-        git push origin bench-results
+          current-*.json
+          base-*.json

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -57,14 +57,19 @@ comparison on GitHub-hosted runners for a matrix of sync/async modes and
 1/8 threads:
 
 - Pull requests: add the `run-benchmark` label to trigger a benchmark run.
-  The results are compared against the baseline recorded on the
-  `bench-results` branch, and the comparison table is written to the job
-  summary of the workflow run (Actions tab).
-- Pushes to master: the results become the new baseline and are committed
-  to the orphan branch `bench-results`
-  (`results/<mode>-<threads>threads.json`).
-- Manual re-baselining: trigger the workflow via `workflow_dispatch` from
-  master, e.g. when the runner image changes.
+  The merge base and the PR are built and benchmarked back to back *in the
+  same job*, and the two result sets are compared in the job summary of the
+  workflow run (Actions tab). The execution order of the two variants is
+  alternated between the thread counts to spread runner drift across them.
+- Pushes to master and manual dispatches run a single benchmark for
+  reference; no baseline is stored.
+
+An earlier revision compared each PR run against a baseline recorded on a
+different runner (the orphan branch `bench-results`). That approach turned
+out to be unusable: GitHub-hosted runners are shared VMs whose performance
+fluctuates by tens of percent, so even code paths the PR did not touch
+regularly showed "regressions" of 20% and more. Comparing two variants on
+the same runner cancels most of that noise.
 
 `tests/scripts/bench_compare.py` normalizes the fio JSON files
 (`collect`) and prints the markdown comparison table (`compare`); it can

--- a/tests/scripts/bench_sync_async.sh
+++ b/tests/scripts/bench_sync_async.sh
@@ -25,6 +25,10 @@
 #   MODES    execution order of the modes (default "sync async"); the
 #            second mode benefits from a warmer page cache, so run both
 #            orders to cross-check the results
+#   DAEMON   path of a prebuilt benchmark daemon (default: build the
+#            daemon of this repository in release mode); used by the CI
+#            pipeline to benchmark different code variants with an
+#            identical workload definition
 #   RESULTS_DIR where to store results (default a fresh mktemp directory)
 
 set -euo pipefail
@@ -34,7 +38,7 @@ REPO_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
 BENCH_DIR="${REPO_DIR}/tests/benchmark"
 # tests/benchmark is a member of the root workspace, so build artifacts
 # land in the workspace target directory, not under tests/benchmark.
-DAEMON="${REPO_DIR}/target/release/fuse-backend-rs-benchmark"
+DAEMON=${DAEMON:-"${REPO_DIR}/target/release/fuse-backend-rs-benchmark"}
 
 THREADS=${THREADS:-4}
 SIZE=${SIZE:-256M}
@@ -61,8 +65,12 @@ fi
 
 echo "results directory: ${RESULTS_DIR}"
 
-# Build the benchmark daemon in release mode.
-(cd "${BENCH_DIR}" && cargo build --release)
+# Build the benchmark daemon in release mode, unless the caller provided
+# a prebuilt one via $DAEMON (e.g. the CI pipeline benchmarking several
+# code variants with this very script).
+if [ ! -x "${DAEMON}" ]; then
+    (cd "${BENCH_DIR}" && cargo build --release)
+fi
 
 DAEMON_PID=
 cleanup() {


### PR DESCRIPTION
The previous design compared each PR run against a baseline recorded on a different runner and stored on the orphan bench-results branch. GitHub-hosted runners are shared VMs whose performance fluctuates by tens of percent, so that comparison was dominated by environment noise: three consecutive runs of the very same PR showed deltas between -10% and +90% for the synchronous mode, which the PR did not even touch, and flagged regressions on those untouched code paths.

Compare the two code variants on the same runner instead: build the benchmark daemons of both the merge base and the PR in one job and run them back to back with the same workload definition, then compare the two result sets. Measuring both variants in the same job cancels most of the between-runner noise. The execution order of the two variants is alternated between the thread counts to spread systematic drift (warmup, thermals) across them.

Implementation details:
- bench_sync_async.sh accepts a prebuilt daemon through the DAEMON environment variable and skips its own build in that case, so both variants are measured by the very same script of the PR.
- The bench-results branch is no longer maintained: pushes to master and workflow_dispatch runs keep a single benchmark for reference, the raw fio results remain available as artifacts.

Note that the comparison is still advisory: shared runners drift even within one job, so significant regressions must be re-checked on bare metal.

Related-to: #188