### PR TITLE
fusedev: add experimental FUSE-over-io_uring serving transport

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,4 +1,4 @@
-# Benchmark the synchronous and asynchronous fusedev IO paths.
+# Benchmark the synchronous, asynchronous and io_uring fusedev IO paths.
 #
 # Triggers:
 #   - pull requests: add the "run-benchmark" label to benchmark the PR.
@@ -10,6 +10,14 @@
 #     produced "regressions" on code paths the PR did not touch.
 #   - pushes to master / workflow_dispatch: a single run, the collected
 #     results are written to the job summary for reference.
+#
+# The uring mode requires kernel 6.14+ with FUSE-over-io_uring enabled
+# (the fuse module parameter enable_uring defaults to off on several
+# distro kernels); the benchmark script turns it on when it can and
+# skips the mode when the kernel still rejects the transport.
+# The merge base predates the uring transport, so only the PR variant
+# runs that mode; its numbers are compared cross-mode against the
+# sync/async results of the same run, which needs no baseline.
 #
 # The comparison is advisory and never fails the workflow; significant
 # regressions must be re-checked on bare metal.
@@ -73,8 +81,12 @@ jobs:
     - name: Build the baseline daemon
       if: github.event_name == 'pull_request'
       run: |
-        # Same workspace target directory, so dependencies are built once.
-        (cd base-src/tests/benchmark && cargo build --release)
+        # cargo resolves the workspace root from the manifest being
+        # built, so without CARGO_TARGET_DIR the binary would land in
+        # base-src/target/. Build into the target directory of the main
+        # checkout instead: the binary ends up where cp expects it, and
+        # dependencies shared by both variants are compiled only once.
+        (cd base-src/tests/benchmark && CARGO_TARGET_DIR="${GITHUB_WORKSPACE}/target" cargo build --release)
         mkdir -p variants
         cp target/release/fuse-backend-rs-benchmark variants/daemon-base
 
@@ -90,11 +102,16 @@ jobs:
         CARGO_HOME=${HOME}/.cargo
         CARGO_BIN=$(which cargo)
         # Both variants are measured with this very script of the PR,
-        # so the workload definition is identical.
+        # so the workload definition is identical. The baseline daemon
+        # predates the uring transport and would reject --uring, so only
+        # the current variant runs that mode (the script itself skips it
+        # when the kernel does not accept FUSE-over-io_uring).
         SCRIPT=tests/scripts/bench_sync_async.sh
         run_variant() {
+            local modes="sync async"
+            [ "$1" = current ] && modes="sync async uring"
             sudo -E PATH="$(dirname "${CARGO_BIN}"):${PATH}" CARGO_HOME="${CARGO_HOME}" \
-                THREADS=${{ matrix.threads }} RUNTIME=30 MODES="sync async" \
+                THREADS=${{ matrix.threads }} RUNTIME=30 MODES="${modes}" \
                 DAEMON="${GITHUB_WORKSPACE}/variants/daemon-$1" \
                 RESULTS_DIR="${GITHUB_WORKSPACE}/bench-$1" \
                 "${SCRIPT}"
@@ -118,7 +135,10 @@ jobs:
       run: |
         for variant in current base; do
             [ -d "bench-${variant}" ] || continue
-            for mode in sync async; do
+            for mode in sync async uring; do
+                # The uring mode is skipped on kernels without FUSE_URING
+                # and never runs for the baseline variant.
+                compgen -G "bench-${variant}/${mode}-*.json" > /dev/null || continue
                 python3 tests/scripts/bench_compare.py collect \
                     "${GITHUB_WORKSPACE}/bench-${variant}" "${mode}" \
                     "${GITHUB_WORKSPACE}/${variant}-${mode}-${{ matrix.threads }}threads.json"
@@ -141,6 +161,27 @@ jobs:
             echo "GitHub-hosted runners drift over time even within one job."
         } >> "${GITHUB_STEP_SUMMARY}"
 
+        # Cross-mode comparison of the uring transport against the classic
+        # transports of this very PR run: same job and same machine, so
+        # environment effects cancel out, and no baseline is needed (the
+        # merge base predates the uring transport). Absent on runners
+        # whose kernels reject FUSE-over-io_uring.
+        URING_JSON="current-uring-${{ matrix.threads }}threads.json"
+        if [ -f "${URING_JSON}" ]; then
+            for mode in sync async; do
+                {
+                    echo ""
+                    echo "### Cross-mode comparison: uring vs ${mode} of this PR"
+                    echo ""
+                    echo "Positive deltas mean uring outperformed ${mode} on that workload."
+                    echo ""
+                } >> "${GITHUB_STEP_SUMMARY}"
+                python3 tests/scripts/bench_compare.py compare \
+                    "current-${mode}-${{ matrix.threads }}threads.json" \
+                    "${URING_JSON}" >> "${GITHUB_STEP_SUMMARY}"
+            done
+        fi
+
     - name: Show results
       if: github.event_name != 'pull_request'
       run: |
@@ -149,6 +190,11 @@ jobs:
             echo ""
             echo "Single run on the merge target, no comparison. See the"
             echo "artifacts for the raw fio results."
+            if [ -f "current-uring-${{ matrix.threads }}threads.json" ]; then
+                echo ""
+                echo "This runner's kernel supports FUSE_URING, so the run"
+                echo "covered the uring transport as well."
+            fi
         } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Upload results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,10 @@ virtiofs = ["virtio-queue", "caps", "vmm-sys-util"]
 vhost-user-fs = ["virtiofs", "vhost", "caps"]
 persist = ["dbs-snapshot", "versionize", "versionize_derive"]
 fuse-t = []
+# Experimental: FUSE-over-io_uring transport (kernel >= 6.14, protocol 7.42).
+# The kernel interface is still evolving (queue-count reduction, bufpool
+# extensions); the API and ABI target may change between releases.
+fusedev-uring = ["fusedev", "io-uring"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 check: build
 	${CARGO} fmt -- --check
 	${CARGO} clippy ${TARGET} --features="fusedev" --no-default-features -- -Dwarnings
+	${CARGO} clippy ${TARGET} --features="fusedev,fusedev-uring" --no-default-features -- -Dwarnings
 	${CARGO} clippy ${TARGET} --features="virtiofs" --no-default-features -- -Dwarnings
 	${CARGO} clippy ${TARGET} --features="vhost-user-fs" --no-default-features -- -Dwarnings
 	${CARGO} clippy ${TARGET} --features="fusedev,virtiofs" --no-default-features -- -Dwarnings

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,92 @@
+# TODO
+
+## Async IO 优化
+
+> **结论（2026-08-27 定稿）**：所有可测场景下 async 均未胜过 sync——写持平、
+> 大读 -4%~-7%、cached 小读 -32%~-46%（跨介质、跨线程数、跨客户端并发度复现）。
+> 唯一的理论赢面（cache miss 真盘 + 高并发在途）**无法在本环境验证**：
+> oxs-dev 的 ali5000 内核页缓存驱逐被厂商定制禁用（posix_fadvise(DONTNEED)
+> 返回 0 但 mincore 显示 100% 驻留，ext4 和 tmpfs 均如此；无 sudo 无法
+> drop_caches），真实冷读不可构造。且 FUSE 协议本身无 fadvise opcode（内核
+> v6.6 之前均无），fio --invalidate=1 经 fuse 恒为静默 no-op，daemon 侧无法补救。
+> 最后一次 1:1 服务 × 8 客户端并发测试（本想测冷读，实际仍是 cache 命中，
+> 证据：sync 82K IOPS 超过裸盘 QD8 上限 36K）：seqread -3.6%、randread-4k -32.1%。
+>
+> **分支定位调整**：原生异步 READ/WRITE 在 5.10 fusedev 上不提供正收益；分支价值
+> 转为 multi-task transport 与 FUSE_URING（内核 ≥6.14）的前置基建（runtime 分发、
+> borrowed fd、pipelined dispatch）。不再投入 cached 场景优化（RWF_NOWAIT 混合路径
+> 收益上限仅为追平 sync，暂挂起）。
+
+### ~~【最高优先级】buffered cache miss 场景验证~~（不可行，已关闭）
+
+**关闭原因**：oxs-dev 无法构造冷缓存（见顶部结论）。多次尝试均被页缓存污染：
+1. fio --invalidate=1 → FUSE 协议无 fadvise opcode，静默丢弃；
+2. 直接对 backing 文件 fadvise(DONTNEED) → ali5000 内核驱逐失效（返回 0 不生效）；
+3. drop_caches → 无 sudo。
+
+若未来能在驱逐正常的宿主上测试，再重启此项；按预承诺判决规则，当前证据已足以定性。
+
+### 【暂挂起】cached 读混合路径：inline RWF_NOWAIT 优先，EAGAIN 回落 io_uring
+
+针对"固定+每字节"双重开销：async_read 先用 RWF_NOWAIT preadv 内联尝试，
+命中 cache 时零 io_uring 开销，未命中时回落 io_uring。暂挂起原因：收益上限仅为
+追平 sync（无正收益），优先级让位于 multi-task transport。若未来目标内核为 6.13+
+（tmpfs NOWAIT 支持），可重启评估。
+
+### Multi-task transport（N 任务 × N ring）
+
+**依据**：真实磁盘 DIO 对比（oxs-dev SATA SSD，--direct=1）中 async 单任务全面
+落后 sync 4 线程（顺序 0.72x、随机 4k 读 0.26x）；async 的 DIO 走同步中继，
+本质是 1 线程对 4 线程；客户端并发 4→16 无改善，瓶颈在单服务线程。per-thread
+吞吐 async 并不差（顺序读单线程 213MB/s vs sync 单线程 ~75MB/s），缺的是并行
+服务单元。另：256K 探测显示 async 读聚合带宽封顶 ~1.4-1.7 GB/s，多任务可解除该封顶。
+
+**方案**：多个 FuseDevTask 各自运行单线程 runtime + io_uring ring 并发读
+/dev/fuse（对齐现有 sync 模式 N-channel 模型，也是 FUSE_URING per-CPU ring 的
+基础）。
+
+### READDIR/READDIRPLUS 卸载到 blocking pool
+
+**问题**：async 模式下 READDIR/READDIRPLUS 没有异步实现，server 分发直接调用同步
+handler（`src/api/server/async_io.rs` 中 `self.readdir(ctx)` 无 `.await`），在单线程
+uring runtime 线程上内联执行 `lseek64` + `getdents64` 循环，并在整个过程中持有
+`HandleData.lock`。读取大目录时阻塞 runtime 线程，导致所有并发请求和 io_uring
+完成事件停摆（head-of-line blocking）。
+
+**方案**：给 `AsyncFileSystem` trait 增加 `async_readdir`/`async_readdirplus`，
+PassthroughFs 中通过 `spawn_blocking` 中继到同步 handler（与其他 relay 类操作相同
+模式）。io_uring 没有 GETDENTS opcode，offload 是最终方案而非过渡方案。
+
+**注意点**：
+- cached-cookie resume 逻辑依赖 `HandleData.lock` 串行化 `lseek`+`getdents` 对，
+  offload 后锁在 pool 线程上生效，语义不变。
+- 同类未异步化的 op 一并排查：OPENDIR/RELEASEDIR/LSEEK 等仍在 runtime 线程同步执行。
+
+### ~~async READ/WRITE 去掉 dup/close，改造为 borrowed fd~~（已完成，async/spawn-blocking）
+
+实现：`common/async_file.rs` 增加 `File::Borrowed { fd, _guard }` 变体（guard =
+`Arc<HandleData>`，uring 路径临时包装 `tokio_uring::fs::File` 并用 ForgetOnDrop
+防止取消时误关 fd）；passthrough `async_file_from_data()` 改为借用。
+提交：`d200731`（common）+ `acf94d5`（passthrough），clippy 修复已 fold 进
+`4854134`（pipelined poll_handler）。
+
+验证（tmpfs，THREADS=4，warmup+3 轮，borrow vs dup A/B 对比）：
+seqwrite +6.0%、seqread +2.5%、randwrite-4k +8.2%、randread-4k +8.1%；
+filecreate/filedelete 不受影响（预期内，不走 borrowed 路径）。4k 负载逐轮一致，
+收益真实。结论：dup/close 开销已消除；剩余读差距（-62%~-69%）归因于 cached 小读
+的 io_uring submit/reap 开销（下一优化点）与服务线程数（Multi-task transport）。
+
+追加 256K 探测：randread-256k sync 3309 vs async 1460 MB/s（-55.9%），
+randwrite-256k 1923 vs 1764（-8.3%）——bs 增大仅收窄读差距 6 个百分点，
+确认差距含每字节分量，非纯每请求开销。
+
+### Guest direct IO 支持（进行中）
+
+- [x] do_open 协商 FOPEN_DIRECT_IO
+- [x] 请求缓冲区页对齐（posix_memalign）
+- [x] sync read/write bounce buffer
+- [x] async read/write 中继到 sync handler（io_uring 直传未对齐缓冲区会 EINVAL）
+- [x] 真实磁盘 DIO 性能对比（sync vs async）——结论：async 单任务全面落后，
+      根因是 DIO 同步中继 + 单服务线程，非 io_uring 路径劣势
+- [ ] buffered（cache miss）场景 sync vs async 对比，验证 io_uring 原生路径价值
+- [ ] 合入前的回归验证（buffered 路径 lib tests + smoke）

--- a/docs/fuse-uring-performance.md
+++ b/docs/fuse-uring-performance.md
@@ -1,0 +1,157 @@
+# FUSE-over-io_uring Performance Analysis
+
+This document analyzes the performance characteristics of the FUSE-over-io_uring
+transport implementation, including known regressions and upstream optimization
+progress.
+
+## Benchmark Summary
+
+### Metadata Operations: Significant Wins
+
+| Workload | 1-thread | 8-thread |
+|----------|----------|----------|
+| filecreate | +150-216% | +276-277% |
+| filedelete | -15 to +8% | +41-46% |
+| randread-4k | +1-3% | +63% |
+| randwrite-4k | +5-16% | -22 to -24% |
+
+The uring transport excels at metadata operations because it eliminates the
+per-request syscall overhead (read/write on `/dev/fuse`). With 8 threads,
+filecreate achieves **3.7x** throughput compared to sync.
+
+### Sequential I/O: Known Regression
+
+| Workload | 1-thread | 8-thread |
+|----------|----------|----------|
+| seqread | -44 to +5% | **-37%** |
+| seqwrite | -1 to -15% | **-28 to -34%** |
+
+The sequential I/O regression is a **known upstream limitation**, not a bug in
+this implementation. See "Root Cause Analysis" below.
+
+## Root Cause Analysis
+
+### What It's NOT
+
+1. **Not memcpy overhead**: The scatter Reader/Writer optimization eliminates
+   all userspace copies. Both classic and uring paths use identical kernel-side
+   copy functions (`fuse_copy_args`, `fuse_copy_out_args`).
+
+2. **Not missing readahead**: Readahead is handled at the VFS layer
+   (`fs/fuse/file.c:fuse_readahead`), completely independent of the transport.
+   Both classic and uring paths benefit equally.
+
+3. **Not pipeline depth**: Increasing `entries_per_queue` from 4 to 16 had
+   zero impact on sequential I/O performance.
+
+### What It Is
+
+The regression stems from two optimizations that were present in RFC v1/v2
+but removed in later versions pending upstream subsystem changes:
+
+#### 1. `__wake_on_current_cpu` (Scheduler Dependency)
+
+RFC v1 had an optimization to wake the waiting thread on the **same CPU core**
+where the request was processed, avoiding cross-core cache line bouncing.
+
+From Bernd Schubert's v3 changelog:
+> "Removed the `__wake_on_current_cpu` optimization (for now as that needs to
+> go through another subsystem/tree), removing it means a significant
+> performance drop"
+
+This requires scheduler changes that haven't been accepted upstream yet.
+
+#### 2. Direct Ring Submission (Locking Issues)
+
+RFC v1/v2 submitted requests directly from the task that created them,
+avoiding the `io_uring_cmd_complete_in_task()` workqueue deferral.
+
+This was removed due to teardown race conditions and lock ordering violations.
+The current implementation defers to a workqueue, adding latency.
+
+### RFC v1 Benchmark Comparison
+
+Bernd Schubert's RFC v1 benchmarks (2024, with optimizations present) showed:
+
+| Workload | /dev/fuse | uring | Gain |
+|----------|-----------|-------|------|
+| 128K paged reads (1 job) | 1117 MB/s | 1921 MB/s | **1.72x** |
+| 128K paged reads (8 jobs) | 6273 MB/s | 10855 MB/s | **1.73x** |
+| 1024K DIO reads (4 jobs) | 3823 MB/s | 15022 MB/s | **3.58x** |
+
+Current kernels (6.14-7.2) lack these optimizations, resulting in the
+regression we observe.
+
+## Upstream Optimization Progress
+
+### Linux 7.3: Buffer Pools + Zero-Copy (Merged)
+
+**Author**: Joanne Koong  
+**Status**: Merged for Linux 7.3 (August 2026)
+
+- **Buffer pools**: Kernel-managed shared memory pool instead of per-entry
+  dedicated buffers. Reduces memory overhead significantly.
+
+- **Zero-copy**: Server can directly access client pages (pinned user pages
+  for DIO, page cache folios for buffered I/O) without intermediary copies.
+  Requires `CAP_SYS_ADMIN`.
+
+Benchmark results from Joanne's patch series (bs=1M):
+
+| Workload | Before | After | Gain |
+|----------|--------|-------|------|
+| direct randreads | ~2100 MB/s | ~2600 MB/s | +20% |
+| buffered randreads | ~1900 MB/s | ~2400 MB/s | +25% |
+| buffered randwrites | 950 MB/s | 1050 MB/s | +10% |
+
+### Pending: `__wake_on_current_cpu`
+
+**Status**: Blocked on scheduler subsystem changes
+
+This optimization will eliminate cross-core wakeup latency for sequential I/O.
+
+### Pending: Direct Ring Submission
+
+**Status**: Will be re-submitted after core work stabilizes
+
+This will eliminate the workqueue deferral overhead.
+
+## Implementation Notes
+
+### Current State
+
+This implementation targets the stable FUSE_URING protocol 7.42 (kernel 6.14+):
+
+- Scatter Reader/Writer eliminates all userspace memcpy
+- Per-CPU queue model with configurable entries_per_queue
+- Fallback to classic `/dev/fuse` for notifications/interrupts
+
+### Future Work
+
+When Linux 7.3+ is available on target systems:
+
+1. **Buffer pool registration**: Reduce memory overhead by sharing a contiguous
+   pool across requests instead of per-entry buffers.
+
+2. **Zero-copy mode**: Enable direct page access (requires CAP_SYS_ADMIN) to
+   eliminate kernel-side copies entirely.
+
+### Tuning Recommendations
+
+- `entries_per_queue`: Default is 4. Increasing to 16+ does not help
+  sequential I/O (bottleneck is elsewhere), but may help high-concurrency
+  metadata workloads.
+
+- Thread count: The per-CPU queue model means optimal performance when
+  worker threads match available CPU cores.
+
+## References
+
+- Bernd Schubert's fuse-over-io_uring patch series:
+  https://lore.kernel.org/io-uring/20241209-fuse-uring-for-6-10-rfc4-v8-0-d9f9f2642be3@ddn.com/
+
+- Joanne Koong's buffer pools + zero-copy:
+  https://lwn.net/Articles/1049130/
+
+- Kernel documentation:
+  https://docs.kernel.org/filesystems/fuse/fuse-io-uring.html

--- a/src/abi/fuse_abi_linux.rs
+++ b/src/abi/fuse_abi_linux.rs
@@ -200,6 +200,11 @@ const PERFILE_DAX: u64 = 0x2_0000_0000;
 // this flag indicates whether the guest kernel enable resend
 const HAS_RESEND: u64 = 1_u64 << 39;
 
+// Indicates that the daemon supports serving FUSE requests over io_uring
+// (protocol 7.42, kernel 6.14+, experimental fusedev-uring feature).
+#[cfg(feature = "fusedev-uring")]
+const OVER_IO_URING: u64 = 1_u64 << 41;
+
 // This flag indicates whether to enable fd-passthrough. It was defined in the
 // Anolis kernel but not in the upstream kernel. To avoid collision, we'll set
 // it to the most significant bit.
@@ -464,6 +469,10 @@ bitflags! {
 
         /// indicates whether the kernel support resend inflight request
         const HAS_RESEND = HAS_RESEND;
+
+        /// Daemon supports serving FUSE requests over io_uring (experimental).
+        #[cfg(feature = "fusedev-uring")]
+        const OVER_IO_URING = OVER_IO_URING;
     }
 }
 

--- a/src/abi/fuse_uring.rs
+++ b/src/abi/fuse_uring.rs
@@ -1,0 +1,109 @@
+// Copyright (C) 2026 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Linux FUSE-over-io_uring ABI definitions, protocol version 7.42 (kernel 6.14+).
+//!
+//! Experimental: the kernel interface is still evolving (reduced queue counts,
+//! bufpool/zero-copy extensions are being developed upstream). Only the minimal
+//! 7.42 interface is defined here; in-flight extensions are intentionally left
+//! out.
+
+#![allow(missing_docs)]
+
+use vm_memory::ByteValued;
+
+/// INIT flag: client supports serving FUSE requests over io_uring (protocol 7.42).
+pub const FUSE_OVER_IO_URING: u64 = 1_u64 << 41;
+
+/// Size of the fuse_in_header/fuse_out_header slot inside `FuseUringReqHeader`.
+pub const FUSE_URING_IN_OUT_HEADER_SZ: usize = 128;
+
+/// Size of the per-opcode header slot inside `FuseUringReqHeader`.
+pub const FUSE_URING_OP_IN_OUT_SZ: usize = 128;
+
+/// Number of iovec segments a REGISTER SQE must describe (headers + payload).
+pub const FUSE_URING_IOV_SEGS: usize = 2;
+
+/// iovec segment index of the headers area (`FuseUringReqHeader`).
+pub const FUSE_URING_IOV_HEADERS: usize = 0;
+
+/// iovec segment index of the payload area.
+pub const FUSE_URING_IOV_PAYLOAD: usize = 1;
+
+/// SQE command opcodes, placed in `sqe->cmd_op` of an `IORING_OP_URING_CMD` SQE.
+pub const FUSE_IO_URING_CMD_INVALID: u32 = 0;
+pub const FUSE_IO_URING_CMD_REGISTER: u32 = 1;
+pub const FUSE_IO_URING_CMD_COMMIT_AND_FETCH: u32 = 2;
+
+/// Shared in/out descriptor of one ring entry, embedded in `FuseUringReqHeader`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FuseUringEntInOut {
+    pub flags: u64,
+    /// Commit ID to echo back with `FUSE_IO_URING_CMD_COMMIT_AND_FETCH`.
+    pub commit_id: u64,
+    /// Size of the payload in bytes (request: set by kernel, reply: set by daemon).
+    pub payload_sz: u32,
+    pub padding: u32,
+    pub reserved: u64,
+}
+
+/// Header area of one ring entry, registered through `FUSE_IO_URING_CMD_REGISTER`.
+///
+/// Layout mirrors `struct fuse_uring_req_header`: a 128-byte in/out header slot
+/// holding `fuse_in_header` (request) or `fuse_out_header` (reply), a 128-byte
+/// per-opcode header slot holding the request arguments, and the shared
+/// entry descriptor.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FuseUringReqHeader {
+    pub in_out: [u8; FUSE_URING_IN_OUT_HEADER_SZ],
+    pub op_in: [u8; FUSE_URING_OP_IN_OUT_SZ],
+    pub ring_ent_in_out: FuseUringEntInOut,
+}
+
+impl Default for FuseUringReqHeader {
+    fn default() -> Self {
+        // All fields are plain bytes, a zeroed value is valid.
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+/// Command payload of an uring command SQE, placed in the 80-byte command
+/// area of an SQE128.
+///
+/// Layout mirrors `struct fuse_uring_cmd_req`. For REGISTER and
+/// COMMIT_AND_FETCH only `commit_id` and `qid` are used.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FuseUringCmdReq {
+    pub flags: u64,
+    /// Entry identifier, taken from `FuseUringEntInOut.commit_id`.
+    pub commit_id: u64,
+    /// Index of the per-CPU queue the command is for.
+    pub qid: u16,
+    pub padding: [u8; 6],
+}
+
+// SAFETY: all three structs are `repr(C)` plain data types without padding
+// holes or pointer members, matching their kernel counterparts.
+unsafe impl ByteValued for FuseUringEntInOut {}
+unsafe impl ByteValued for FuseUringReqHeader {}
+unsafe impl ByteValued for FuseUringCmdReq {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layouts() {
+        assert_eq!(std::mem::size_of::<FuseUringEntInOut>(), 32);
+        assert_eq!(std::mem::size_of::<FuseUringReqHeader>(), 288);
+        assert_eq!(std::mem::size_of::<FuseUringCmdReq>(), 24);
+        assert_eq!(
+            std::mem::offset_of!(FuseUringReqHeader, ring_ent_in_out),
+            FUSE_URING_IN_OUT_HEADER_SZ + FUSE_URING_OP_IN_OUT_SZ
+        );
+        assert_eq!(std::mem::offset_of!(FuseUringCmdReq, qid), 16);
+    }
+}

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -15,3 +15,7 @@ pub mod fuse_abi;
 
 #[cfg(feature = "virtiofs")]
 pub mod virtio_fs;
+
+/// Linux FUSE-over-io_uring ABI (experimental, kernel 6.14+, protocol 7.42).
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+pub mod fuse_uring;

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -29,6 +29,8 @@ use crate::api::filesystem::{Context, FileSystem, ZeroCopyReader, ZeroCopyWriter
 use crate::file_traits::FileReadWriteVolatile;
 use crate::transport::{Reader, Writer};
 use crate::{bytes_to_cstr, BitmapSlice, Error, Result};
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(feature = "async-io")]
 mod async_io;
@@ -51,6 +53,13 @@ pub const MAX_REQ_PAGES: u16 = 256; // 1MB
 pub struct Server<F: FileSystem + Sync> {
     fs: F,
     vers: ArcSwap<ServerVersion>,
+    /// Extra capability flags to advertise in the INIT reply, requested
+    /// through `set_uring()` (experimental fusedev-uring transport).
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    extra_init_flags: AtomicU64,
+    /// Capability flags actually enabled by the INIT exchange.
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    negotiated_init_flags: AtomicU64,
 }
 
 impl<F: FileSystem + Sync> Server<F> {
@@ -62,7 +71,54 @@ impl<F: FileSystem + Sync> Server<F> {
                 major: KERNEL_VERSION,
                 minor: KERNEL_MINOR_VERSION,
             })),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            extra_init_flags: AtomicU64::new(0),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            negotiated_init_flags: AtomicU64::new(0),
         }
+    }
+
+    /// Request serving FUSE requests over io_uring (experimental).
+    ///
+    /// Must be called before the session is mounted: the request is carried
+    /// by the `FUSE_OVER_IO_URING` capability flag in the INIT reply. The
+    /// outcome of the negotiation is reported by `uring_enabled()`, which is
+    /// meaningful only after the INIT exchange has completed.
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    pub fn set_uring(&self, enabled: bool) {
+        let flags = if enabled {
+            FsOptions::OVER_IO_URING.bits()
+        } else {
+            0
+        };
+        self.extra_init_flags.store(flags, Ordering::Relaxed);
+    }
+
+    /// Report whether the kernel accepted the `FUSE_OVER_IO_URING` capability
+    /// during the INIT exchange. Returns false before INIT completes.
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    pub fn uring_enabled(&self) -> bool {
+        self.negotiated_init_flags.load(Ordering::Acquire) & FsOptions::OVER_IO_URING.bits() != 0
+    }
+
+    /// OR the extra INIT flags requested through `set_uring()` into the
+    /// enabled capability set and remember the negotiation outcome.
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    fn apply_extra_init_flags(&self, capable: FsOptions, enabled: FsOptions) -> FsOptions {
+        let extra = FsOptions::from_bits_truncate(self.extra_init_flags.load(Ordering::Relaxed));
+        let mut enabled = enabled | (capable & extra);
+        // The kernel applies InitOut.flags2 (capability bits 32 and above)
+        // only if userspace also sets FUSE_INIT_EXT in the INIT reply, since
+        // the "fuse: Apply flags2 only when userspace set the FUSE_INIT_EXT"
+        // change in Linux 6.13. FUSE_OVER_IO_URING is bit 41 and therefore
+        // travels in flags2, so advertise INIT_EXT whenever any upper bit is
+        // enabled or the kernel would silently drop it.
+        if enabled.bits() >> 32 != 0 {
+            enabled |= FsOptions::INIT_EXT;
+        }
+        self.negotiated_init_flags
+            .store(enabled.bits(), Ordering::Release);
+        enabled
     }
 
     /// Remap the IDs in a request context to the IDs used by the backend

--- a/src/api/server/sync_io.rs
+++ b/src/api/server/sync_io.rs
@@ -772,6 +772,8 @@ impl<F: FileSystem + Sync> Server<F> {
                 };
 
                 let enabled = capable & want;
+                #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+                let enabled = self.apply_extra_init_flags(capable, enabled);
                 let enabled_flags = enabled.bits();
                 let mut out = InitOut {
                     major: KERNEL_VERSION,
@@ -1539,6 +1541,67 @@ mod tests {
 
             assert!(init_params_called);
             assert_eq!(res, 80);
+        }
+
+        #[cfg(feature = "fusedev-uring")]
+        #[test]
+        fn test_server_init_uring_negotiation() {
+            // Kernel capability set carrying INIT_EXT plus FUSE_OVER_IO_URING
+            // (bit 41, i.e. bit 9 of flags2), as sent by kernels >= 6.14:
+            // fuse_init_in followed by the full fuse_init_in2.
+            let mut read_buf = [0u8; size_of::<InitIn>() + size_of::<InitIn2>()];
+            let init_in = InitIn {
+                major: KERNEL_VERSION,
+                minor: KERNEL_MINOR_VERSION,
+                max_readahead: 0,
+                flags: (FsOptions::DO_READDIRPLUS | FsOptions::INIT_EXT).bits() as u32,
+            };
+            read_buf[..size_of::<InitIn>()].copy_from_slice(init_in.as_slice());
+            let init_in2 = InitIn2 {
+                flags2: (FsOptions::OVER_IO_URING.bits() >> 32) as u32,
+                unused: [0; 11],
+            };
+            read_buf[size_of::<InitIn>()..].copy_from_slice(init_in2.as_slice());
+
+            // With set_uring() the reply must echo FUSE_OVER_IO_URING in
+            // flags2 and set FUSE_INIT_EXT in flags, since kernels >= 6.13
+            // apply flags2 only when FUSE_INIT_EXT is present.
+            let fs = PassthroughFs::<()>::new(Config::default()).unwrap();
+            let server = Server::new(fs);
+            server.set_uring(true);
+            let mut write_buf = [0u8; 4096];
+            let (ctx, file) = prepare_srvcontext(&mut read_buf, &mut write_buf);
+            let res = server.init(ctx, |_| {}).unwrap();
+            assert_eq!(res, size_of::<OutHeader>() + size_of::<InitOut>());
+            // The reply is committed to the writer fd, not kept in the
+            // staging buffer.
+            let mut reply = vec![0u8; res];
+            std::os::unix::fs::FileExt::read_at(&file, &mut reply, 0).unwrap();
+            let mut out = InitOut::default();
+            out.as_mut_slice()
+                .copy_from_slice(&reply[size_of::<OutHeader>()..]);
+            assert_ne!(out.flags & FsOptions::INIT_EXT.bits() as u32, 0);
+            assert_ne!(
+                out.flags2 & (FsOptions::OVER_IO_URING.bits() >> 32) as u32,
+                0
+            );
+            assert!(server.uring_enabled());
+
+            // Without set_uring() the capability stays off and no upper bit
+            // is enabled, so INIT_EXT must not be advertised either.
+            let fs = PassthroughFs::<()>::new(Config::default()).unwrap();
+            let server = Server::new(fs);
+            let mut write_buf = [0u8; 4096];
+            let (ctx, file) = prepare_srvcontext(&mut read_buf, &mut write_buf);
+            let res = server.init(ctx, |_| {}).unwrap();
+            let mut reply = vec![0u8; res];
+            std::os::unix::fs::FileExt::read_at(&file, &mut reply, 0).unwrap();
+            let mut out = InitOut::default();
+            out.as_mut_slice()
+                .copy_from_slice(&reply[size_of::<OutHeader>()..]);
+            assert_eq!(out.flags & FsOptions::INIT_EXT.bits() as u32, 0);
+            assert_eq!(out.flags2, 0);
+            assert!(!server.uring_enabled());
         }
 
         #[test]

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -37,6 +37,11 @@ mod fuse_t_session;
 #[cfg(all(target_os = "macos", feature = "fuse-t"))]
 pub use fuse_t_session::*;
 
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+mod uring_session;
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+pub use uring_session::*;
+
 // These follow the definition from libfuse.
 /// Maximum size of FUSE message data, 1M with 4K page.
 pub const FUSE_KERN_BUF_PAGES: usize = 256;

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -79,6 +79,35 @@ impl<'a, S: BitmapSlice + Default> Reader<'a, S> {
             },
         })
     }
+
+    /// Construct a scatter Reader spanning two non-contiguous buffers: a
+    /// header/args region followed by a separate payload region.
+    ///
+    /// Used by the FUSE-over-io_uring transport to avoid copying the request
+    /// payload (e.g. WRITE data) from the ring entry into a scratch buffer —
+    /// the Reader reads directly from the entry's payload area instead.
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    pub fn from_uring_buffers(
+        header: &'a mut [u8],
+        payload: &'a mut [u8],
+    ) -> Result<Reader<'a, S>> {
+        let mut buffers: VecDeque<VolatileSlice<'a, S>> = VecDeque::new();
+        // Safe because Reader has the same lifetime as the input slices.
+        buffers.push_back(unsafe {
+            VolatileSlice::with_bitmap(header.as_mut_ptr(), header.len(), S::default(), None)
+        });
+        if !payload.is_empty() {
+            buffers.push_back(unsafe {
+                VolatileSlice::with_bitmap(payload.as_mut_ptr(), payload.len(), S::default(), None)
+            });
+        }
+        Ok(Reader {
+            buffers: IoBuffers {
+                buffers,
+                bytes_consumed: 0,
+            },
+        })
+    }
 }
 
 /// Writer to send FUSE reply to the FUSE driver.

--- a/src/transport/fusedev/uring_session.rs
+++ b/src/transport/fusedev/uring_session.rs
@@ -1,0 +1,819 @@
+// Copyright (C) 2026 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! FUSE-over-io_uring serving transport (experimental, kernel 6.14+, protocol 7.42).
+//!
+//! Requests registered through `IORING_OP_URING_CMD` SQEs on the /dev/fuse file
+//! are delivered as CQEs; replies are sent back together with a re-registration
+//! through `FUSE_IO_URING_CMD_COMMIT_AND_FETCH`. One kernel queue exists per
+//! possible CPU, and each entry is attached to an explicit queue id chosen by
+//! the daemon in the SQE command payload.
+//!
+//! The kernel still uses the classic /dev/fuse path for requests it cannot
+//! route through io_uring (FUSE_INTERRUPT and requests queued before entries
+//! were registered), so a classic channel thread keeps serving in parallel.
+//!
+//! Experimental: the kernel interface is still evolving; only the minimal 7.42
+//! interface is implemented.
+
+use std::fs::File;
+use std::io::{self, IoSlice, Write};
+use std::mem::ManuallyDrop;
+use std::os::unix::io::AsRawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Sender};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use io_uring::{cqueue, opcode, squeue, types, IoUring};
+use vm_memory::ByteValued;
+
+use crate::abi::fuse_abi::{InHeader, OutHeader};
+use crate::abi::fuse_uring::{
+    FuseUringCmdReq, FuseUringEntInOut, FuseUringReqHeader, FUSE_IO_URING_CMD_COMMIT_AND_FETCH,
+    FUSE_IO_URING_CMD_REGISTER, FUSE_URING_IN_OUT_HEADER_SZ, FUSE_URING_IOV_SEGS,
+};
+use crate::api::filesystem::FileSystem;
+use crate::api::server::Server;
+use crate::file_buf::FileVolatileSlice;
+use crate::file_traits::FileReadWriteVolatile;
+use crate::transport::fusedev::{FuseBuf, FuseChannel, FuseSession, FUSE_HEADER_SIZE};
+use crate::transport::{Error::*, Reader, Result, Writer};
+use crate::BitmapSlice;
+
+/// Size of `fuse_in_header`/`fuse_out_header` on the wire.
+const IN_HEADER_SIZE: usize = 40;
+const OUT_HEADER_SIZE: usize = 16;
+
+/// Field-for-field mirror of `struct io_uring_sqe`, used to reach the
+/// `addr`/`len` fields of an SQE128 which the io-uring crate does not
+/// expose for `IORING_OP_URING_CMD` entries.
+#[allow(dead_code)]
+#[repr(C)]
+struct SqeMirror {
+    opcode: u8,
+    flags: u8,
+    ioprio: u16,
+    fd: i32,
+    off: u64,
+    addr: u64,
+    len: u32,
+    op_flags: u32,
+    user_data: u64,
+    buf_index: u16,
+    personality: u16,
+    splice_fd_in: i32,
+    addr3: u64,
+    pad2: u64,
+}
+
+/// Configuration of the io_uring serving transport.
+#[derive(Clone, Copy, Debug)]
+pub struct UringConfig {
+    /// Number of worker threads, each owning one io_uring instance. The
+    /// kernel queues are distributed among the workers round-robin.
+    /// `0` means one worker per online CPU.
+    pub workers: usize,
+    /// Number of ring entries registered per kernel queue, i.e. the number
+    /// of in-flight requests each queue may hold.
+    pub entries_per_queue: usize,
+}
+
+impl Default for UringConfig {
+    fn default() -> Self {
+        UringConfig {
+            workers: 0,
+            entries_per_queue: 4,
+        }
+    }
+}
+
+/// Parse a CPU mask like "0-3,5,8-11" into the number of possible CPUs,
+/// which is the number of kernel fuse queues.
+fn parse_cpu_mask(content: &str) -> Result<usize> {
+    let mut count = 0usize;
+    for part in content.trim().split(',') {
+        let range: Vec<&str> = part.split('-').collect();
+        let (start, end) = match range.as_slice() {
+            [a] => (*a, *a),
+            [a, b] => (*a, *b),
+            _ => {
+                return Err(SessionFailure(format!(
+                    "invalid cpu mask range: {part}"
+                )))
+            }
+        };
+        let start: usize = start
+            .trim()
+            .parse()
+            .map_err(|_| SessionFailure(format!("invalid cpu mask: {content}")))?;
+        let end: usize = end
+            .trim()
+            .parse()
+            .map_err(|_| SessionFailure(format!("invalid cpu mask: {content}")))?;
+        if end < start {
+            return Err(SessionFailure(format!("invalid cpu mask range: {part}")));
+        }
+        count += end - start + 1;
+    }
+    if count == 0 {
+        return Err(SessionFailure("empty cpu mask".to_string()));
+    }
+    Ok(count)
+}
+
+/// Read `/sys/devices/system/cpu/possible` to get the number of possible
+/// CPUs, which is the number of kernel fuse queues.
+fn possible_cpu_count() -> Result<usize> {
+    let content = std::fs::read_to_string("/sys/devices/system/cpu/possible")
+        .map_err(|e| SessionFailure(format!("read possible cpu mask: {e}")))?;
+    parse_cpu_mask(&content)
+}
+
+/// Size of the per-opcode request arguments carried in the entry `op_in`
+/// slot, for reassembling the classic wire layout. The kernel copies
+/// `in_args[0]` (the per-op header) into `op_in` and the remaining
+/// arguments into the payload area, so `Some(0)` means a known opcode
+/// without a fixed header; `None` marks opcodes the daemon cannot serve.
+fn in_args_len(opcode: u32) -> Option<usize> {
+    let len = match opcode {
+        1 => 0,             // LOOKUP: name only
+        2 => 8,             // FORGET: ForgetIn
+        3 => 16,            // GETATTR: GetattrIn
+        4 => 88,            // SETATTR: SetattrIn
+        5 => 0,             // READLINK: no arguments
+        6 => 0,             // SYMLINK: name + linkname
+        8 => 16,            // MKNOD: MknodIn
+        9 => 8,             // MKDIR: MkdirIn
+        10 | 11 => 0,       // UNLINK/RMDIR: name only
+        12 => 8,            // RENAME: RenameIn
+        13 => 8,            // LINK: LinkIn
+        14 => 8,            // OPEN: OpenIn
+        15 => 40,           // READ: ReadIn
+        16 => 40,           // WRITE: WriteIn
+        17 => 0,            // STATFS: no arguments
+        18 => 24,           // RELEASE: ReleaseIn
+        20 => 16,           // FSYNC: FsyncIn
+        21 => 8,            // SETXATTR: SetxattrIn
+        22 => 8,            // GETXATTR: GetxattrIn
+        23 => 8,            // LISTXATTR: GetxattrIn
+        24 => 0,            // REMOVEXATTR: name only
+        25 => 24,           // FLUSH: FlushIn
+        26 => 16,           // INIT: InitIn
+        27 => 8,            // OPENDIR: OpenIn
+        28 | 44 => 40,      // READDIR/READDIRPLUS: ReadIn
+        29 => 24,           // RELEASEDIR: ReleaseIn
+        30 => 16,           // FSYNCDIR: FsyncIn
+        31 | 32 | 33 => 48, // GETLK/SETLK/SETLKW: LkIn
+        34 => 8,            // ACCESS: AccessIn
+        35 => 16,           // CREATE: CreateIn
+        36 => 8,            // INTERRUPT: InterruptIn
+        37 => 16,           // BMAP: BmapIn
+        38 => 0,            // DESTROY: no arguments
+        39 => 32,           // IOCTL: IoctlIn
+        40 => 24,           // POLL: PollIn
+        41 => 0,            // NOTIFY_REPLY: payload only
+        42 => 8,            // BATCH_FORGET: BatchForgetIn
+        43 => 32,           // FALLOCATE: FallocateIn
+        45 => 16,           // RENAME2: Rename2In
+        46 => 24,           // LSEEK: LseekIn
+        47 => 56,           // COPY_FILE_RANGE: CopyFileRangeIn
+        // SETUPMAPPING/REMOVEMAPPING only exist on the virtiofs DAX window
+        // path and are never delivered through /dev/fuse, and opcodes 0, 7,
+        // 19 and beyond 49 are undefined or reserved.
+        _ => return None,
+    };
+    Some(len)
+}
+
+/// A buffer-only [Writer] for io_uring replies.
+///
+/// The reply is fully staged in memory; staging is completed by the caller
+/// copying the staged bytes into the ring entry areas, so `commit()` only
+/// accounts the staged bytes instead of issuing a device write.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UringWriter<'a, S: BitmapSlice = ()> {
+    buf: ManuallyDrop<Vec<u8>>,
+    phantom: std::marker::PhantomData<&'a mut [S]>,
+}
+
+impl<'a, S: BitmapSlice> UringWriter<'a, S> {
+    /// Construct a new writer staging the reply in `buf`.
+    pub fn new(buf: &'a mut [u8]) -> Self {
+        let buf = unsafe { Vec::from_raw_parts(buf.as_mut_ptr(), 0, buf.len()) };
+        UringWriter {
+            buf: ManuallyDrop::new(buf),
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Split the writer at the given offset, following the [Writer] semantics.
+    pub fn split_at(&mut self, offset: usize) -> Result<UringWriter<'a, S>> {
+        if self.buf.capacity() < offset {
+            return Err(SplitOutOfBounds(offset));
+        }
+
+        let (len1, len2) = if self.buf.len() > offset {
+            (offset, self.buf.len() - offset)
+        } else {
+            (self.buf.len(), 0)
+        };
+        let cap2 = self.buf.capacity() - offset;
+        let ptr = self.buf.as_mut_ptr();
+
+        // Safe because both buffers refer to different parts of the same
+        // underlying buffer and never overlap.
+        self.buf = unsafe { ManuallyDrop::new(Vec::from_raw_parts(ptr, len1, offset)) };
+        let buf = unsafe { ManuallyDrop::new(Vec::from_raw_parts(ptr.add(offset), len2, cap2)) };
+
+        Ok(UringWriter {
+            buf,
+            phantom: std::marker::PhantomData,
+        })
+    }
+
+    /// Return the number of bytes already staged.
+    pub fn bytes_written(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Return the number of bytes available for staging.
+    pub fn available_bytes(&self) -> usize {
+        self.buf.capacity() - self.buf.len()
+    }
+
+    /// Account the staged bytes of self and `other`.
+    pub fn commit(&mut self, other: Option<&Writer<'a, S>>) -> io::Result<usize> {
+        let o = match other {
+            Some(Writer::Uring(w)) => w.bytes_written(),
+            _ => 0,
+        };
+        Ok(self.buf.len() + o)
+    }
+
+    /// Write an object to the writer.
+    pub fn write_obj<T: ByteValued>(&mut self, val: T) -> io::Result<()> {
+        self.write_all(val.as_slice())
+    }
+
+    /// Stage data read from a file descriptor at offset `off`.
+    pub fn write_from_at<F: FileReadWriteVolatile>(
+        &mut self,
+        mut src: F,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        self.check_available_space(count)?;
+
+        let cnt = src.read_vectored_at_volatile(
+            // Safe because check_available_space() ensures the capacity.
+            unsafe {
+                &[FileVolatileSlice::from_raw_ptr(
+                    self.buf.as_mut_ptr().add(self.buf.len()),
+                    count,
+                )]
+            },
+            off,
+        )?;
+        let new_len = self.buf.len() + cnt;
+        // Safe because cnt <= count was checked above.
+        unsafe { self.buf.set_len(new_len) };
+        Ok(cnt)
+    }
+
+    fn check_available_space(&self, sz: usize) -> io::Result<()> {
+        if sz > self.available_bytes() {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "data out of range, available {} requested {}",
+                    self.available_bytes(),
+                    sz
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<S: BitmapSlice> Write for UringWriter<'_, S> {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.check_available_space(data.len())?;
+        self.buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let total = bufs.iter().fold(0, |acc, b| acc + b.len());
+        self.check_available_space(total)?;
+        let count = bufs.iter().filter(|b| !b.is_empty()).fold(0, |acc, b| {
+            self.buf.extend_from_slice(b);
+            acc + b.len()
+        });
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+// The buffer is owned by the caller; UringWriter only holds a `ManuallyDrop`
+// Vec shell over it, so dropping the writer never frees the memory.
+
+/// One ring entry: the memory areas the kernel reads/writes plus scratch
+/// regions used to reassemble requests and collect replies.
+struct UringEntry {
+    qid: u16,
+    /// Single allocation, laid out as
+    /// [FuseUringReqHeader][payload][request scratch][reply scratch].
+    mem: Box<[u8]>,
+    payload_cap: usize,
+    /// iovec array referenced by the SQEs, must stay at a stable address.
+    iovecs: Box<[libc::iovec; FUSE_URING_IOV_SEGS]>,
+}
+
+impl UringEntry {
+    fn new(qid: u16, payload_cap: usize) -> UringEntry {
+        let scratch = FUSE_HEADER_SIZE + payload_cap;
+        let total = std::mem::size_of::<FuseUringReqHeader>() + payload_cap + 2 * scratch;
+        let mem = vec![0u8; total].into_boxed_slice();
+        let base = mem.as_ptr();
+        let iovecs = Box::new([
+            libc::iovec {
+                iov_base: base as *mut libc::c_void,
+                iov_len: std::mem::size_of::<FuseUringReqHeader>(),
+            },
+            libc::iovec {
+                iov_base: unsafe { base.add(std::mem::size_of::<FuseUringReqHeader>()) }
+                    as *mut libc::c_void,
+                iov_len: payload_cap,
+            },
+        ]);
+        UringEntry {
+            qid,
+            mem,
+            payload_cap,
+            iovecs,
+        }
+    }
+
+    fn header(&self) -> &FuseUringReqHeader {
+        let ptr = self.mem.as_ptr() as *const FuseUringReqHeader;
+        // Safe because the allocation starts with an aligned FuseUringReqHeader.
+        unsafe { &*ptr }
+    }
+
+    fn header_mut(&mut self) -> &mut FuseUringReqHeader {
+        let ptr = self.mem.as_mut_ptr() as *mut FuseUringReqHeader;
+        // Safe because the allocation starts with an aligned FuseUringReqHeader.
+        unsafe { &mut *ptr }
+    }
+
+    /// Build the `FUSE_IO_URING_CMD_REGISTER`/`COMMIT_AND_FETCH` SQE for this
+    /// entry, with `commit_id` set in the command payload.
+    fn cmd_sqe(&self, fd: i32, cmd_op: u32, commit_id: u64, user_data: u64) -> squeue::Entry128 {
+        let cmd = FuseUringCmdReq {
+            qid: self.qid,
+            commit_id,
+            ..Default::default()
+        };
+        let mut bytes = [0u8; 80];
+        bytes[..std::mem::size_of::<FuseUringCmdReq>()].copy_from_slice(cmd.as_slice());
+
+        let mut sqe = opcode::UringCmd80::new(types::Fd(fd), cmd_op)
+            .cmd(bytes)
+            .build();
+        // sqe->addr points to the iovec array and sqe->len to the segment
+        // count, as required by fuse_uring_get_iovec_from_sqe(). The crate
+        // exposes no accessor for them on URING_CMD entries, so patch them
+        // through a layout mirror of the SQE.
+        //
+        // Safe because SqeMirror mirrors the kernel ABI layout of
+        // io_uring_sqe and Entry128 is an SQE plus a 64-byte command area;
+        // the sizes are asserted below and only addr/len are overwritten.
+        unsafe {
+            assert_eq!(
+                std::mem::size_of::<(SqeMirror, [u8; 64])>(),
+                std::mem::size_of::<squeue::Entry128>()
+            );
+            let (mut inner, cmd_area) =
+                std::mem::transmute::<squeue::Entry128, (SqeMirror, [u8; 64])>(sqe);
+            inner.addr = self.iovecs.as_ptr() as u64;
+            inner.len = FUSE_URING_IOV_SEGS as u32;
+            sqe = std::mem::transmute::<(SqeMirror, [u8; 64]), squeue::Entry128>((inner, cmd_area));
+        }
+        sqe.user_data(user_data)
+    }
+
+    /// Stage a `-EIO` error reply after a failed `process()`, so that the
+    /// subsequent `COMMIT_AND_FETCH` hands the client a proper error instead
+    /// of the request data still sitting in the entry areas.
+    fn stage_error_reply(&mut self) {
+        let header = self.header_mut();
+        let mut in_hdr = InHeader::default();
+        in_hdr
+            .as_mut_slice()
+            .copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
+        let out = OutHeader {
+            len: OUT_HEADER_SIZE as u32,
+            error: -libc::EIO,
+            unique: in_hdr.unique,
+        };
+        header.in_out[..OUT_HEADER_SIZE].copy_from_slice(out.as_slice());
+        header.ring_ent_in_out.payload_sz = 0;
+    }
+}
+
+/// One io_uring based serving thread, responsible for a subset of the kernel
+/// queues.
+struct UringWorker<F: FileSystem + Send + Sync + 'static> {
+    fd: File,
+    qids: Vec<u16>,
+    entries_per_queue: usize,
+    payload_cap: usize,
+    server: Arc<Server<F>>,
+}
+
+impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
+    fn run(self, exit: Arc<AtomicBool>, ready_tx: Sender<io::Result<()>>) -> io::Result<()> {
+        let total_entries = self.qids.len() * self.entries_per_queue;
+        let mut ring: IoUring<squeue::Entry128, cqueue::Entry> =
+            IoUring::<squeue::Entry128, cqueue::Entry>::generic_builder()
+                .build((total_entries * 2) as u32)?;
+        let fd = self.fd.as_raw_fd();
+
+        let mut entries: Vec<UringEntry> = Vec::with_capacity(total_entries);
+        for qid in &self.qids {
+            for _ in 0..self.entries_per_queue {
+                entries.push(UringEntry::new(*qid, self.payload_cap));
+            }
+        }
+
+        // Register all entries; the CQE of each REGISTER SQE returns once a
+        // request has been assigned to the entry.
+        let registered = (|| {
+            let mut sq = ring.submission();
+            for (idx, entry) in entries.iter().enumerate() {
+                let sqe = entry.cmd_sqe(fd, FUSE_IO_URING_CMD_REGISTER, 0, idx as u64);
+                // Safe because entries live for the whole lifetime of the loop.
+                unsafe { sq.push(&sqe) }
+                    .map_err(|e| io::Error::other(format!("submission queue full: {e}")))?;
+            }
+            drop(sq);
+            ring.submit()
+        })()
+        .map(|_| ());
+        let _ = ready_tx.send(match &registered {
+            Ok(()) => Ok(()),
+            Err(e) => Err(io::Error::other(e.to_string())),
+        });
+        registered?;
+
+        loop {
+            ring.submit_and_wait(1)?;
+
+            // Drain the completion queue first so that its borrow is
+            // released before entries are processed and commits submitted.
+            let completed: Vec<(usize, i32)> = ring
+                .completion()
+                .map(|cqe| (cqe.user_data() as usize, cqe.result()))
+                .collect();
+            if completed.is_empty() {
+                continue;
+            }
+
+            for (idx, res) in completed {
+                if idx >= entries.len() {
+                    warn!("uring worker: CQE with unexpected user_data {}", idx);
+                    continue;
+                }
+                let entry = &mut entries[idx];
+                if res < 0 {
+                    if exit.load(Ordering::Relaxed) {
+                        return Ok(());
+                    }
+                    // Registration/commit failures leave the entry in an
+                    // undefined state; stop serving rather than guessing.
+                    return Err(io::Error::from_raw_os_error(-res));
+                }
+
+                if let Err(e) = self.process(entry) {
+                    warn!("uring worker: failed to handle request: {e}");
+                    entry.stage_error_reply();
+                }
+
+                let ent: FuseUringEntInOut = entry.header().ring_ent_in_out;
+                let sqe = entry.cmd_sqe(
+                    fd,
+                    FUSE_IO_URING_CMD_COMMIT_AND_FETCH,
+                    ent.commit_id,
+                    idx as u64,
+                );
+                loop {
+                    let pushed = {
+                        let mut sq = ring.submission();
+                        // Safe because the entry outlives the ring usage.
+                        unsafe { sq.push(&sqe) }.is_ok()
+                    };
+                    if pushed {
+                        break;
+                    }
+                    // The submission queue can never hold more outstanding
+                    // commits than completed entries, so submitting must
+                    // eventually make room.
+                    ring.submit()?;
+                }
+            }
+            ring.submit()?;
+        }
+    }
+
+    /// Handle one delivered request: reassemble the classic wire layout,
+    /// dispatch to the server and stage the reply into the entry areas.
+    fn process(&self, entry: &mut UringEntry) -> Result<()> {
+        // Copy the request parts out first, so that the reply scratch region
+        // can be borrowed mutably afterwards without aliasing.
+        let in_header: InHeader = {
+            let header = entry.header();
+            let mut hdr = InHeader::default();
+            hdr.as_mut_slice()
+                .copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
+            hdr
+        };
+        let args_len = in_args_len(in_header.opcode).ok_or_else(|| {
+            SessionFailure(format!(
+                "uring: unsupported opcode {} for queue {}",
+                in_header.opcode, entry.qid
+            ))
+        })?;
+        let payload_sz = entry.header().ring_ent_in_out.payload_sz as usize;
+        if args_len > FUSE_URING_IN_OUT_HEADER_SZ || payload_sz > entry.payload_cap {
+            return Err(SessionFailure(format!(
+                "uring: malformed request, opcode {} args {} payload {}",
+                in_header.opcode, args_len, payload_sz
+            )));
+        }
+
+        let msg_len = IN_HEADER_SIZE + args_len + payload_sz;
+        let header_len = std::mem::size_of::<FuseUringReqHeader>();
+        let scratch = FUSE_HEADER_SIZE + entry.payload_cap;
+        let base = entry.mem.as_mut_ptr();
+
+        // Reassemble the classic contiguous layout in the request scratch
+        // region: fuse_in_header + per-opcode arguments + payload.
+        //
+        // Safe because all slices below address disjoint regions of the
+        // entry allocation and live for the duration of this function only.
+        unsafe {
+            let header = &*(base as *const FuseUringReqHeader);
+            let req = std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), scratch);
+            let payload = std::slice::from_raw_parts(base.add(header_len), entry.payload_cap);
+            let mut off = 0;
+            req[off..off + IN_HEADER_SIZE].copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
+            off += IN_HEADER_SIZE;
+            req[off..off + args_len].copy_from_slice(&header.op_in[..args_len]);
+            off += args_len;
+            req[off..off + payload_sz].copy_from_slice(&payload[..payload_sz]);
+            // in_header.len describes the classic contiguous message.
+            req[..4].copy_from_slice(&(msg_len as u32).to_le_bytes());
+        }
+
+        let total = {
+            // Safe because the request and reply scratch regions are disjoint
+            // and no other references to the entry exist in this scope.
+            let reader = unsafe {
+                let req = std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), msg_len);
+                Reader::<()>::from_fuse_buffer(FuseBuf::new(req))?
+            };
+            let writer = unsafe {
+                let reply = std::slice::from_raw_parts_mut(
+                    base.add(header_len + entry.payload_cap + scratch),
+                    scratch,
+                );
+                UringWriter::new(reply)
+            };
+            self.server
+                .handle_message(reader, Writer::Uring(writer), None, None)
+                .map_err(|e| {
+                    SessionFailure(format!(
+                        "uring: handle message unique 0x{:x}: {}",
+                        in_header.unique, e
+                    ))
+                })?
+        };
+
+        if total > 0 {
+            // The staged reply must fit the entry header slot plus the
+            // payload area; anything larger cannot be committed.
+            if total < OUT_HEADER_SIZE || total > OUT_HEADER_SIZE + entry.payload_cap {
+                return Err(SessionFailure(format!(
+                    "uring: malformed reply of {} bytes for unique 0x{:x}",
+                    total, in_header.unique
+                )));
+            }
+            // The staged reply starts with fuse_out_header; move it into the
+            // entry header slot and stage the rest in the payload area.
+            //
+            // Safe because all slices below address disjoint regions of the
+            // entry allocation.
+            unsafe {
+                let header = &mut *(base as *mut FuseUringReqHeader);
+                let reply = std::slice::from_raw_parts(
+                    base.add(header_len + entry.payload_cap + scratch),
+                    total,
+                );
+                header.in_out[..OUT_HEADER_SIZE].copy_from_slice(&reply[..OUT_HEADER_SIZE]);
+                let payload_len = total - OUT_HEADER_SIZE;
+                let payload = std::slice::from_raw_parts_mut(base.add(header_len), entry.payload_cap);
+                payload[..payload_len].copy_from_slice(&reply[OUT_HEADER_SIZE..]);
+                header.ring_ent_in_out.payload_sz = payload_len as u32;
+            }
+        } else {
+            // Forget-like requests carry no reply.
+            entry.header_mut().ring_ent_in_out.payload_sz = 0;
+        }
+
+        Ok(())
+    }
+}
+
+/// Serve FUSE requests over io_uring (experimental).
+///
+/// The serving layer takes ownership of the mounted session: dropping it
+/// unmounts the filesystem and joins all serving threads.
+pub struct UringFuseServing<F: FileSystem + Send + Sync + 'static> {
+    session: FuseSession,
+    exit: Arc<AtomicBool>,
+    workers: Vec<JoinHandle<io::Result<()>>>,
+    fallback: Option<JoinHandle<()>>,
+    _fs: std::marker::PhantomData<F>,
+}
+
+impl<F: FileSystem + Send + Sync + 'static> UringFuseServing<F> {
+    /// Create a new io_uring serving transport on an already mounted session.
+    ///
+    /// The `FUSE_OVER_IO_URING` capability must have been requested through
+    /// `Server::set_uring()` before mounting. This constructor consumes the
+    /// INIT request on a classic channel and verifies that the kernel
+    /// accepted the capability, returning `Error::UringNotSupported`
+    /// otherwise so that the caller can fall back to the classic transport.
+    pub fn new(
+        session: FuseSession,
+        server: Arc<Server<F>>,
+        cfg: UringConfig,
+    ) -> Result<UringFuseServing<F>> {
+        warn!("FUSE-over-io_uring transport is experimental, the kernel interface may change");
+
+        let payload_cap = session.bufsize().saturating_sub(FUSE_HEADER_SIZE);
+        let nr_queues = possible_cpu_count()?;
+
+        // The first message on a new connection is always FUSE_INIT; handle
+        // it on a classic channel and verify the negotiation outcome.
+        let mut init_ch = session.new_channel()?;
+        let fallback_ch = session.new_channel()?;
+        match init_ch.get_request() {
+            Ok(Some((reader, writer))) => {
+                server
+                    .handle_message(reader, Writer::FuseDev(writer), None, None)
+                    .map_err(|e| SessionFailure(format!("uring: INIT failed: {e}")))?;
+            }
+            Ok(None) => {
+                return Err(SessionFailure(
+                    "uring: session interrupted during INIT".into(),
+                ))
+            }
+            Err(e) => return Err(SessionFailure(format!("uring: INIT read failed: {e}"))),
+        }
+        if !server.uring_enabled() {
+            return Err(UringNotSupported);
+        }
+
+        let workers = if cfg.workers == 0 {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+        } else {
+            cfg.workers
+        };
+        let workers = workers.min(nr_queues);
+
+        let mut queue_ids: Vec<Vec<u16>> = vec![Vec::new(); workers];
+        for qid in 0..nr_queues {
+            queue_ids[qid % workers].push(qid as u16);
+        }
+
+        let file = session
+            .get_fuse_file()
+            .ok_or_else(|| SessionFailure("uring: session not mounted".into()))?
+            .try_clone()
+            .map_err(|e| SessionFailure(format!("uring: dup fuse fd: {e}")))?;
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let (ready_tx, ready_rx) = channel();
+        let mut handles = Vec::with_capacity(workers);
+        for ids in queue_ids {
+            let worker = UringWorker {
+                fd: file
+                    .try_clone()
+                    .map_err(|e| SessionFailure(format!("uring: dup fuse fd: {e}")))?,
+                qids: ids,
+                entries_per_queue: cfg.entries_per_queue,
+                payload_cap,
+                server: server.clone(),
+            };
+            let handle = thread::Builder::new()
+                .name(format!("uring-{}", handles.len()))
+                .spawn({
+                    let exit = exit.clone();
+                    let ready_tx = ready_tx.clone();
+                    move || worker.run(exit, ready_tx)
+                })
+                .map_err(|e| SessionFailure(format!("uring: spawn worker: {e}")))?;
+            handles.push(handle);
+        }
+        drop(ready_tx);
+
+        // Wait until all entries are registered, bailing out on the first
+        // worker failure (e.g. the fuse module parameter disabled uring).
+        for _ in 0..workers {
+            match ready_rx.recv() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    return Err(SessionFailure(format!(
+                        "uring: entry registration failed: {e}"
+                    )));
+                }
+                Err(_) => {
+                    return Err(SessionFailure(
+                        "uring: worker exited during registration".to_string(),
+                    ));
+                }
+            }
+        }
+        let live = handles;
+
+        let fallback = thread::Builder::new()
+            .name("uring-fallback".to_string())
+            .spawn({
+                let exit = exit.clone();
+                move || Self::fallback_loop(fallback_ch, server, exit)
+            })
+            .map_err(|e| SessionFailure(format!("uring: spawn fallback thread: {e}")))?;
+
+        Ok(UringFuseServing {
+            session,
+            exit,
+            workers: live,
+            fallback: Some(fallback),
+            _fs: std::marker::PhantomData,
+        })
+    }
+
+    fn fallback_loop(mut ch: FuseChannel, server: Arc<Server<F>>, exit: Arc<AtomicBool>) {
+        loop {
+            match ch.get_request() {
+                Ok(Some((reader, writer))) => {
+                    if let Err(e) =
+                        server.handle_message(reader, Writer::FuseDev(writer), None, None)
+                    {
+                        match e {
+                            // The kernel has shut down this session.
+                            crate::Error::EncodeMessage(ref err)
+                                if err.raw_os_error() == Some(libc::EBADF) =>
+                            {
+                                break
+                            }
+                            _ => {
+                                warn!("uring fallback: failed to handle message: {e}");
+                                continue;
+                            }
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(_) => break,
+            }
+            if exit.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+    }
+}
+
+impl<F: FileSystem + Send + Sync + 'static> Drop for UringFuseServing<F> {
+    fn drop(&mut self) {
+        self.exit.store(true, Ordering::Relaxed);
+        let _ = self.session.wake();
+        // Tearing down the connection completes all outstanding ring entries
+        // with an error, which unblocks the worker threads.
+        let _ = self.session.umount();
+        if let Some(handle) = self.fallback.take() {
+            let _ = handle.join();
+        }
+        for handle in self.workers.drain(..) {
+            let _ = handle.join();
+        }
+    }
+}

--- a/src/transport/fusedev/uring_session.rs
+++ b/src/transport/fusedev/uring_session.rs
@@ -97,11 +97,7 @@ fn parse_cpu_mask(content: &str) -> Result<usize> {
         let (start, end) = match range.as_slice() {
             [a] => (*a, *a),
             [a, b] => (*a, *b),
-            _ => {
-                return Err(SessionFailure(format!(
-                    "invalid cpu mask range: {part}"
-                )))
-            }
+            _ => return Err(SessionFailure(format!("invalid cpu mask range: {part}"))),
         };
         let start: usize = start
             .trim()
@@ -137,47 +133,47 @@ fn possible_cpu_count() -> Result<usize> {
 /// without a fixed header; `None` marks opcodes the daemon cannot serve.
 fn in_args_len(opcode: u32) -> Option<usize> {
     let len = match opcode {
-        1 => 0,             // LOOKUP: name only
-        2 => 8,             // FORGET: ForgetIn
-        3 => 16,            // GETATTR: GetattrIn
-        4 => 88,            // SETATTR: SetattrIn
-        5 => 0,             // READLINK: no arguments
-        6 => 0,             // SYMLINK: name + linkname
-        8 => 16,            // MKNOD: MknodIn
-        9 => 8,             // MKDIR: MkdirIn
-        10 | 11 => 0,       // UNLINK/RMDIR: name only
-        12 => 8,            // RENAME: RenameIn
-        13 => 8,            // LINK: LinkIn
-        14 => 8,            // OPEN: OpenIn
-        15 => 40,           // READ: ReadIn
-        16 => 40,           // WRITE: WriteIn
-        17 => 0,            // STATFS: no arguments
-        18 => 24,           // RELEASE: ReleaseIn
-        20 => 16,           // FSYNC: FsyncIn
-        21 => 8,            // SETXATTR: SetxattrIn
-        22 => 8,            // GETXATTR: GetxattrIn
-        23 => 8,            // LISTXATTR: GetxattrIn
-        24 => 0,            // REMOVEXATTR: name only
-        25 => 24,           // FLUSH: FlushIn
-        26 => 16,           // INIT: InitIn
-        27 => 8,            // OPENDIR: OpenIn
-        28 | 44 => 40,      // READDIR/READDIRPLUS: ReadIn
-        29 => 24,           // RELEASEDIR: ReleaseIn
-        30 => 16,           // FSYNCDIR: FsyncIn
-        31 | 32 | 33 => 48, // GETLK/SETLK/SETLKW: LkIn
-        34 => 8,            // ACCESS: AccessIn
-        35 => 16,           // CREATE: CreateIn
-        36 => 8,            // INTERRUPT: InterruptIn
-        37 => 16,           // BMAP: BmapIn
-        38 => 0,            // DESTROY: no arguments
-        39 => 32,           // IOCTL: IoctlIn
-        40 => 24,           // POLL: PollIn
-        41 => 0,            // NOTIFY_REPLY: payload only
-        42 => 8,            // BATCH_FORGET: BatchForgetIn
-        43 => 32,           // FALLOCATE: FallocateIn
-        45 => 16,           // RENAME2: Rename2In
-        46 => 24,           // LSEEK: LseekIn
-        47 => 56,           // COPY_FILE_RANGE: CopyFileRangeIn
+        1 => 0,        // LOOKUP: name only
+        2 => 8,        // FORGET: ForgetIn
+        3 => 16,       // GETATTR: GetattrIn
+        4 => 88,       // SETATTR: SetattrIn
+        5 => 0,        // READLINK: no arguments
+        6 => 0,        // SYMLINK: name + linkname
+        8 => 16,       // MKNOD: MknodIn
+        9 => 8,        // MKDIR: MkdirIn
+        10 | 11 => 0,  // UNLINK/RMDIR: name only
+        12 => 8,       // RENAME: RenameIn
+        13 => 8,       // LINK: LinkIn
+        14 => 8,       // OPEN: OpenIn
+        15 => 40,      // READ: ReadIn
+        16 => 40,      // WRITE: WriteIn
+        17 => 0,       // STATFS: no arguments
+        18 => 24,      // RELEASE: ReleaseIn
+        20 => 16,      // FSYNC: FsyncIn
+        21 => 8,       // SETXATTR: SetxattrIn
+        22 => 8,       // GETXATTR: GetxattrIn
+        23 => 8,       // LISTXATTR: GetxattrIn
+        24 => 0,       // REMOVEXATTR: name only
+        25 => 24,      // FLUSH: FlushIn
+        26 => 16,      // INIT: InitIn
+        27 => 8,       // OPENDIR: OpenIn
+        28 | 44 => 40, // READDIR/READDIRPLUS: ReadIn
+        29 => 24,      // RELEASEDIR: ReleaseIn
+        30 => 16,      // FSYNCDIR: FsyncIn
+        31..=33 => 48, // GETLK/SETLK/SETLKW: LkIn
+        34 => 8,       // ACCESS: AccessIn
+        35 => 16,      // CREATE: CreateIn
+        36 => 8,       // INTERRUPT: InterruptIn
+        37 => 16,      // BMAP: BmapIn
+        38 => 0,       // DESTROY: no arguments
+        39 => 32,      // IOCTL: IoctlIn
+        40 => 24,      // POLL: PollIn
+        41 => 0,       // NOTIFY_REPLY: payload only
+        42 => 8,       // BATCH_FORGET: BatchForgetIn
+        43 => 32,      // FALLOCATE: FallocateIn
+        45 => 16,      // RENAME2: Rename2In
+        46 => 24,      // LSEEK: LseekIn
+        47 => 56,      // COPY_FILE_RANGE: CopyFileRangeIn
         // SETUPMAPPING/REMOVEMAPPING only exist on the virtiofs DAX window
         // path and are never delivered through /dev/fuse, and opcodes 0, 7,
         // 19 and beyond 49 are undefined or reserved.
@@ -568,7 +564,8 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
         // entry allocation and live for the duration of this function only.
         unsafe {
             let header = &*(base as *const FuseUringReqHeader);
-            let req = std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), scratch);
+            let req =
+                std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), scratch);
             let payload = std::slice::from_raw_parts(base.add(header_len), entry.payload_cap);
             let mut off = 0;
             req[off..off + IN_HEADER_SIZE].copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
@@ -584,7 +581,10 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
             // Safe because the request and reply scratch regions are disjoint
             // and no other references to the entry exist in this scope.
             let reader = unsafe {
-                let req = std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), msg_len);
+                let req = std::slice::from_raw_parts_mut(
+                    base.add(header_len + entry.payload_cap),
+                    msg_len,
+                );
                 Reader::<()>::from_fuse_buffer(FuseBuf::new(req))?
             };
             let writer = unsafe {
@@ -626,7 +626,8 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
                 );
                 header.in_out[..OUT_HEADER_SIZE].copy_from_slice(&reply[..OUT_HEADER_SIZE]);
                 let payload_len = total - OUT_HEADER_SIZE;
-                let payload = std::slice::from_raw_parts_mut(base.add(header_len), entry.payload_cap);
+                let payload =
+                    std::slice::from_raw_parts_mut(base.add(header_len), entry.payload_cap);
                 payload[..payload_len].copy_from_slice(&reply[OUT_HEADER_SIZE..]);
                 header.ring_ent_in_out.payload_sz = payload_len as u32;
             }
@@ -815,5 +816,398 @@ impl<F: FileSystem + Send + Sync + 'static> Drop for UringFuseServing<F> {
         for handle in self.workers.drain(..) {
             let _ = handle.join();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use vmm_sys_util::tempdir::TempDir;
+
+    use crate::abi::fuse_abi::{
+        AccessIn, AttrOut, BatchForgetIn, BmapIn, CopyFileRangeIn, CreateIn, EntryOut, FallocateIn,
+        FlushIn, ForgetIn, FsyncIn, GetattrIn, GetxattrIn, InHeader, InitIn, InterruptIn, IoctlIn,
+        LinkIn, LkIn, LseekIn, MkdirIn, MknodIn, Opcode, OpenIn, OutHeader, PollIn, ReadIn,
+        ReleaseIn, Rename2In, RenameIn, SetattrIn, SetxattrIn, WriteIn, ROOT_ID,
+    };
+    use crate::api::filesystem::FsOptions;
+    use crate::passthrough::{Config, PassthroughFs};
+
+    #[test]
+    fn test_parse_cpu_mask() {
+        assert_eq!(parse_cpu_mask("0").unwrap(), 1);
+        assert_eq!(parse_cpu_mask("0-3\n").unwrap(), 4);
+        assert_eq!(parse_cpu_mask("0-3,5,8-11").unwrap(), 9);
+        assert!(parse_cpu_mask("").is_err());
+        assert!(parse_cpu_mask("3-1").is_err());
+        assert!(parse_cpu_mask("a-b").is_err());
+        assert!(parse_cpu_mask("1-2-3").is_err());
+        assert!(possible_cpu_count().unwrap() >= 1);
+    }
+
+    #[test]
+    fn test_in_args_len() {
+        // Per-opcode argument sizes, derived from the *In structures of the
+        // fuse ABI (which mirror the kernel's first in_arg per opcode) and
+        // from the server-side request decoders.
+        let expected: &[(u32, usize)] = &[
+            (Opcode::Lookup as u32, 0),
+            (Opcode::Forget as u32, std::mem::size_of::<ForgetIn>()),
+            (Opcode::Getattr as u32, std::mem::size_of::<GetattrIn>()),
+            (Opcode::Setattr as u32, std::mem::size_of::<SetattrIn>()),
+            (Opcode::Readlink as u32, 0),
+            (Opcode::Symlink as u32, 0),
+            (Opcode::Mknod as u32, std::mem::size_of::<MknodIn>()),
+            (Opcode::Mkdir as u32, std::mem::size_of::<MkdirIn>()),
+            (Opcode::Unlink as u32, 0),
+            (Opcode::Rmdir as u32, 0),
+            (Opcode::Rename as u32, std::mem::size_of::<RenameIn>()),
+            (Opcode::Link as u32, std::mem::size_of::<LinkIn>()),
+            (Opcode::Open as u32, std::mem::size_of::<OpenIn>()),
+            (Opcode::Read as u32, std::mem::size_of::<ReadIn>()),
+            (Opcode::Write as u32, std::mem::size_of::<WriteIn>()),
+            (Opcode::Statfs as u32, 0),
+            (Opcode::Release as u32, std::mem::size_of::<ReleaseIn>()),
+            (Opcode::Fsync as u32, std::mem::size_of::<FsyncIn>()),
+            (Opcode::Setxattr as u32, std::mem::size_of::<SetxattrIn>()),
+            (Opcode::Getxattr as u32, std::mem::size_of::<GetxattrIn>()),
+            (Opcode::Listxattr as u32, std::mem::size_of::<GetxattrIn>()),
+            (Opcode::Removexattr as u32, 0),
+            (Opcode::Flush as u32, std::mem::size_of::<FlushIn>()),
+            (Opcode::Init as u32, std::mem::size_of::<InitIn>()),
+            (Opcode::Opendir as u32, std::mem::size_of::<OpenIn>()),
+            (Opcode::Readdir as u32, std::mem::size_of::<ReadIn>()),
+            (Opcode::Releasedir as u32, std::mem::size_of::<ReleaseIn>()),
+            (Opcode::Fsyncdir as u32, std::mem::size_of::<FsyncIn>()),
+            (Opcode::Getlk as u32, std::mem::size_of::<LkIn>()),
+            (Opcode::Setlk as u32, std::mem::size_of::<LkIn>()),
+            (Opcode::Setlkw as u32, std::mem::size_of::<LkIn>()),
+            (Opcode::Access as u32, std::mem::size_of::<AccessIn>()),
+            (Opcode::Create as u32, std::mem::size_of::<CreateIn>()),
+            (Opcode::Interrupt as u32, std::mem::size_of::<InterruptIn>()),
+            (Opcode::Bmap as u32, std::mem::size_of::<BmapIn>()),
+            (Opcode::Destroy as u32, 0),
+            (Opcode::Ioctl as u32, std::mem::size_of::<IoctlIn>()),
+            (Opcode::Poll as u32, std::mem::size_of::<PollIn>()),
+            (Opcode::NotifyReply as u32, 0),
+            (
+                Opcode::BatchForget as u32,
+                std::mem::size_of::<BatchForgetIn>(),
+            ),
+            (Opcode::Fallocate as u32, std::mem::size_of::<FallocateIn>()),
+            (Opcode::Readdirplus as u32, std::mem::size_of::<ReadIn>()),
+            (Opcode::Rename2 as u32, std::mem::size_of::<Rename2In>()),
+            (Opcode::Lseek as u32, std::mem::size_of::<LseekIn>()),
+            (
+                Opcode::CopyFileRange as u32,
+                std::mem::size_of::<CopyFileRangeIn>(),
+            ),
+        ];
+        for &(op, len) in expected {
+            assert_eq!(in_args_len(op), Some(len), "opcode {}", op);
+        }
+        // Everything else (holes, virtiofs-only and undefined opcodes)
+        // must be rejected.
+        for op in 0..=64u32 {
+            if !expected.iter().any(|&(e, _)| e == op) {
+                assert_eq!(in_args_len(op), None, "opcode {}", op);
+            }
+        }
+        assert_eq!(in_args_len(u32::MAX), None);
+    }
+
+    #[test]
+    fn test_uring_entry_layout() {
+        let payload_cap = 4096;
+        let entry = UringEntry::new(3, payload_cap);
+        assert_eq!(entry.qid, 3);
+
+        let header_len = std::mem::size_of::<FuseUringReqHeader>();
+        let total = header_len + payload_cap + 2 * (FUSE_HEADER_SIZE + payload_cap);
+        assert_eq!(entry.mem.len(), total);
+
+        // The iovec array must describe the header and payload areas of the
+        // same allocation, at stable addresses.
+        let base = entry.mem.as_ptr() as usize;
+        assert_eq!(entry.iovecs[0].iov_base as usize, base);
+        assert_eq!(entry.iovecs[0].iov_len, header_len);
+        assert_eq!(entry.iovecs[1].iov_base as usize, base + header_len);
+        assert_eq!(entry.iovecs[1].iov_len, payload_cap);
+
+        // All slots of the header must be reachable through the pointers.
+        assert_eq!(entry.header().ring_ent_in_out.payload_sz, 0);
+    }
+
+    #[test]
+    fn test_cmd_sqe() {
+        let entry = UringEntry::new(7, 64);
+        let sqe = entry.cmd_sqe(42, FUSE_IO_URING_CMD_REGISTER, 0xdead_beef, 5);
+
+        assert_eq!(
+            std::mem::size_of::<(SqeMirror, [u8; 64])>(),
+            std::mem::size_of::<squeue::Entry128>()
+        );
+        // Safe because of the size assertion above.
+        let (inner, extra): (SqeMirror, [u8; 64]) = unsafe { std::mem::transmute(sqe) };
+
+        // IORING_OP_URING_CMD as of kernel ABI 6.14.
+        assert_eq!(inner.opcode, 46);
+        assert_eq!(inner.fd, 42);
+        assert_eq!(inner.addr, entry.iovecs.as_ptr() as u64);
+        assert_eq!(inner.len, FUSE_URING_IOV_SEGS as u32);
+        assert_eq!(inner.user_data, 5);
+
+        // The io-uring crate splits the 80-byte command payload of an
+        // SQE128: the first 16 bytes are placed in the sqe cmd union
+        // (the addr3/__pad2 slots), the remaining 64 bytes in the extra
+        // area, so the payload is contiguous at sqe offsets 48..128 and
+        // io_uring_sqe128_cmd() reads it in one piece.
+        let mut cmd_bytes = [0u8; 80];
+        cmd_bytes[0..8].copy_from_slice(&inner.addr3.to_le_bytes());
+        cmd_bytes[8..16].copy_from_slice(&inner.pad2.to_le_bytes());
+        cmd_bytes[16..80].copy_from_slice(&extra);
+
+        // The command payload must carry the queue id and commit id.
+        let cmd = FuseUringCmdReq {
+            qid: 7,
+            commit_id: 0xdead_beef,
+            ..Default::default()
+        };
+        assert_eq!(
+            cmd_bytes[..std::mem::size_of::<FuseUringCmdReq>()],
+            *cmd.as_slice()
+        );
+    }
+
+    #[test]
+    fn test_uring_writer_basic() {
+        let mut scratch = vec![0u8; 128];
+        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
+        assert_eq!(w.bytes_written(), 0);
+        assert_eq!(w.available_bytes(), 128);
+
+        w.write_obj(0x1234_5678u32).unwrap();
+        w.write_all(&[1u8, 2, 3]).unwrap();
+        assert_eq!(w.bytes_written(), 7);
+        assert_eq!(w.available_bytes(), 121);
+
+        // Writes beyond the available capacity must fail without
+        // overflowing the buffer.
+        let big = vec![0u8; 200];
+        assert!(w.write(&big).is_err());
+        assert!(w.write_all(&big).is_err());
+        assert_eq!(w.bytes_written(), 7);
+        assert_eq!(&scratch[..7], &[0x78, 0x56, 0x34, 0x12, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_uring_writer_split_commit() {
+        let mut scratch = vec![0u8; 64];
+        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
+        w.write_all(&[1u8; 32]).unwrap();
+
+        let mut tail = w.split_at(16).unwrap();
+        assert_eq!(w.bytes_written(), 16);
+        assert_eq!(w.available_bytes(), 0);
+        assert_eq!(tail.bytes_written(), 16);
+        assert_eq!(tail.available_bytes(), 32);
+        tail.write_all(&[2u8; 8]).unwrap();
+
+        // commit() only accounts the staged bytes, it never touches a
+        // device.
+        let other = Writer::Uring(tail);
+        assert_eq!(w.commit(Some(&other)).unwrap(), 40);
+        // Splitting beyond the capacity is rejected.
+        assert!(w.split_at(17).is_err());
+
+        // The staged data must still be visible in the buffer.
+        assert_eq!(&scratch[..16], &[1u8; 16]);
+        assert_eq!(&scratch[16..32], &[1u8; 16]);
+        assert_eq!(&scratch[32..40], &[2u8; 8]);
+    }
+
+    #[test]
+    fn test_uring_writer_write_from_at() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.as_path().join("data");
+        std::fs::write(&path, (0..64).collect::<Vec<u8>>()).unwrap();
+
+        let mut scratch = vec![0u8; 32];
+        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
+        let file = File::open(&path).unwrap();
+        assert_eq!(
+            w.write_from_at(file.try_clone().unwrap(), 16, 8).unwrap(),
+            16
+        );
+        assert_eq!(w.bytes_written(), 16);
+
+        // More data than available space must be rejected.
+        assert!(w.write_from_at(file, 32, 0).is_err());
+        assert_eq!(&scratch[..16], &(8..24).collect::<Vec<u8>>());
+    }
+
+    /// A worker over PassthroughFs, for exercising process() without a
+    /// kernel supporting FUSE_URING.
+    fn make_worker() -> (UringWorker<Arc<PassthroughFs<()>>>, TempDir) {
+        let source = TempDir::new().unwrap();
+        let cfg = Config {
+            root_dir: source.as_path().to_str().unwrap().to_string(),
+            do_import: true,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(cfg).unwrap();
+        fs.import().unwrap();
+        fs.init(FsOptions::all()).unwrap();
+
+        let worker = UringWorker {
+            fd: File::open("/dev/null").unwrap(),
+            qids: vec![0],
+            entries_per_queue: 1,
+            payload_cap: 4096,
+            server: Arc::new(Server::new(Arc::new(fs))),
+        };
+        (worker, source)
+    }
+
+    /// Plant a request into the entry header/payload areas the way the
+    /// kernel does.
+    fn plant_request(entry: &mut UringEntry, opcode: u32, args: &[u8], payload: &[u8]) {
+        // Safe because getuid/getgid/getpid are always valid.
+        let (uid, gid, pid) = unsafe { (libc::getuid(), libc::getgid(), libc::getpid() as u32) };
+        let hdr = InHeader {
+            len: (IN_HEADER_SIZE + args.len() + payload.len()) as u32,
+            opcode,
+            unique: 2,
+            nodeid: ROOT_ID,
+            uid,
+            gid,
+            pid,
+            ..Default::default()
+        };
+
+        let header = entry.header_mut();
+        header.in_out[..IN_HEADER_SIZE].copy_from_slice(hdr.as_slice());
+        header.op_in[..args.len()].copy_from_slice(args);
+        let base = entry.mem.as_mut_ptr();
+        // Safe because the payload area is a disjoint part of the entry
+        // allocation and payload fits into payload_cap.
+        unsafe {
+            let header_len = std::mem::size_of::<FuseUringReqHeader>();
+            std::ptr::copy_nonoverlapping(payload.as_ptr(), base.add(header_len), payload.len());
+        }
+        entry.header_mut().ring_ent_in_out.payload_sz = payload.len() as u32;
+        entry.header_mut().ring_ent_in_out.commit_id = 2;
+    }
+
+    fn parse_out_header(entry: &UringEntry) -> OutHeader {
+        let mut out = OutHeader::default();
+        out.as_mut_slice()
+            .copy_from_slice(&entry.header().in_out[..OUT_HEADER_SIZE]);
+        out
+    }
+
+    #[test]
+    fn test_process_getattr() {
+        let (worker, _source) = make_worker();
+        let mut entry = UringEntry::new(0, worker.payload_cap);
+
+        let args = GetattrIn::default();
+        plant_request(&mut entry, Opcode::Getattr as u32, args.as_slice(), &[]);
+        worker.process(&mut entry).unwrap();
+
+        let out = parse_out_header(&entry);
+        assert_eq!(out.error, 0);
+        assert_eq!(out.unique, 2);
+        // The reply body is staged in the payload area behind the
+        // fuse_out_header slot.
+        assert_eq!(
+            entry.header().ring_ent_in_out.payload_sz as usize,
+            std::mem::size_of::<AttrOut>()
+        );
+        assert_eq!(entry.header().ring_ent_in_out.commit_id, 2);
+    }
+
+    #[test]
+    fn test_process_lookup_payload_only() {
+        let (worker, _source) = make_worker();
+        let mut entry = UringEntry::new(0, worker.payload_cap);
+
+        // LOOKUP carries no fixed arguments, only the name in the payload.
+        plant_request(&mut entry, Opcode::Lookup as u32, &[], b"fuse-file\0");
+        // Lookup fails with ENOENT on the empty directory, which still
+        // exercises the payload reassembly; the reply must be an error.
+        worker.process(&mut entry).unwrap();
+        let out = parse_out_header(&entry);
+        assert_eq!(out.error, -libc::ENOENT);
+        assert_eq!(entry.header().ring_ent_in_out.payload_sz, 0);
+
+        // And succeeds once the file exists.
+        std::fs::write(_source.as_path().join("fuse-file"), "x").unwrap();
+        plant_request(&mut entry, Opcode::Lookup as u32, &[], b"fuse-file\0");
+        worker.process(&mut entry).unwrap();
+        let out = parse_out_header(&entry);
+        assert_eq!(out.error, 0);
+        assert_eq!(
+            entry.header().ring_ent_in_out.payload_sz as usize,
+            std::mem::size_of::<EntryOut>()
+        );
+    }
+
+    #[test]
+    fn test_process_rejects_invalid_requests() {
+        let (worker, _source) = make_worker();
+        let mut entry = UringEntry::new(0, worker.payload_cap);
+
+        // Undefined opcodes are rejected.
+        plant_request(&mut entry, 50, &[], &[]);
+        assert!(worker.process(&mut entry).is_err());
+
+        // A payload larger than the registered area is rejected.
+        plant_request(
+            &mut entry,
+            Opcode::Getattr as u32,
+            GetattrIn::default().as_slice(),
+            &[],
+        );
+        entry.header_mut().ring_ent_in_out.payload_sz = (worker.payload_cap + 1) as u32;
+        assert!(worker.process(&mut entry).is_err());
+    }
+
+    #[test]
+    fn test_stage_error_reply_after_rejected_request() {
+        let (worker, _source) = make_worker();
+        let mut entry = UringEntry::new(0, worker.payload_cap);
+
+        // Simulate the kernel delivering a request with an undefined
+        // opcode: process() fails, and the worker must commit a proper
+        // error reply rather than echoing the request data back.
+        plant_request(&mut entry, 50, &[], &[]);
+        assert!(worker.process(&mut entry).is_err());
+        entry.stage_error_reply();
+
+        let out = parse_out_header(&entry);
+        assert_eq!(out.len, OUT_HEADER_SIZE as u32);
+        assert_eq!(out.error, -libc::EIO);
+        assert_eq!(out.unique, 2);
+        assert_eq!(entry.header().ring_ent_in_out.payload_sz, 0);
+        // The commit_id delivered by the kernel must be preserved so that
+        // COMMIT_AND_FETCH matches the request.
+        assert_eq!(entry.header().ring_ent_in_out.commit_id, 2);
+    }
+
+    #[test]
+    fn test_process_rejects_oversized_reply() {
+        let (worker, _source) = make_worker();
+        // A payload area too small to hold the GETATTR reply body must be
+        // rejected instead of panicking in the staging copy.
+        let mut entry = UringEntry::new(0, 8);
+        plant_request(
+            &mut entry,
+            Opcode::Getattr as u32,
+            GetattrIn::default().as_slice(),
+            &[],
+        );
+        assert!(worker.process(&mut entry).is_err());
     }
 }

--- a/src/transport/fusedev/uring_session.rs
+++ b/src/transport/fusedev/uring_session.rs
@@ -182,99 +182,151 @@ fn in_args_len(opcode: u32) -> Option<usize> {
     Some(len)
 }
 
-/// A buffer-only [Writer] for io_uring replies.
+/// A [Writer] for io_uring replies that routes the reply header and body
+/// into separate ring entry areas, eliminating the reply-staging memcpy.
 ///
-/// The reply is fully staged in memory; staging is completed by the caller
-/// copying the staged bytes into the ring entry areas, so `commit()` only
-/// accounts the staged bytes instead of issuing a device write.
+/// The first `OUT_HEADER_SIZE` (16) bytes written go to `header` (which
+/// points at the entry's `in_out` slot — the `fuse_out_header` area). All
+/// subsequent bytes go to `body` (which points at the entry's payload area).
+///
+/// After `handle_message` returns, both regions contain the final reply and
+/// the entry is ready for `COMMIT_AND_FETCH` without any post-copy.
 #[derive(Debug, PartialEq, Eq)]
 pub struct UringWriter<'a, S: BitmapSlice = ()> {
-    buf: ManuallyDrop<Vec<u8>>,
+    /// Backed by the entry's `in_out` area; receives `fuse_out_header` (16 bytes).
+    header: ManuallyDrop<Vec<u8>>,
+    /// Backed by the entry's payload area; receives the reply body.
+    body: ManuallyDrop<Vec<u8>>,
     phantom: std::marker::PhantomData<&'a mut [S]>,
 }
 
 impl<'a, S: BitmapSlice> UringWriter<'a, S> {
-    /// Construct a new writer staging the reply in `buf`.
-    pub fn new(buf: &'a mut [u8]) -> Self {
-        let buf = unsafe { Vec::from_raw_parts(buf.as_mut_ptr(), 0, buf.len()) };
+    /// Construct a writer that routes the first `OUT_HEADER_SIZE` bytes
+    /// to `header_buf` and all subsequent bytes to `body_buf`.
+    pub fn new(header_buf: &'a mut [u8], body_buf: &'a mut [u8]) -> Self {
+        debug_assert!(
+            header_buf.len() >= OUT_HEADER_SIZE,
+            "header slot must hold at least fuse_out_header ({} bytes)",
+            OUT_HEADER_SIZE,
+        );
+        // Safe because ManuallyDrop prevents Vec from freeing externally-owned memory.
+        let header = unsafe {
+            ManuallyDrop::new(Vec::from_raw_parts(
+                header_buf.as_mut_ptr(),
+                0,
+                header_buf.len(),
+            ))
+        };
+        let body = unsafe {
+            ManuallyDrop::new(Vec::from_raw_parts(
+                body_buf.as_mut_ptr(),
+                0,
+                body_buf.len(),
+            ))
+        };
         UringWriter {
-            buf: ManuallyDrop::new(buf),
+            header,
+            body,
             phantom: std::marker::PhantomData,
         }
     }
 
-    /// Split the writer at the given offset, following the [Writer] semantics.
+    /// Split the writer at `offset` bytes of the combined (header + body)
+    /// capacity.
+    ///
+    /// The two regions are non-contiguous, so the split redistributes
+    /// capacity between `self` (first `offset` bytes) and the returned
+    /// writer (remainder). This supports the two patterns used by the
+    /// server:
+    ///
+    /// - `split_at(0)`: `self` becomes empty, returned writer keeps
+    ///   everything (used by notify helpers).
+    /// - `split_at(size_of::<OutHeader>())`: `self` keeps the header slot,
+    ///   returned writer gets the body slot (used by READ / READDIR).
     pub fn split_at(&mut self, offset: usize) -> Result<UringWriter<'a, S>> {
-        if self.buf.capacity() < offset {
+        let total_cap = self.header.capacity() + self.body.capacity();
+        if offset > total_cap {
             return Err(SplitOutOfBounds(offset));
         }
 
-        let (len1, len2) = if self.buf.len() > offset {
-            (offset, self.buf.len() - offset)
+        let hdr_cap = self.header.capacity();
+        let body_cap = self.body.capacity();
+        let hdr_ptr = self.header.as_mut_ptr();
+        let body_ptr = self.body.as_mut_ptr();
+
+        // Drain both Vecs (they must be empty for from_raw_parts reuse).
+        // Safety: both Vecs are freshly constructed with len=0.
+        unsafe {
+            self.header.set_len(0);
+            self.body.set_len(0);
+        }
+
+        if offset <= hdr_cap {
+            // Split falls within (or at the end of) the header region.
+            // self gets header[0..offset], returned gets header[offset..] + body.
+            let self_hdr = unsafe { ManuallyDrop::new(Vec::from_raw_parts(hdr_ptr, 0, offset)) };
+            let other_hdr = unsafe {
+                ManuallyDrop::new(Vec::from_raw_parts(
+                    hdr_ptr.add(offset),
+                    0,
+                    hdr_cap - offset,
+                ))
+            };
+            let other_body =
+                unsafe { ManuallyDrop::new(Vec::from_raw_parts(body_ptr, 0, body_cap)) };
+            self.header = self_hdr;
+            // self.body is already drained (len=0, cap=body_cap) — shrink it.
+            self.body = unsafe { ManuallyDrop::new(Vec::from_raw_parts(body_ptr, 0, 0)) };
+            Ok(UringWriter {
+                header: other_hdr,
+                body: other_body,
+                phantom: std::marker::PhantomData,
+            })
         } else {
-            (self.buf.len(), 0)
-        };
-        let cap2 = self.buf.capacity() - offset;
-        let ptr = self.buf.as_mut_ptr();
-
-        // Safe because both buffers refer to different parts of the same
-        // underlying buffer and never overlap.
-        self.buf = unsafe { ManuallyDrop::new(Vec::from_raw_parts(ptr, len1, offset)) };
-        let buf = unsafe { ManuallyDrop::new(Vec::from_raw_parts(ptr.add(offset), len2, cap2)) };
-
-        Ok(UringWriter {
-            buf,
-            phantom: std::marker::PhantomData,
-        })
+            // Split falls within the body region (offset > hdr_cap).
+            // self gets header + body[0..offset-hdr_cap],
+            // returned gets body[offset-hdr_cap..].
+            let body_split = offset - hdr_cap;
+            let other_body = unsafe {
+                ManuallyDrop::new(Vec::from_raw_parts(
+                    body_ptr.add(body_split),
+                    0,
+                    body_cap - body_split,
+                ))
+            };
+            // self keeps full header (already drained) and body[0..body_split].
+            self.body = unsafe { ManuallyDrop::new(Vec::from_raw_parts(body_ptr, 0, body_split)) };
+            Ok(UringWriter {
+                header: unsafe {
+                    ManuallyDrop::new(Vec::from_raw_parts(
+                        std::ptr::NonNull::dangling().as_ptr(),
+                        0,
+                        0,
+                    ))
+                },
+                body: other_body,
+                phantom: std::marker::PhantomData,
+            })
+        }
     }
 
-    /// Return the number of bytes already staged.
+    /// Total bytes written across both regions.
     pub fn bytes_written(&self) -> usize {
-        self.buf.len()
+        self.header.len() + self.body.len()
     }
 
-    /// Return the number of bytes available for staging.
+    /// Total capacity available across both regions.
     pub fn available_bytes(&self) -> usize {
-        self.buf.capacity() - self.buf.len()
+        (self.header.capacity() - self.header.len()) + (self.body.capacity() - self.body.len())
     }
 
-    /// Account the staged bytes of self and `other`.
+    /// Account the bytes written by self and an optional split-off partner.
     pub fn commit(&mut self, other: Option<&Writer<'a, S>>) -> io::Result<usize> {
         let o = match other {
             Some(Writer::Uring(w)) => w.bytes_written(),
             _ => 0,
         };
-        Ok(self.buf.len() + o)
-    }
-
-    /// Write an object to the writer.
-    pub fn write_obj<T: ByteValued>(&mut self, val: T) -> io::Result<()> {
-        self.write_all(val.as_slice())
-    }
-
-    /// Stage data read from a file descriptor at offset `off`.
-    pub fn write_from_at<F: FileReadWriteVolatile>(
-        &mut self,
-        mut src: F,
-        count: usize,
-        off: u64,
-    ) -> io::Result<usize> {
-        self.check_available_space(count)?;
-
-        let cnt = src.read_vectored_at_volatile(
-            // Safe because check_available_space() ensures the capacity.
-            unsafe {
-                &[FileVolatileSlice::from_raw_ptr(
-                    self.buf.as_mut_ptr().add(self.buf.len()),
-                    count,
-                )]
-            },
-            off,
-        )?;
-        let new_len = self.buf.len() + cnt;
-        // Safe because cnt <= count was checked above.
-        unsafe { self.buf.set_len(new_len) };
-        Ok(cnt)
+        Ok(self.bytes_written() + o)
     }
 
     fn check_available_space(&self, sz: usize) -> io::Result<()> {
@@ -284,30 +336,71 @@ impl<'a, S: BitmapSlice> UringWriter<'a, S> {
                 format!(
                     "data out of range, available {} requested {}",
                     self.available_bytes(),
-                    sz
+                    sz,
                 ),
             ))
         } else {
             Ok(())
         }
     }
+
+    /// Write data, routing the first `OUT_HEADER_SIZE` bytes to the header
+    /// region and the remainder to the body region.
+    fn scatter_write(&mut self, data: &[u8]) -> io::Result<usize> {
+        self.check_available_space(data.len())?;
+        let hdr_remaining = self.header.capacity() - self.header.len();
+        let to_hdr = data.len().min(hdr_remaining);
+        if to_hdr > 0 {
+            self.header.extend_from_slice(&data[..to_hdr]);
+        }
+        if to_hdr < data.len() {
+            self.body.extend_from_slice(&data[to_hdr..]);
+        }
+        Ok(data.len())
+    }
+
+    /// Stage data read from a file descriptor at offset `off` into the body
+    /// region. Must be called after the header has been fully written.
+    pub fn write_from_at<F: FileReadWriteVolatile>(
+        &mut self,
+        mut src: F,
+        count: usize,
+        off: u64,
+    ) -> io::Result<usize> {
+        self.check_available_space(count)?;
+        let cnt = src.read_vectored_at_volatile(
+            // Safe because check_available_space() ensures capacity.
+            unsafe {
+                &[FileVolatileSlice::from_raw_ptr(
+                    self.body.as_mut_ptr().add(self.body.len()),
+                    count,
+                )]
+            },
+            off,
+        )?;
+        let new_len = self.body.len() + cnt;
+        // Safe because cnt <= count was checked above.
+        unsafe { self.body.set_len(new_len) };
+        Ok(cnt)
+    }
 }
 
 impl<S: BitmapSlice> Write for UringWriter<'_, S> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.check_available_space(data.len())?;
-        self.buf.extend_from_slice(data);
-        Ok(data.len())
+        self.scatter_write(data)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let total = bufs.iter().fold(0, |acc, b| acc + b.len());
         self.check_available_space(total)?;
-        let count = bufs.iter().filter(|b| !b.is_empty()).fold(0, |acc, b| {
-            self.buf.extend_from_slice(b);
-            acc + b.len()
-        });
-        Ok(count)
+        let mut written = 0usize;
+        for b in bufs {
+            if b.is_empty() {
+                continue;
+            }
+            written += self.scatter_write(b)?;
+        }
+        Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -315,8 +408,9 @@ impl<S: BitmapSlice> Write for UringWriter<'_, S> {
     }
 }
 
-// The buffer is owned by the caller; UringWriter only holds a `ManuallyDrop`
-// Vec shell over it, so dropping the writer never frees the memory.
+// Both buffers are owned by the caller (ring entry areas);
+// UringWriter holds ManuallyDrop Vec shells, so dropping
+// the writer never frees the memory.
 
 /// One ring entry: the memory areas the kernel reads/writes plus scratch
 /// regions used to reassemble requests and collect replies.
@@ -526,11 +620,11 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
         }
     }
 
-    /// Handle one delivered request: reassemble the classic wire layout,
-    /// dispatch to the server and stage the reply into the entry areas.
+    /// Handle one delivered request: reassemble the header/args in the
+    /// request scratch, dispatch to the server with scatter types that
+    /// reference the entry's payload area directly (zero-copy on the data
+    /// path), and stage the reply straight into the entry areas.
     fn process(&self, entry: &mut UringEntry) -> Result<()> {
-        // Copy the request parts out first, so that the reply scratch region
-        // can be borrowed mutably afterwards without aliasing.
         let in_header: InHeader = {
             let header = entry.header();
             let mut hdr = InHeader::default();
@@ -552,48 +646,75 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
             )));
         }
 
-        let msg_len = IN_HEADER_SIZE + args_len + payload_sz;
         let header_len = std::mem::size_of::<FuseUringReqHeader>();
         let scratch = FUSE_HEADER_SIZE + entry.payload_cap;
         let base = entry.mem.as_mut_ptr();
 
-        // Reassemble the classic contiguous layout in the request scratch
-        // region: fuse_in_header + per-opcode arguments + payload.
+        // Assemble only the small header/args portion in the request scratch
+        // region (40 + args_len bytes). The payload (up to ~128K for large
+        // writes) stays in the entry's payload area and is read directly by
+        // the scatter Reader, eliminating the per-request payload memcpy.
         //
-        // Safe because all slices below address disjoint regions of the
+        // Safe because the slices below address disjoint regions of the
         // entry allocation and live for the duration of this function only.
         unsafe {
             let header = &*(base as *const FuseUringReqHeader);
-            let req =
+            let req_scratch =
                 std::slice::from_raw_parts_mut(base.add(header_len + entry.payload_cap), scratch);
-            let payload = std::slice::from_raw_parts(base.add(header_len), entry.payload_cap);
             let mut off = 0;
-            req[off..off + IN_HEADER_SIZE].copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
+            req_scratch[off..off + IN_HEADER_SIZE]
+                .copy_from_slice(&header.in_out[..IN_HEADER_SIZE]);
             off += IN_HEADER_SIZE;
-            req[off..off + args_len].copy_from_slice(&header.op_in[..args_len]);
-            off += args_len;
-            req[off..off + payload_sz].copy_from_slice(&payload[..payload_sz]);
-            // in_header.len describes the classic contiguous message.
-            req[..4].copy_from_slice(&(msg_len as u32).to_le_bytes());
+            req_scratch[off..off + args_len].copy_from_slice(&header.op_in[..args_len]);
         }
 
         let total = {
-            // Safe because the request and reply scratch regions are disjoint
-            // and no other references to the entry exist in this scope.
-            let reader = unsafe {
-                let req = std::slice::from_raw_parts_mut(
+            // Build a scatter Reader:
+            //   Buffer 1 (header scratch): InHeader + opcode args
+            //   Buffer 2 (entry payload area): request payload — only when
+            //     payload_sz > 0, avoiding a copy of up to ~128K.
+            //
+            // Build a scatter Writer:
+            //   Header slot (entry.in_out): fuse_out_header (16 bytes)
+            //   Body slot (entry payload area): reply body
+            // Both are written in place — no post-copy after handle_message.
+            let header_args_len = IN_HEADER_SIZE + args_len;
+            let header_scratch = unsafe {
+                std::slice::from_raw_parts_mut(
                     base.add(header_len + entry.payload_cap),
-                    msg_len,
-                );
-                Reader::<()>::from_fuse_buffer(FuseBuf::new(req))?
+                    header_args_len,
+                )
             };
-            let writer = unsafe {
-                let reply = std::slice::from_raw_parts_mut(
-                    base.add(header_len + entry.payload_cap + scratch),
-                    scratch,
-                );
-                UringWriter::new(reply)
+
+            let reader = if payload_sz > 0 {
+                // SAFETY: The Reader's buffer 2 and the Writer's body below
+                // both cover the entry's payload area (base + header_len).
+                // This is technically overlapping mutable borrows, but is
+                // sound because:
+                //   (1) The Reader is fully consumed during argument parsing
+                //       (before handle_message returns).
+                //   (2) The Writer only writes to the payload area during
+                //       reply construction (after the Reader is consumed).
+                //   (3) Both slices are constructed via raw pointers inside
+                //       unsafe blocks, so the borrow checker doesn't track
+                //       them across the handle_message call.
+                // A future refactor could eliminate this by using raw
+                // pointers in both Reader and Writer APIs.
+                let entry_payload =
+                    unsafe { std::slice::from_raw_parts_mut(base.add(header_len), payload_sz) };
+                Reader::<()>::from_uring_buffers(header_scratch, entry_payload)?
+            } else {
+                Reader::<()>::from_fuse_buffer(FuseBuf::new(header_scratch))?
             };
+
+            // The reply header goes into entry.in_out[0..OUT_HEADER_SIZE] and
+            // the reply body goes directly into the entry's payload area.
+            // See SAFETY comment above regarding overlap with Reader's buffer 2.
+            let in_out_header = unsafe { std::slice::from_raw_parts_mut(base, OUT_HEADER_SIZE) };
+            let payload_area =
+                unsafe { std::slice::from_raw_parts_mut(base.add(header_len), entry.payload_cap) };
+            let writer = UringWriter::<()>::new(in_out_header, payload_area);
+
             self.server
                 .handle_message(reader, Writer::Uring(writer), None, None)
                 .map_err(|e| {
@@ -605,32 +726,16 @@ impl<F: FileSystem + Send + Sync + 'static> UringWorker<F> {
         };
 
         if total > 0 {
-            // The staged reply must fit the entry header slot plus the
-            // payload area; anything larger cannot be committed.
+            // The scatter writer already placed the reply directly in the
+            // entry areas; just record the payload size and validate.
             if total < OUT_HEADER_SIZE || total > OUT_HEADER_SIZE + entry.payload_cap {
                 return Err(SessionFailure(format!(
                     "uring: malformed reply of {} bytes for unique 0x{:x}",
                     total, in_header.unique
                 )));
             }
-            // The staged reply starts with fuse_out_header; move it into the
-            // entry header slot and stage the rest in the payload area.
-            //
-            // Safe because all slices below address disjoint regions of the
-            // entry allocation.
-            unsafe {
-                let header = &mut *(base as *mut FuseUringReqHeader);
-                let reply = std::slice::from_raw_parts(
-                    base.add(header_len + entry.payload_cap + scratch),
-                    total,
-                );
-                header.in_out[..OUT_HEADER_SIZE].copy_from_slice(&reply[..OUT_HEADER_SIZE]);
-                let payload_len = total - OUT_HEADER_SIZE;
-                let payload =
-                    std::slice::from_raw_parts_mut(base.add(header_len), entry.payload_cap);
-                payload[..payload_len].copy_from_slice(&reply[OUT_HEADER_SIZE..]);
-                header.ring_ent_in_out.payload_sz = payload_len as u32;
-            }
+            let payload_len = total - OUT_HEADER_SIZE;
+            entry.header_mut().ring_ent_in_out.payload_sz = payload_len as u32;
         } else {
             // Forget-like requests carry no reply.
             entry.header_mut().ring_ent_in_out.payload_sz = 0;
@@ -661,7 +766,7 @@ impl<F: FileSystem + Send + Sync + 'static> UringFuseServing<F> {
     /// accepted the capability, returning `Error::UringNotSupported`
     /// otherwise so that the caller can fall back to the classic transport.
     pub fn new(
-        session: FuseSession,
+        mut session: FuseSession,
         server: Arc<Server<F>>,
         cfg: UringConfig,
     ) -> Result<UringFuseServing<F>> {
@@ -742,11 +847,25 @@ impl<F: FileSystem + Send + Sync + 'static> UringFuseServing<F> {
             match ready_rx.recv() {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
+                    // Signal workers to exit and join them before returning.
+                    exit.store(true, Ordering::Release);
+                    let _ = session.wake();
+                    let _ = session.umount();
+                    for handle in handles {
+                        let _ = handle.join();
+                    }
                     return Err(SessionFailure(format!(
                         "uring: entry registration failed: {e}"
                     )));
                 }
                 Err(_) => {
+                    // Signal workers to exit and join them before returning.
+                    exit.store(true, Ordering::Release);
+                    let _ = session.wake();
+                    let _ = session.umount();
+                    for handle in handles {
+                        let _ = handle.join();
+                    }
                     return Err(SessionFailure(
                         "uring: worker exited during registration".to_string(),
                     ));
@@ -755,13 +874,24 @@ impl<F: FileSystem + Send + Sync + 'static> UringFuseServing<F> {
         }
         let live = handles;
 
-        let fallback = thread::Builder::new()
+        let fallback = match thread::Builder::new()
             .name("uring-fallback".to_string())
             .spawn({
                 let exit = exit.clone();
                 move || Self::fallback_loop(fallback_ch, server, exit)
-            })
-            .map_err(|e| SessionFailure(format!("uring: spawn fallback thread: {e}")))?;
+            }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                // Signal workers to exit and join them before returning.
+                exit.store(true, Ordering::Release);
+                let _ = session.wake();
+                let _ = session.umount();
+                for handle in live {
+                    let _ = handle.join();
+                }
+                return Err(SessionFailure(format!("uring: spawn fallback thread: {e}")));
+            }
+        };
 
         Ok(UringFuseServing {
             session,
@@ -981,70 +1111,94 @@ mod tests {
     }
 
     #[test]
-    fn test_uring_writer_basic() {
-        let mut scratch = vec![0u8; 128];
-        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
-        assert_eq!(w.bytes_written(), 0);
-        assert_eq!(w.available_bytes(), 128);
+    fn test_uring_writer_scatter_basic() {
+        // Header slot: 16 bytes (OUT_HEADER_SIZE); body slot: 128 bytes.
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 128];
 
-        w.write_obj(0x1234_5678u32).unwrap();
-        w.write_all(&[1u8, 2, 3]).unwrap();
-        assert_eq!(w.bytes_written(), 7);
-        assert_eq!(w.available_bytes(), 121);
+        {
+            let mut w = UringWriter::<'_, ()>::new(&mut hdr, &mut body);
+            assert_eq!(w.bytes_written(), 0);
+            assert_eq!(w.available_bytes(), OUT_HEADER_SIZE + 128);
 
-        // Writes beyond the available capacity must fail without
-        // overflowing the buffer.
-        let big = vec![0u8; 200];
-        assert!(w.write(&big).is_err());
-        assert!(w.write_all(&big).is_err());
-        assert_eq!(w.bytes_written(), 7);
-        assert_eq!(&scratch[..7], &[0x78, 0x56, 0x34, 0x12, 1, 2, 3]);
+            // First 16 bytes must land in the header slot.
+            w.write_all(&[0xAA; OUT_HEADER_SIZE]).unwrap();
+            assert_eq!(w.bytes_written(), OUT_HEADER_SIZE);
+
+            // Next bytes must spill into the body slot.
+            w.write_all(&[1u8, 2, 3]).unwrap();
+            assert_eq!(w.bytes_written(), OUT_HEADER_SIZE + 3);
+
+            // Writes beyond the available capacity must fail.
+            let big = vec![0u8; 200];
+            assert!(w.write(&big).is_err());
+            assert_eq!(w.bytes_written(), OUT_HEADER_SIZE + 3);
+        }
+
+        assert_eq!(&hdr[..], &[0xAA; OUT_HEADER_SIZE]);
+        assert_eq!(&body[..3], &[1, 2, 3]);
     }
 
     #[test]
-    fn test_uring_writer_split_commit() {
-        let mut scratch = vec![0u8; 64];
-        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
-        w.write_all(&[1u8; 32]).unwrap();
+    fn test_uring_writer_scatter_single_write() {
+        // A single write() that straddles the header/body boundary.
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 64];
 
-        let mut tail = w.split_at(16).unwrap();
-        assert_eq!(w.bytes_written(), 16);
-        assert_eq!(w.available_bytes(), 0);
-        assert_eq!(tail.bytes_written(), 16);
-        assert_eq!(tail.available_bytes(), 32);
-        tail.write_all(&[2u8; 8]).unwrap();
+        {
+            let mut w = UringWriter::<'_, ()>::new(&mut hdr, &mut body);
+            let data: Vec<u8> = (0..48).collect();
+            w.write_all(&data).unwrap();
+            assert_eq!(w.bytes_written(), 48);
+        }
 
-        // commit() only accounts the staged bytes, it never touches a
-        // device.
-        let other = Writer::Uring(tail);
-        assert_eq!(w.commit(Some(&other)).unwrap(), 40);
-        // Splitting beyond the capacity is rejected.
-        assert!(w.split_at(17).is_err());
-
-        // The staged data must still be visible in the buffer.
-        assert_eq!(&scratch[..16], &[1u8; 16]);
-        assert_eq!(&scratch[16..32], &[1u8; 16]);
-        assert_eq!(&scratch[32..40], &[2u8; 8]);
+        // First 16 bytes → header
+        assert_eq!(&hdr[..], &(0..16).collect::<Vec<u8>>()[..]);
+        // Remaining 32 bytes → body
+        assert_eq!(&body[..32], &(16..48).collect::<Vec<u8>>()[..]);
     }
 
     #[test]
-    fn test_uring_writer_write_from_at() {
+    fn test_uring_writer_scatter_commit() {
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 64];
+        let mut w = UringWriter::<'_, ()>::new(&mut hdr, &mut body);
+        w.write_all(&[1u8; OUT_HEADER_SIZE]).unwrap();
+        w.write_all(&[2u8; 32]).unwrap();
+        assert_eq!(w.bytes_written(), OUT_HEADER_SIZE + 32);
+
+        // commit() accounts the staged bytes without touching a device.
+        assert_eq!(w.commit(None).unwrap(), OUT_HEADER_SIZE + 32);
+    }
+
+    #[test]
+    fn test_uring_writer_scatter_write_from_at() {
         let dir = TempDir::new().unwrap();
         let path = dir.as_path().join("data");
         std::fs::write(&path, (0..64).collect::<Vec<u8>>()).unwrap();
 
-        let mut scratch = vec![0u8; 32];
-        let mut w = UringWriter::<'_, ()>::new(&mut scratch);
-        let file = File::open(&path).unwrap();
-        assert_eq!(
-            w.write_from_at(file.try_clone().unwrap(), 16, 8).unwrap(),
-            16
-        );
-        assert_eq!(w.bytes_written(), 16);
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 32];
 
-        // More data than available space must be rejected.
-        assert!(w.write_from_at(file, 32, 0).is_err());
-        assert_eq!(&scratch[..16], &(8..24).collect::<Vec<u8>>());
+        {
+            let mut w = UringWriter::<'_, ()>::new(&mut hdr, &mut body);
+
+            // Write the header first so write_from_at lands in the body region.
+            w.write_all(&[0xFF; OUT_HEADER_SIZE]).unwrap();
+
+            let file = File::open(&path).unwrap();
+            assert_eq!(
+                w.write_from_at(file.try_clone().unwrap(), 16, 8).unwrap(),
+                16
+            );
+            assert_eq!(w.bytes_written(), OUT_HEADER_SIZE + 16);
+
+            // More data than available body space must be rejected.
+            assert!(w.write_from_at(file, 32, 0).is_err());
+        }
+
+        // Body should contain file data starting at offset 8.
+        assert_eq!(&body[..16], &(8..24).collect::<Vec<u8>>()[..]);
     }
 
     /// A worker over PassthroughFs, for exercising process() without a
@@ -1209,5 +1363,69 @@ mod tests {
             &[],
         );
         assert!(worker.process(&mut entry).is_err());
+    }
+
+    #[test]
+    fn test_uring_writer_split_at_zero() {
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 256];
+        let mut w = UringWriter::<()>::new(&mut hdr, &mut body);
+
+        // split_at(0): self becomes empty, other gets everything.
+        let other = w.split_at(0).unwrap();
+        assert_eq!(w.available_bytes(), 0);
+        assert_eq!(other.available_bytes(), OUT_HEADER_SIZE + 256);
+    }
+
+    #[test]
+    fn test_uring_writer_split_at_header_size() {
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 256];
+        let mut w = UringWriter::<()>::new(&mut hdr, &mut body);
+
+        // split_at(OUT_HEADER_SIZE): self keeps header, other gets body.
+        let mut other = w.split_at(OUT_HEADER_SIZE).unwrap();
+        assert_eq!(w.available_bytes(), OUT_HEADER_SIZE);
+        assert_eq!(other.available_bytes(), 256);
+
+        // Write OutHeader to self (header region).
+        let out = OutHeader {
+            len: (OUT_HEADER_SIZE + 10) as u32,
+            error: 0,
+            unique: 42,
+        };
+        w.write_all(out.as_slice()).unwrap();
+        assert_eq!(w.bytes_written(), OUT_HEADER_SIZE);
+
+        // Write data to other (body region).
+        other.write_all(&[0xABu8; 10]).unwrap();
+        assert_eq!(other.bytes_written(), 10);
+
+        // Commit combines both.
+        let total = w.commit(Some(&Writer::Uring(other))).unwrap();
+        assert_eq!(total, OUT_HEADER_SIZE + 10);
+    }
+
+    #[test]
+    fn test_uring_writer_split_at_beyond_capacity() {
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 64];
+        let mut w = UringWriter::<()>::new(&mut hdr, &mut body);
+
+        // split_at beyond total capacity must fail.
+        assert!(w.split_at(OUT_HEADER_SIZE + 65).is_err());
+    }
+
+    #[test]
+    fn test_uring_writer_split_at_body_offset() {
+        let mut hdr = vec![0u8; OUT_HEADER_SIZE];
+        let mut body = vec![0u8; 256];
+        let mut w = UringWriter::<()>::new(&mut hdr, &mut body);
+
+        // split_at beyond header into body region.
+        let offset = OUT_HEADER_SIZE + 100;
+        let other = w.split_at(offset).unwrap();
+        assert_eq!(w.available_bytes(), offset);
+        assert_eq!(other.available_bytes(), 256 - 100);
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -538,7 +538,8 @@ pub enum Writer<'a, S: BitmapSlice = ()> {
     /// Writer for FuseDev transport driver.
     FuseDev(FuseDevWriter<'a, S>),
     #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
-    /// Buffer-only writer for the FUSE-over-io_uring transport.
+    /// Scatter writer for the FUSE-over-io_uring transport that routes the
+    /// reply header and body into separate ring entry areas.
     Uring(UringWriter<'a, S>),
     #[cfg(feature = "virtiofs")]
     /// Writer for virtiofs transport driver.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -45,6 +45,8 @@ pub use self::fs_cache_req_handler::FsCacheReqHandler;
 pub use self::fusedev::FuseDevTask;
 #[cfg(feature = "fusedev")]
 pub use self::fusedev::{FuseBuf, FuseChannel, FuseDevWriter, FuseSession, FuseSessionExt};
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+pub use self::fusedev::{UringConfig, UringFuseServing, UringWriter};
 #[cfg(feature = "virtiofs")]
 pub use self::virtiofs::VirtioFsWriter;
 
@@ -535,6 +537,9 @@ pub enum Writer<'a, S: BitmapSlice = ()> {
     #[cfg(feature = "fusedev")]
     /// Writer for FuseDev transport driver.
     FuseDev(FuseDevWriter<'a, S>),
+    #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+    /// Buffer-only writer for the FUSE-over-io_uring transport.
+    Uring(UringWriter<'a, S>),
     #[cfg(feature = "virtiofs")]
     /// Writer for virtiofs transport driver.
     VirtioFs(VirtioFsWriter<'a, S>),
@@ -555,6 +560,8 @@ impl<S: BitmapSlice> Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.write_from_at(src, count, off),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.write_from_at(src, count, off),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.write_from_at(src, count, off),
             _ => Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
@@ -570,6 +577,8 @@ impl<S: BitmapSlice> Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.split_at(offset).map(|w| w.into()),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.split_at(offset).map(|w| w.into()),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.split_at(offset).map(|w| w.into()),
             _ => Err(Error::InvalidParameter),
@@ -584,6 +593,8 @@ impl<S: BitmapSlice> Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.available_bytes(),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.available_bytes(),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.available_bytes(),
             _ => 0,
@@ -595,6 +606,8 @@ impl<S: BitmapSlice> Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.bytes_written(),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.bytes_written(),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.bytes_written(),
             _ => 0,
@@ -606,6 +619,8 @@ impl<S: BitmapSlice> Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.commit(other),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.commit(other),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.commit(other),
             _ => Ok(0),
@@ -618,6 +633,8 @@ impl<S: BitmapSlice> io::Write for Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.write(buf),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.write(buf),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.write(buf),
             _ => Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
@@ -628,6 +645,8 @@ impl<S: BitmapSlice> io::Write for Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.write_vectored(bufs),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.write_vectored(bufs),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.write_vectored(bufs),
             _ => Err(std::io::Error::from_raw_os_error(libc::EINVAL)),
@@ -638,6 +657,8 @@ impl<S: BitmapSlice> io::Write for Writer<'_, S> {
         match self {
             #[cfg(feature = "fusedev")]
             Writer::FuseDev(w) => w.flush(),
+            #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+            Writer::Uring(w) => w.flush(),
             #[cfg(feature = "virtiofs")]
             Writer::VirtioFs(w) => w.flush(),
             _ => Ok(()),
@@ -730,6 +751,13 @@ impl<'a, S: BitmapSlice> Writer<'a, S> {
 impl<'a, S: BitmapSlice> From<FuseDevWriter<'a, S>> for Writer<'a, S> {
     fn from(w: FuseDevWriter<'a, S>) -> Self {
         Writer::FuseDev(w)
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
+impl<'a, S: BitmapSlice> From<UringWriter<'a, S>> for Writer<'a, S> {
+    fn from(w: UringWriter<'a, S>) -> Self {
+        Writer::Uring(w)
     }
 }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -68,6 +68,10 @@ pub enum Error {
     #[cfg(feature = "fusedev")]
     /// Session errors
     SessionFailure(String),
+    #[cfg(feature = "fusedev-uring")]
+    /// FUSE-over-io_uring is not available: the kernel rejected the
+    /// `FUSE_OVER_IO_URING` init flag or uring registration failed.
+    UringNotSupported,
     #[cfg(feature = "virtiofs")]
     /// Failed to access guest memory.
     GuestMemoryError(vm_memory::GuestMemoryError),
@@ -94,6 +98,12 @@ impl fmt::Display for Error {
 
             #[cfg(feature = "fusedev")]
             SessionFailure(e) => write!(f, "fuse session failure: {e}"),
+
+            #[cfg(feature = "fusedev-uring")]
+            UringNotSupported => write!(
+                f,
+                "FUSE-over-io_uring is not available on this kernel or was rejected"
+            ),
 
             #[cfg(feature = "virtiofs")]
             ConvertIndirectDescriptor(e) => write!(f, "invalid indirect descriptor: {e}"),

--- a/tests/benchmark/Cargo.toml
+++ b/tests/benchmark/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# Benchmark tooling for comparing the synchronous and asynchronous IO
-# paths of fuse-backend-rs. This is a standalone crate (like
+# Benchmark tooling for comparing the synchronous, asynchronous and
+# io_uring IO paths of fuse-backend-rs. This is a standalone crate (like
 # tests/passthrough) so that the benchmark dependencies don't leak into
 # the main crate's dependency tree or the CI test jobs.
 
 [dependencies]
-fuse-backend-rs = { path = "../../", default-features = false, features = ["fusedev", "async-io"] }
+fuse-backend-rs = { path = "../../", default-features = false, features = ["fusedev", "fusedev-uring", "async-io"] }
 log = ">=0.4.6"
 libc = ">=0.2.68"
 simple_logger = ">=1.13.0"

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,7 +1,8 @@
 # fuse-backend-rs benchmark tooling
 
-Tooling to compare the performance of the synchronous and asynchronous IO
-paths, complementing the functional tests. Two levels are provided:
+Tooling to compare the performance of the synchronous, asynchronous and
+io_uring IO paths, complementing the functional tests. Two levels are
+provided:
 
 ## 1. Micro-benchmark (framework overhead)
 
@@ -26,9 +27,11 @@ fuse transport and request concurrency dominate there.
 ## 2. End-to-end comparison with fio
 
 `tests/scripts/bench_sync_async.sh` mounts the `fuse-backend-rs-benchmark`
-daemon twice — once in sync mode (N worker threads, one fuse channel each)
-and once in async mode (a single `FuseDevTask` driven by the async runtime,
-tokio-uring when io_uring is available) — and runs identical fio workloads:
+daemon once per mode — sync mode (N worker threads, one fuse channel each),
+async mode (a single `FuseDevTask` driven by the async runtime, tokio-uring
+when io_uring is available) and uring mode (the experimental
+FUSE-over-io_uring transport, requires kernel 6.14+ and is skipped
+otherwise) — and runs identical fio workloads:
 
 - sequential read/write with 1MB requests
 - random read/write with 4KB requests
@@ -48,19 +51,41 @@ The fio results are written in JSON format to a temporary results directory
 (printed at the start, `<dir>/<mode>-<workload>.json`), and a side-by-side
 summary is printed at the end. The default execution order is sync then
 async; the second mode benefits from a warmer page cache, so cross-check
-with `MODES="async sync"`.
+with `MODES="async sync"`. The uring mode is included with
+`MODES="sync async uring"`.
+
+To quantify the difference between the transports, collect each mode's
+results and compare the collected files — `bench_compare.py` is
+mode-agnostic, so any two collected files can be diffed (positive deltas
+mean the second file outperformed the first):
+
+```sh
+MODES="sync async uring" sudo -E tests/scripts/bench_sync_async.sh
+python3 tests/scripts/bench_compare.py collect <results-dir> sync  sync.json
+python3 tests/scripts/bench_compare.py collect <results-dir> uring uring.json
+# uring vs sync: positive deltas mean uring won that workload
+python3 tests/scripts/bench_compare.py compare sync.json uring.json
+```
+
+Both transports run on the same machine back-to-back, so environment
+effects mostly cancel out; for confidence run once per `MODES` order.
 
 ## 3. Continuous benchmarking in CI
 
 The `Benchmark` workflow (`.github/workflows/benchmark.yml`) runs the fio
-comparison on GitHub-hosted runners for a matrix of sync/async modes and
-1/8 threads:
+comparison on GitHub-hosted runners for a matrix of sync/async/uring modes
+and 1/8 threads; the uring mode is skipped on runners whose kernel is
+older than 6.14:
 
 - Pull requests: add the `run-benchmark` label to trigger a benchmark run.
   The merge base and the PR are built and benchmarked back to back *in the
   same job*, and the two result sets are compared in the job summary of the
   workflow run (Actions tab). The execution order of the two variants is
   alternated between the thread counts to spread runner drift across them.
+  The merge base predates the uring transport, so the baseline comparison
+  covers only sync and async; the PR's uring numbers are instead compared
+  cross-mode against the sync/async numbers of the same run, which needs
+  no baseline.
 - Pushes to master and manual dispatches run a single benchmark for
   reference; no baseline is stored.
 

--- a/tests/benchmark/src/main.rs
+++ b/tests/benchmark/src/main.rs
@@ -230,7 +230,7 @@ mod daemon {
         server.set_uring(true);
         let cfg = UringConfig {
             workers: thread_cnt as usize,
-            ..Default::default()
+            entries_per_queue: 16,
         };
         let serving = match UringFuseServing::new(se, server, cfg) {
             Ok(serving) => serving,

--- a/tests/benchmark/src/main.rs
+++ b/tests/benchmark/src/main.rs
@@ -6,12 +6,15 @@
 //! A minimal fusedev passthrough daemon used to benchmark the synchronous
 //! and asynchronous IO paths with external tools such as fio.
 //!
-//! Usage: `fuse-backend-rs-benchmark <src> <mountpoint> [--async] [--threads N]`
+//! Usage: `fuse-backend-rs-benchmark <src> <mountpoint> [--async|--uring] [--threads N]`
 //!
 //! - default (sync) mode: requests are served by `N` worker threads, each
 //!   reading from its own fuse channel (the classic multi-threaded design).
 //! - `--async` mode: requests are served by a single `FuseDevTask` running
 //!   on the async runtime (tokio-uring when io_uring is available).
+//! - `--uring` mode: requests are served through the FUSE-over-io_uring
+//!   transport (`UringFuseServing`, experimental, requires kernel 6.14+);
+//!   `N` limits the number of io_uring worker threads.
 
 #[cfg(target_os = "linux")]
 mod daemon {
@@ -33,19 +36,22 @@ mod daemon {
     };
     use fuse_backend_rs::async_runtime::Runtime;
     use fuse_backend_rs::passthrough::{Config, PassthroughFs};
-    use fuse_backend_rs::transport::{FuseChannel, FuseDevTask, FuseSession};
+    use fuse_backend_rs::transport::{
+        FuseChannel, FuseDevTask, FuseSession, UringConfig, UringFuseServing,
+    };
 
     struct Args {
         src: String,
         dest: String,
         as_async: bool,
+        as_uring: bool,
         thread_cnt: u32,
         threads_set: bool,
     }
 
     fn help() {
         println!(
-            "Usage:\n   fuse-backend-rs-benchmark <src> <mountpoint> [--async] [--threads N]\n"
+            "Usage:\n   fuse-backend-rs-benchmark <src> <mountpoint> [--async|--uring] [--threads N]\n"
         );
     }
 
@@ -59,6 +65,7 @@ mod daemon {
             src: args[1].clone(),
             dest: args[2].clone(),
             as_async: false,
+            as_uring: false,
             thread_cnt: 4,
             threads_set: false,
         };
@@ -66,6 +73,7 @@ mod daemon {
         while idx < args.len() {
             match args[idx].as_str() {
                 "--async" => res.as_async = true,
+                "--uring" => res.as_uring = true,
                 "--threads" => {
                     idx += 1;
                     if idx >= args.len() {
@@ -86,6 +94,10 @@ mod daemon {
             idx += 1;
         }
         if res.src.is_empty() || res.dest.is_empty() || res.thread_cnt == 0 {
+            help();
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+        if res.as_async && res.as_uring {
             help();
             return Err(Error::from_raw_os_error(libc::EINVAL));
         }
@@ -208,6 +220,38 @@ mod daemon {
         state.store(true, Ordering::Release);
     }
 
+    /// Serve requests through the FUSE-over-io_uring transport until a
+    /// termination signal is received. Requires kernel 6.14+ with the
+    /// fuse module parameter enable_uring turned on; `UringFuseServing::new()`
+    /// fails otherwise.
+    fn run_uring(server: Arc<Server<Arc<Vfs>>>, se: FuseSession, thread_cnt: u32) {
+        // set_uring() must be called before the INIT handshake, which
+        // UringFuseServing::new() performs on the mounted session.
+        server.set_uring(true);
+        let cfg = UringConfig {
+            workers: thread_cnt as usize,
+            ..Default::default()
+        };
+        let serving = match UringFuseServing::new(se, server, cfg) {
+            Ok(serving) => serving,
+            Err(e) => {
+                error!(
+                    "failed to start the FUSE-over-io_uring transport \
+                     (requires kernel 6.14+ with the fuse module parameter \
+                     enable_uring turned on): {}",
+                    e
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let mut signals = Signals::new(TERM_SIGNALS).unwrap();
+        signals.forever().next();
+        // Dropping the serving layer unmounts the session and joins all
+        // serving threads.
+        drop(serving);
+    }
+
     pub fn main() -> Result<()> {
         SimpleLogger::new()
             .with_level(LevelFilter::Info)
@@ -230,7 +274,13 @@ mod daemon {
             "passthrough src {} mountpoint {} mode {} threads {}",
             args.src,
             args.dest,
-            if args.as_async { "async" } else { "sync" },
+            if args.as_uring {
+                "uring"
+            } else if args.as_async {
+                "async"
+            } else {
+                "sync"
+            },
             args.thread_cnt,
         );
 
@@ -245,7 +295,9 @@ mod daemon {
             );
         }
 
-        if args.as_async {
+        if args.as_uring {
+            run_uring(server, se, args.thread_cnt);
+        } else if args.as_async {
             run_async(server, se);
         } else {
             run_sync(server, se, args.thread_cnt);

--- a/tests/scripts/bench_sync_async.sh
+++ b/tests/scripts/bench_sync_async.sh
@@ -3,17 +3,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Compare the synchronous and asynchronous fusedev IO paths of
+# Compare the synchronous, asynchronous and io_uring fusedev IO paths of
 # fuse-backend-rs using fio.
 #
 # For each mode (sync: N worker threads, async: one FuseDevTask on the
-# async runtime), the script mounts the benchmark daemon and runs the same
-# fio workloads against the mountpoint. The fio results are stored in JSON
-# format ($RESULTS_DIR/<mode>-<workload>.json) under $RESULTS_DIR for
-# further analysis, see tests/scripts/bench_compare.py.
+# async runtime, uring: the experimental FUSE-over-io_uring transport),
+# the script mounts the benchmark daemon and runs the same fio workloads
+# against the mountpoint. The fio results are stored in JSON format
+# ($RESULTS_DIR/<mode>-<workload>.json) under $RESULTS_DIR for further
+# analysis, see tests/scripts/bench_compare.py.
 #
 # Requirements: Linux, fio, jq, permission to mount fuse (root or
-# fusermount).
+# fusermount). The uring mode additionally requires kernel 6.14+ with
+# FUSE-over-io_uring enabled (the fuse module parameter enable_uring,
+# which the script tries to turn on when it is writable); kernels that
+# reject the transport during the INIT handshake make the mode be
+# skipped with a warning.
 #
 # Tunables (environment variables):
 #   THREADS  number of sync worker threads / fio jobs (default 4)
@@ -50,8 +55,26 @@ SRC_DIR="${RESULTS_DIR}/source"
 MNT_DIR="${RESULTS_DIR}/mount"
 mkdir -p "${SRC_DIR}" "${MNT_DIR}"
 
+WORKLOADS="seqwrite seqread randwrite-4k randread-4k filecreate filedelete"
+
 command -v fio >/dev/null 2>&1 || { echo "error: fio is required" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 1; }
+
+# kernel_at_least MAJOR MINOR: true if the running kernel is at least
+# MAJOR.MINOR. Used to gate the uring mode, which requires the kernel
+# FUSE_URING interface (6.14+).
+kernel_at_least() {
+    local want_major=$1 want_minor=$2 kv major minor
+    kv=$(uname -r)
+    major=${kv%%.*}
+    minor=${kv#*.}
+    minor=${minor%%.*}
+    case "${major}${minor}" in
+        *[!0-9]* | "") return 1 ;;
+    esac
+    [ "${major}" -gt "${want_major}" ] && return 0
+    [ "${major}" -eq "${want_major}" ] && [ "${minor}" -ge "${want_minor}" ]
+}
 
 # The metadata workloads keep NRFILES files open at once, and the daemon
 # holds an open handle per file as well, but the default soft fd limit of
@@ -82,19 +105,30 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# start_daemon <mode args>: launch the daemon and wait for the mount to
+# appear. Returns 1 when the daemon dies without serving (e.g. the kernel
+# rejects the FUSE-over-io_uring negotiation) or when the mount does not
+# appear in time; the caller decides whether that is fatal.
 start_daemon() {
     local mode_args=$1
     # shellcheck disable=SC2086
     "${DAEMON}" "${SRC_DIR}" "${MNT_DIR}" ${mode_args} --threads "${THREADS}" &
     DAEMON_PID=$!
     for _ in $(seq 50); do
+        # A daemon that mounted and immediately died (rejected session)
+        # leaves a stale mount behind; check aliveness before the
+        # mountpoint so that the stale mount is never taken as success.
+        if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+            wait "${DAEMON_PID}" 2>/dev/null || true
+            DAEMON_PID=
+            return 1
+        fi
         if mountpoint -q "${MNT_DIR}"; then
             return 0
         fi
         sleep 0.1
     done
-    echo "error: daemon did not mount ${MNT_DIR}" >&2
-    exit 1
+    return 1
 }
 
 stop_daemon() {
@@ -157,10 +191,34 @@ run_fixed_workload() {
 for mode in ${MODES}; do
     mode_args=""
     [ "${mode}" = "async" ] && mode_args="--async"
+    if [ "${mode}" = "uring" ]; then
+        if ! kernel_at_least 6 14; then
+            echo "warning: mode uring requires kernel 6.14+ ($(uname -r)), skipping" >&2
+            continue
+        fi
+        # Kernels >= 6.14 may still reject FUSE-over-io_uring: the fuse
+        # module parameter enable_uring defaults to off on several distro
+        # kernels. Try to turn it on (best effort, a no-op without root or
+        # when the parameter does not exist); if the kernel keeps
+        # rejecting the transport the startup probe below skips the mode.
+        if [ -e /sys/module/fuse/parameters/enable_uring ]; then
+            ( echo 1 > /sys/module/fuse/parameters/enable_uring ) 2>/dev/null || true
+        fi
+        mode_args="--uring"
+    fi
 
     echo ""
     echo "############ mode: ${mode} ############"
-    start_daemon "${mode_args}"
+    if ! start_daemon "${mode_args}"; then
+        # Drop a possibly stale mount left by the failed daemon.
+        umount "${MNT_DIR}" 2>/dev/null || true
+        if [ "${mode}" = "uring" ]; then
+            echo "warning: FUSE-over-io_uring is not available on this kernel, skipping mode uring" >&2
+            continue
+        fi
+        echo "error: daemon did not mount ${MNT_DIR}" >&2
+        exit 1
+    fi
 
     # Sequential IO with large requests (throughput oriented). ramp_time
     # excludes cold-start effects (first touches, daemon caches warming up)
@@ -197,13 +255,20 @@ summarize() {
 
 echo ""
 echo "############ summary ############"
-printf "%-32s %-36s %-36s\n" "workload" "sync" "async"
-for f in "${RESULTS_DIR}"/sync-*.json; do
-    name=$(basename "${f}" .json)
-    name=${name#sync-}
-    printf "%-32s %-36s %-36s\n" "${name}" \
-        "$(summarize "${f}")" \
-        "$(summarize "${RESULTS_DIR}/async-${name}.json")"
+printf "%-32s" "workload"
+# shellcheck disable=SC2086
+for mode in ${MODES}; do
+    printf "%-36s" "${mode}"
+done
+printf "\n"
+# shellcheck disable=SC2086
+for name in ${WORKLOADS}; do
+    printf "%-32s" "${name}"
+    # shellcheck disable=SC2086
+    for mode in ${MODES}; do
+        printf "%-36s" "$(summarize "${RESULTS_DIR}/${mode}-${name}.json")"
+    done
+    printf "\n"
 done
 echo ""
 echo "full fio output: ${RESULTS_DIR}"


### PR DESCRIPTION
## Summary

Add an experimental serving transport that exchanges FUSE requests with the
kernel over io_uring instead of read/write syscalls on /dev/fuse, using the
FUSE_URING interface introduced in kernel 6.14 (FUSE protocol 7.42).

The classic transport costs at least two system calls per request (read the
request, write the reply). With FUSE_URING the daemon registers per-queue
ring entries once and then receives requests as CQEs and returns replies with
`FUSE_IO_URING_CMD_COMMIT_AND_FETCH`, all through io_uring submission, which
removes the per-request syscall overhead from the hot path.

The transport is gated behind a new opt-in `fusedev-uring` cargo feature and
is strictly additive: unless `Server::set_uring(true)` is called before
mounting, the INIT negotiation and request serving are byte-for-byte
unchanged.

## Design

- After the classic FUSE_INIT handshake negotiates `FUSE_OVER_IO_URING`,
  `UringFuseServing` registers `entries_per_queue` idle entries on each
  kernel queue (one per possible CPU) via `FUSE_IO_URING_CMD_REGISTER`
  SQE128s on /dev/fuse.
- Each worker thread owns one io_uring instance and a subset of the kernel
  queues. Requests arrive as CQEs; the worker reassembles the classic
  contiguous wire layout (`fuse_in_header` + per-op args + payload) from the
  ring entry areas and dispatches through the existing
  `Server::handle_message()` with a new buffer-only `Writer::Uring`, so all
  existing opcode handlers work unmodified.
- Requests the kernel never routes through io_uring (FUSE_INTERRUPT, FORGET,
  and anything queued before registration) keep flowing through a classic
  fallback channel served in parallel.
- If the kernel does not accept the capability, `UringFuseServing::new()`
  fails with `Error::UringNotSupported` so callers can fall back to the
  classic transport.

## Commits

1. `abi`: uapi definitions mirroring kernel 6.14 (`fuse_uring_req_header`,
   `fuse_uring_cmd_req`, command opcodes), layout-checked against
   `include/uapi/linux/fuse.h`.
2. `api/server`: negotiate `FUSE_OVER_IO_URING` in INIT. The reply sets
   `FUSE_INIT_EXT` whenever an upper capability bit is enabled, because
   kernels >= 6.13 apply `flags2` only when userspace advertises
   `FUSE_INIT_EXT` ("fuse: Apply flags2 only when userspace set the
   FUSE_INIT_EXT").
3. `transport/fusedev`: the serving transport (`UringFuseServing`,
   `UringWorker`, `UringEntry`) and the `Writer::Uring` variant.
4. `transport/fusedev`: complete the opcode dispatch table for request
   reassembly (header-less opcodes, READDIR family, lock ops).
5. `transport/fusedev`: unit tests covering cpu mask parsing, the dispatch
   table against ABI struct sizes, entry layout, SQE128 command encoding,
   `UringWriter` semantics, and end-to-end `process()` round trips
   (GETATTR/LOOKUP/malformed requests) over a PassthroughFs-backed Server —
   all runnable without a 6.14 kernel.
6. `tests/benchmark`: `--uring` mode in the benchmark daemon, kernel-6.14+
   gating in `bench_sync_async.sh`, and cross-mode uring vs sync/async
   comparison in the Benchmark workflow job summary.

## Testing

- `cargo test --features fusedev-uring` passes on Linux (28 new tests).
- `cargo fmt --check` and