### PR TITLE
tests/passthrough: make notify_resend best-effort

### DIFF
--- a/tests/passthrough/src/main.rs
+++ b/tests/passthrough/src/main.rs
@@ -71,12 +71,16 @@ impl Daemon {
             FuseSession::new(Path::new(&self.mountpoint), "testpassthrough", "", false).unwrap();
         se.mount().unwrap();
 
-        se.try_with_writer(|writer| {
+        // Ask the kernel to resend pending requests, if any. This is
+        // best-effort: FUSE_NOTIFY_RESEND was added in kernel 6.9 and older
+        // kernels reject it with EINVAL, which used to abort the daemon at
+        // startup. There is nothing to resend right after the connection is
+        // established, so a failure here is harmless.
+        let _ = se.try_with_writer(|writer| {
             self.server
                 .notify_resend(writer)
                 .map_err(PassthroughFsError::FuseError)
-        })
-        .map_err(|_| Error::from_raw_os_error(libc::EINVAL))?;
+        });
 
         for _ in 0..self.thread_cnt {
             let mut server = FuseServer {


### PR DESCRIPTION
FUSE_NOTIFY_RESEND was added in kernel 6.9; on older kernels the ioctl fails with EINVAL and the daemon aborts during mount. Right after the connection is established there is nothing to resend, so the failure is harmless — ignore it instead of exiting.

Reproduced on kernel 5.10.134: the daemon panicked at startup and the mountpoint was left behind.