### PR TITLE
transport/fusedev: add a FuseChannelExt trait for request reception

### DIFF
--- a/src/transport/fusedev/fuse_t_session.rs
+++ b/src/transport/fusedev/fuse_t_session.rs
@@ -29,6 +29,7 @@ use super::{
     Error::IoError, Error::SessionFailure, FuseBuf, FuseDevWriter, Reader, Result,
     FUSE_HEADER_SIZE, FUSE_KERN_BUF_PAGES,
 };
+use crate::transport::fusedev::FuseChannelExt;
 use crate::transport::pagesize;
 
 // These follows definition from libfuse.
@@ -354,6 +355,12 @@ impl FuseChannel {
         let reader = Reader::from_fuse_buffer(FuseBuf::new(&mut self.buf[..header_len])).unwrap();
         let writer = FuseDevWriter::new(fd, buf).unwrap();
         Ok(Some((reader, writer)))
+    }
+}
+
+impl FuseChannelExt for FuseChannel {
+    fn next_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
+        FuseChannel::get_request(self)
     }
 }
 

--- a/src/transport/fusedev/linux_session.rs
+++ b/src/transport/fusedev/linux_session.rs
@@ -16,7 +16,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::transport::fusedev::FuseSessionExt;
+use crate::transport::fusedev::{FuseChannelExt, FuseSessionExt};
 use mio::{Events, Poll, Token, Waker};
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
@@ -520,6 +520,18 @@ impl BlockingFuseChannel {
                 },
             }
         }
+    }
+}
+
+impl FuseChannelExt for FuseChannel {
+    fn next_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
+        FuseChannel::get_request(self)
+    }
+}
+
+impl FuseChannelExt for BlockingFuseChannel {
+    fn next_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
+        BlockingFuseChannel::get_request(self)
     }
 }
 

--- a/src/transport/fusedev/macos_session.rs
+++ b/src/transport/fusedev/macos_session.rs
@@ -35,7 +35,7 @@ use super::{
     Error::IoError, Error::SessionFailure, FuseBuf, FuseDevWriter, Reader, Result,
     FUSE_HEADER_SIZE, FUSE_KERN_BUF_PAGES,
 };
-use crate::transport::fusedev::FuseSessionExt;
+use crate::transport::fusedev::{FuseChannelExt, FuseSessionExt};
 use crate::transport::pagesize;
 
 const OSXFUSE_MOUNT_PROG: &str = "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse";
@@ -279,6 +279,12 @@ impl FuseChannel {
                 },
             }
         }
+    }
+}
+
+impl FuseChannelExt for FuseChannel {
+    fn next_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
+        FuseChannel::get_request(self)
     }
 }
 

--- a/src/transport/fusedev/mod.rs
+++ b/src/transport/fusedev/mod.rs
@@ -407,6 +407,35 @@ pub trait FuseSessionExt {
     }
 }
 
+/// Abstraction over the fusedev channels that receive requests from `/dev/fuse`.
+///
+/// Every fusedev channel exposes an inherent `get_request()` entry point: the
+/// epoll-based [`FuseChannel`] on Linux, the blocking-read [`FuseChannel`] on
+/// macOS and fuse-t, and Linux's `BlockingFuseChannel`. This trait names that
+/// shared operation `next_request()`, forwarding to each channel's inherent
+/// method, so a service loop can be written once, generic over the concrete
+/// channel type, instead of once per channel.
+///
+/// The trait method is deliberately named differently from the inherent
+/// `get_request()`: the distinct name keeps each forwarding call unambiguous
+/// and means that removing an inherent method surfaces as a compile error
+/// instead of silently turning the forward into infinite recursion.
+///
+/// This covers only the `/dev/fuse`-based channels: the virtiofs and
+/// FUSE-over-io_uring transports receive requests through different mechanisms
+/// and intentionally do not implement this trait.
+pub trait FuseChannelExt {
+    /// Get the next available FUSE request from the underlying fuse device.
+    ///
+    /// Returns:
+    /// - Ok(None): the channel should stop, either because the session was
+    ///   umounted/aborted or because a wakeup was delivered
+    /// - Ok(Some((reader, writer))): reader to receive the request and writer
+    ///   to send the reply
+    /// - Err(e): error message
+    fn next_request(&mut self) -> Result<Option<(Reader<'_>, FuseDevWriter<'_>)>>;
+}
+
 #[cfg(feature = "async-io")]
 mod async_io {
     use super::*;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -46,7 +46,9 @@ pub use self::fusedev::BlockingFuseChannel;
 #[cfg(all(target_os = "linux", feature = "fusedev", feature = "async-io"))]
 pub use self::fusedev::FuseDevTask;
 #[cfg(feature = "fusedev")]
-pub use self::fusedev::{FuseBuf, FuseChannel, FuseDevWriter, FuseSession, FuseSessionExt};
+pub use self::fusedev::{
+    FuseBuf, FuseChannel, FuseChannelExt, FuseDevWriter, FuseSession, FuseSessionExt,
+};
 #[cfg(all(target_os = "linux", feature = "fusedev-uring"))]
 pub use self::fusedev::{UringConfig, UringFuseServing, UringWriter};
 #[cfg(feature = "virtiofs")]

--- a/tests/passthrough/src/main.rs
+++ b/tests/passthrough/src/main.rs
@@ -1,4 +1,3 @@
-use fuse_backend_rs::transport::FuseSessionExt as _;
 use log::{error, info, warn, LevelFilter};
 use std::env;
 use std::fs;
@@ -11,9 +10,7 @@ use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
 
 use fuse_backend_rs::api::{server::Server, Vfs, VfsOptions};
 use fuse_backend_rs::passthrough::{Config, PassthroughFs};
-use fuse_backend_rs::transport::{
-    BlockingFuseChannel, FuseChannel, FuseDevWriter, FuseSession, Reader,
-};
+use fuse_backend_rs::transport::{FuseChannelExt, FuseSession, FuseSessionExt as _};
 
 use simple_logger::SimpleLogger;
 
@@ -118,42 +115,17 @@ impl Drop for Daemon {
     }
 }
 
-/// `FuseChannel` and `BlockingFuseChannel` receive requests identically; this
-/// trait abstracts the shared `get_request()` so the service loop below is
-/// written once instead of once per channel type.
-trait GetRequest {
-    fn get_request(
-        &mut self,
-    ) -> fuse_backend_rs::transport::Result<Option<(Reader<'_>, FuseDevWriter<'_>)>>;
-}
-
-impl GetRequest for FuseChannel {
-    fn get_request(
-        &mut self,
-    ) -> fuse_backend_rs::transport::Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
-        FuseChannel::get_request(self)
-    }
-}
-
-impl GetRequest for BlockingFuseChannel {
-    fn get_request(
-        &mut self,
-    ) -> fuse_backend_rs::transport::Result<Option<(Reader<'_>, FuseDevWriter<'_>)>> {
-        BlockingFuseChannel::get_request(self)
-    }
-}
-
 struct FuseServer<C> {
     server: Arc<Server<Arc<Vfs>>>,
     ch: C,
 }
 
-impl<C: GetRequest> FuseServer<C> {
+impl<C: FuseChannelExt> FuseServer<C> {
     fn svc_loop(&mut self) -> Result<()> {
         loop {
             if let Some((reader, writer)) = self
                 .ch
-                .get_request()
+                .next_request()
                 .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?
             {
                 if let Err(e) = self
@@ -181,7 +153,7 @@ impl<C: GetRequest> FuseServer<C> {
 /// Spawn one service thread that drives `ch` until the session is torn down.
 fn spawn_fuse_server<C>(server: Arc<Server<Arc<Vfs>>>, ch: C, blocking: bool)
 where
-    C: GetRequest + Send + 'static,
+    C: FuseChannelExt + Send + 'static,
 {
     let mut fuse_server = FuseServer { server, ch };
     thread::Builder::new()


### PR DESCRIPTION
All four fusedev channels -- the epoll-based FuseChannel and BlockingFuseChannel on Linux, and the blocking-read FuseChannel on macOS and fuse-t -- expose an identical inherent get_request() but had no common type to name it. A caller driving them generically had to define its own abstraction, as the passthrough daemon did with a private GetRequest trait.

Add a public FuseChannelExt trait alongside FuseSessionExt and implement it for all four channels. The trait method is named next_request(), not get_request(), on purpose: the distinct name keeps every forwarding call unambiguous and turns removal of an inherent method into a compile error instead of silent infinite recursion.

The inherent get_request() methods stay, so this is purely additive: concrete callers are unaffected and need no trait import, while generic code can be written once over `C: FuseChannelExt`. The virtiofs and io_uring transports receive requests differently and intentionally do not implement it.

Update the passthrough test daemon to use the library trait and drop its private GetRequest definition.