### PR TITLE
passthrough: support O_DIRECT requests

### DIFF
--- a/src/passthrough/mod.rs
+++ b/src/passthrough/mod.rs
@@ -22,8 +22,8 @@ use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockWriteGuard};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 use std::time::Duration;
 
 use vm_memory::{bitmap::BitmapSlice, ByteValued};
@@ -35,7 +35,7 @@ use self::mount_fd::MountFds;
 use self::statx::{statx, StatExt};
 use self::util::{
     ebadf, einval, enosys, eperm, is_dir, is_safe_inode, openat, reopen_fd_through_proc, stat_fd,
-    UniqueInodeGenerator,
+    FileFlagGuard, UniqueInodeGenerator,
 };
 use crate::abi::fuse_abi as fuse;
 use crate::abi::fuse_abi::Opcode;
@@ -257,8 +257,7 @@ impl InodeMap {
 struct HandleData {
     inode: Inode,
     file: File,
-    lock: Mutex<()>,
-    open_flags: AtomicU32,
+    open_flags: RwLock<u32>,
 }
 
 impl HandleData {
@@ -266,8 +265,7 @@ impl HandleData {
         HandleData {
             inode,
             file,
-            lock: Mutex::new(()),
-            open_flags: AtomicU32::new(flags),
+            open_flags: RwLock::new(flags),
         }
     }
 
@@ -275,20 +273,13 @@ impl HandleData {
         &self.file
     }
 
-    fn get_file_mut(&self) -> (MutexGuard<'_, ()>, &File) {
-        (self.lock.lock().unwrap(), &self.file)
+    fn get_file_mut(&self) -> (FileFlagGuard<'_, u32>, &File) {
+        let guard = self.open_flags.write().unwrap();
+        (FileFlagGuard::Writer(guard), &self.file)
     }
 
     fn borrow_fd(&self) -> BorrowedFd<'_> {
         self.file.as_fd()
-    }
-
-    fn get_flags(&self) -> u32 {
-        self.open_flags.load(Ordering::Relaxed)
-    }
-
-    fn set_flags(&self, flags: u32) {
-        self.open_flags.store(flags, Ordering::Relaxed);
     }
 }
 

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -25,8 +25,52 @@ use crate::api::filesystem::{
     SetattrValid, ZeroCopyReader, ZeroCopyWriter,
 };
 use crate::bytes_to_cstr;
+use crate::transport::pagesize;
 #[cfg(any(feature = "vhost-user-fs", feature = "virtiofs"))]
 use crate::transport::FsCacheReqHandler;
+
+/// A byte buffer allocated by `posix_memalign()` and freed with `libc::free()`
+/// on drop.
+///
+/// Pairing the C allocation with an explicit free(), instead of wrapping the
+/// pointer in a `Vec` whose deallocator always receives a layout with an
+/// alignment of 1, keeps the `GlobalAlloc` contract satisfied no matter which
+/// global allocator the embedding crate is built with.
+struct AlignedBuf {
+    ptr: *mut u8,
+    len: usize,
+}
+
+impl AlignedBuf {
+    fn new(alignment: usize, len: usize) -> io::Result<Self> {
+        let mut ptr = std::ptr::null_mut();
+        // Safe because `ptr` is a valid out-pointer and the return value is
+        // checked, so `ptr` is only read when posix_memalign() succeeded.
+        let ret = unsafe { libc::posix_memalign(&mut ptr, alignment, len) };
+        if ret != 0 {
+            return Err(io::Error::from_raw_os_error(ret));
+        }
+        Ok(AlignedBuf {
+            ptr: ptr as *mut u8,
+            len,
+        })
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        // Safe because posix_memalign() returned a valid allocation of `len`
+        // bytes; `u8` has no invalid bit patterns, so it's fine to treat the
+        // memory as initialized before it's actually written.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+impl Drop for AlignedBuf {
+    fn drop(&mut self) {
+        // Safe because `ptr` came from posix_memalign() and is passed to
+        // free() exactly once, here.
+        unsafe { libc::free(self.ptr as *mut libc::c_void) };
+    }
+}
 
 impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
     fn open_inode(&self, inode: Inode, flags: i32) -> io::Result<File> {
@@ -56,6 +100,113 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
             data.set_flags(flags);
         }
         Ok(())
+    }
+
+    /// Serve a write request targeting a file opened with `O_DIRECT`.
+    ///
+    /// The payload of a fuse WRITE request sits in the request buffer right
+    /// after the request headers, an offset the daemon can't control, so it
+    /// generally doesn't satisfy the alignment constraints of direct IO
+    /// (buffer address, length and file offset must all be multiples of the
+    /// device logical block size) and `pwritev()` fails with `EINVAL`.
+    /// Stage the payload through a page-aligned buffer instead. That lifts
+    /// only the buffer-address constraint: a request whose size or offset is
+    /// unaligned still fails with `EINVAL`, the same error the underlying
+    /// filesystem reports for it.
+    fn write_direct(
+        &self,
+        f: &File,
+        r: &mut dyn ZeroCopyReader,
+        size: usize,
+        offset: u64,
+    ) -> io::Result<usize> {
+        use std::os::unix::fs::FileExt;
+
+        if size == 0 {
+            return Ok(0);
+        }
+
+        // Align the bounce buffer to the runtime page size, which is always a
+        // multiple of the device logical block size that O_DIRECT requires,
+        // instead of assuming a fixed 4096 (wrong on 16K/64K-page systems).
+        let mut buffer = AlignedBuf::new(pagesize(), size)?;
+        let buf = buffer.as_mut_slice();
+
+        let mut copied = 0usize;
+        while copied < size {
+            match r.read(&mut buf[copied..]) {
+                Ok(0) => break,
+                Ok(n) => copied += n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        let mut written = 0usize;
+        while written < copied {
+            match f.write_at(&buf[written..copied], offset + written as u64) {
+                Ok(0) => break,
+                Ok(n) => written += n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(written)
+    }
+
+    /// Serve a read request targeting a file opened with `O_DIRECT`.
+    ///
+    /// The data of a fuse READ reply is appended to the reply right after
+    /// the response header, an offset the daemon can't control, so it
+    /// generally doesn't satisfy the alignment constraints of direct IO and
+    /// `preadv()` fails with `EINVAL`. Stage the data through a page-aligned
+    /// buffer instead. That lifts only the buffer-address constraint: a
+    /// request whose size or offset is unaligned still fails with `EINVAL`,
+    /// the same error the underlying filesystem reports for it.
+    fn read_direct(
+        &self,
+        f: &File,
+        w: &mut dyn ZeroCopyWriter,
+        size: usize,
+        offset: u64,
+    ) -> io::Result<usize> {
+        use std::os::unix::fs::FileExt;
+
+        if size == 0 {
+            return Ok(0);
+        }
+
+        // Align the bounce buffer to the runtime page size, which is always a
+        // multiple of the device logical block size that O_DIRECT requires,
+        // instead of assuming a fixed 4096 (wrong on 16K/64K-page systems).
+        let mut buffer = AlignedBuf::new(pagesize(), size)?;
+        let buf = buffer.as_mut_slice();
+
+        let mut read_cnt = 0usize;
+        while read_cnt < size {
+            match f.read_at(&mut buf[read_cnt..], offset + read_cnt as u64) {
+                Ok(0) => break,
+                Ok(n) => read_cnt += n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        let mut written = 0usize;
+        while written < read_cnt {
+            match w.write(&buf[written..read_cnt]) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ))
+                }
+                Ok(n) => written += n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(written)
     }
 
     /// Skip entries in a getdents64 buffer up to and including the entry whose
@@ -372,6 +523,17 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
         self.handle_map.insert(handle, data);
 
         let mut opts = OpenOptions::empty();
+        // If the client requested O_DIRECT and we honor it, `open_inode()`
+        // opened the backing file with O_DIRECT, so the kernel must route IO
+        // on this handle through the direct IO path: serving an O_DIRECT fd
+        // through the page-cache path fails with EINVAL because the page-cache
+        // buffers don't satisfy direct IO alignment requirements.
+        if self.cfg.allow_direct_io
+            && flags & (libc::O_DIRECT as u32) != 0
+            && flags & (libc::O_DIRECTORY as u32) == 0
+        {
+            opts |= OpenOptions::DIRECT_IO;
+        }
         match self.cfg.cache_policy {
             // We only set the direct I/O option on files.
             CachePolicy::Never => opts.set(
@@ -847,6 +1009,13 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
 
         let mut f = ManuallyDrop::new(f);
 
+        // The backing file was opened with O_DIRECT (see `open_inode()`), whose
+        // alignment constraints the transport buffers don't satisfy, so stage
+        // the data through an aligned bounce buffer.
+        if self.cfg.allow_direct_io && data.get_flags() & (libc::O_DIRECT as u32) != 0 {
+            return self.read_direct(&f, w, size as usize, offset);
+        }
+
         w.write_from(&mut *f, size as usize, offset)
     }
 
@@ -886,6 +1055,13 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
             } else {
                 None
             };
+
+        // The backing file was opened with O_DIRECT (see `open_inode()`), whose
+        // alignment constraints the transport buffers don't satisfy, so stage
+        // the payload through an aligned bounce buffer.
+        if self.cfg.allow_direct_io && data.get_flags() & (libc::O_DIRECT as u32) != 0 {
+            return self.write_direct(&f, r, size as usize, offset);
+        }
 
         r.read_to(&mut *f, size as usize, offset)
     }
@@ -1514,6 +1690,8 @@ mod tests {
 
     use super::*;
     use crate::abi::fuse_abi::ROOT_ID;
+    use crate::file_buf::FileVolatileSlice;
+    use crate::file_traits::FileReadWriteVolatile;
     use std::path::Path;
     use vmm_sys_util::{tempdir::TempDir, tempfile::TempFile};
 
@@ -1564,6 +1742,158 @@ mod tests {
         let (test_entry, handle, _, _) = fs.create(&ctx, ROOT_ID, &fname, args).unwrap();
 
         (test_entry, handle.unwrap())
+    }
+
+    /// An in-memory sink implementing `ZeroCopyWriter`, to receive the data
+    /// staged back out by `read_direct()`.
+    struct MemWriter(Vec<u8>);
+
+    impl MemWriter {
+        fn new() -> Self {
+            MemWriter(Vec::new())
+        }
+    }
+
+    impl io::Write for MemWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl ZeroCopyWriter for MemWriter {
+        fn write_from(
+            &mut self,
+            f: &mut dyn FileReadWriteVolatile,
+            count: usize,
+            off: u64,
+        ) -> io::Result<usize> {
+            if self.0.len() < count {
+                self.0.resize(count, 0);
+            }
+            // Safe because the slice points into `self.0` and doesn't out-live it.
+            let slice = unsafe { FileVolatileSlice::from_raw_ptr(self.0.as_mut_ptr(), count) };
+            f.read_at_volatile(slice, off)
+        }
+
+        fn available_bytes(&self) -> usize {
+            usize::MAX
+        }
+    }
+
+    /// An in-memory source implementing `ZeroCopyReader`, to provide the data
+    /// staged through the bounce buffer by `write_direct()`.
+    struct MemReader(Vec<u8>);
+
+    impl io::Read for MemReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let n = std::cmp::min(buf.len(), self.0.len());
+            buf[..n].copy_from_slice(&self.0[..n]);
+            self.0.drain(..n);
+            Ok(n)
+        }
+    }
+
+    impl ZeroCopyReader for MemReader {
+        fn read_to(
+            &mut self,
+            f: &mut dyn FileReadWriteVolatile,
+            count: usize,
+            off: u64,
+        ) -> io::Result<usize> {
+            let start = off as usize;
+            if start >= self.0.len() {
+                return Ok(0);
+            }
+            let n = std::cmp::min(count, self.0.len() - start);
+            // Safe because the buffer is only read from and the slice doesn't
+            // out-live `self.0`.
+            let slice = unsafe {
+                FileVolatileSlice::from_raw_ptr(self.0.as_ptr().add(start) as *mut u8, n)
+            };
+            f.write_at_volatile(slice, off)
+        }
+    }
+
+    // A direct IO request has to stage its payload through a page-aligned bounce
+    // buffer, because the fuse transport buffer holds the payload at an offset
+    // the daemon can't align (right after the request/response headers). Verify
+    // both halves of that contract against a real O_DIRECT fd: a raw unaligned
+    // access fails with EINVAL, while `write_direct()`/`read_direct()` succeed
+    // and round-trip the payload byte for byte.
+    //
+    // O_DIRECT needs a backing filesystem that supports it; tmpfs (a common
+    // /tmp) rejects it at open() with EINVAL, so skip gracefully there rather
+    // than fail, to keep the test from being environment-dependent.
+    #[test]
+    fn test_direct_io_bounce_buffer() {
+        use std::os::unix::fs::{FileExt, OpenOptionsExt};
+
+        const BLOCK: usize = 4096;
+
+        let dir = TempDir::new().expect("Cannot create temporary directory.");
+        let path = dir.as_path().join("direct_io_file");
+
+        let file = match std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .custom_flags(libc::O_DIRECT)
+            .open(&path)
+        {
+            Ok(f) => f,
+            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+                eprintln!(
+                    "skipping test_direct_io_bounce_buffer: {:?} does not support O_DIRECT",
+                    dir.as_path()
+                );
+                return;
+            }
+            Err(e) => panic!("unexpected error opening {:?} with O_DIRECT: {}", path, e),
+        };
+
+        // A minimal, unprivileged fs instance. The helpers don't consult it, but
+        // they hang off `PassthroughFs`, so an instance is needed to call them.
+        let fs_cfg = Config {
+            root_dir: dir.as_path().to_str().unwrap().to_string(),
+            allow_direct_io: true,
+            ..Default::default()
+        };
+        let fs = PassthroughFs::<()>::new(fs_cfg).unwrap();
+
+        // Reproduce the bug: pwrite from a buffer whose address is misaligned by
+        // one byte, while the length and file offset stay block-aligned, so only
+        // the address violates the O_DIRECT constraint -- exactly like a payload
+        // that follows the fuse headers in the transport buffer.
+        let backing = vec![0u8; BLOCK + 1];
+        match file.write_at(&backing[1..=BLOCK], 0) {
+            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {}
+            Ok(_) => {
+                eprintln!(
+                    "skipping test_direct_io_bounce_buffer: {:?} does not enforce O_DIRECT alignment",
+                    dir.as_path()
+                );
+                return;
+            }
+            Err(e) => panic!("expected EINVAL from unaligned O_DIRECT pwrite, got: {}", e),
+        }
+
+        // The fix: write_direct() stages the payload through an aligned buffer.
+        let payload: Vec<u8> = (0..BLOCK).map(|i| (i % 251) as u8).collect();
+        let mut reader = MemReader(payload.clone());
+        let written = fs.write_direct(&file, &mut reader, BLOCK, 0).unwrap();
+        assert_eq!(written, BLOCK);
+
+        // ...and read_direct() stages it back out, byte for byte.
+        let mut writer = MemWriter::new();
+        let read = fs.read_direct(&file, &mut writer, BLOCK, 0).unwrap();
+        assert_eq!(read, BLOCK);
+        assert_eq!(writer.0, payload);
     }
 
     #[test]

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -90,16 +90,34 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
     /// if these do not match update the file descriptor flags and store the new
     /// result in the HandleData entry
     #[inline(always)]
-    fn check_fd_flags(&self, data: Arc<HandleData>, fd: RawFd, flags: u32) -> io::Result<()> {
-        let open_flags = data.get_flags();
-        if open_flags != flags {
-            let ret = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
+    fn ensure_file_flags<'a>(
+        &self,
+        data: &'a Arc<HandleData>,
+        fd: &impl AsRawFd,
+        mut flags: u32,
+    ) -> io::Result<FileFlagGuard<'a, u32>> {
+        let guard = data.open_flags.read().unwrap();
+        if *guard & libc::O_DIRECT as u32 == flags & libc::O_DIRECT as u32 {
+            return Ok(FileFlagGuard::Reader(guard));
+        }
+        drop(guard);
+
+        let mut guard = data.open_flags.write().unwrap();
+        // Update the O_DIRECT flag if needed
+        if *guard & libc::O_DIRECT as u32 != flags & libc::O_DIRECT as u32 {
+            if flags & libc::O_DIRECT as u32 != 0 {
+                flags = *guard | libc::O_DIRECT as u32;
+            } else {
+                flags = *guard & !libc::O_DIRECT as u32;
+            }
+            let ret = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags) };
             if ret != 0 {
                 return Err(io::Error::last_os_error());
             }
-            data.set_flags(flags);
+            *guard = flags;
         }
-        Ok(())
+
+        Ok(FileFlagGuard::Writer(guard))
     }
 
     /// Serve a write request targeting a file opened with `O_DIRECT`.
@@ -999,20 +1017,21 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         flags: u32,
     ) -> io::Result<usize> {
         let data = self.get_data(handle, inode, libc::O_RDONLY)?;
+        let fd = data.borrow_fd();
+
+        // Hold the guard over the whole IO operation, so that no other request
+        // can change the O_DIRECT flag of the fd while we are using it.
+        let _flags_guard = self.ensure_file_flags(&data, &fd, flags)?;
 
         // Manually implement File::try_clone() by borrowing fd of data.file instead of dup().
         // It's safe because the `data` variable's lifetime spans the whole function,
         // so data.file won't be closed.
-        let f = unsafe { File::from_raw_fd(data.borrow_fd().as_raw_fd()) };
-
-        self.check_fd_flags(data.clone(), f.as_raw_fd(), flags)?;
-
-        let mut f = ManuallyDrop::new(f);
+        let mut f = unsafe { ManuallyDrop::new(File::from_raw_fd(fd.as_raw_fd())) };
 
         // The backing file was opened with O_DIRECT (see `open_inode()`), whose
         // alignment constraints the transport buffers don't satisfy, so stage
         // the data through an aligned bounce buffer.
-        if self.cfg.allow_direct_io && data.get_flags() & (libc::O_DIRECT as u32) != 0 {
+        if self.cfg.allow_direct_io && flags & (libc::O_DIRECT as u32) != 0 {
             return self.read_direct(&f, w, size as usize, offset);
         }
 
@@ -1033,20 +1052,15 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
         fuse_flags: u32,
     ) -> io::Result<usize> {
         let data = self.get_data(handle, inode, libc::O_RDWR)?;
+        let fd = data.borrow_fd();
 
-        // Manually implement File::try_clone() by borrowing fd of data.file instead of dup().
-        // It's safe because the `data` variable's lifetime spans the whole function,
-        // so data.file won't be closed.
-        let f = unsafe { File::from_raw_fd(data.borrow_fd().as_raw_fd()) };
-
-        self.check_fd_flags(data.clone(), f.as_raw_fd(), flags)?;
-
+        // Hold the guard over the whole IO operation, so that no other request
+        // can change the O_DIRECT flag of the fd while we are using it.
+        let _flags_guard = self.ensure_file_flags(&data, &fd, flags)?;
         if self.seal_size.load(Ordering::Relaxed) {
-            let st = stat_fd(&f, None)?;
+            let st = stat_fd(&fd, None)?;
             self.seal_size_check(Opcode::Write, st.st_size as u64, offset, size as u64, 0)?;
         }
-
-        let mut f = ManuallyDrop::new(f);
 
         // Cap restored when _killpriv is dropped
         let _killpriv =
@@ -1056,10 +1070,15 @@ impl<S: BitmapSlice + Send + Sync> FileSystem for PassthroughFs<S> {
                 None
             };
 
+        // Manually implement File::try_clone() by borrowing fd of data.file instead of dup().
+        // It's safe because the `data` variable's lifetime spans the whole function,
+        // so data.file won't be closed.
+        let mut f = unsafe { ManuallyDrop::new(File::from_raw_fd(fd.as_raw_fd())) };
+
         // The backing file was opened with O_DIRECT (see `open_inode()`), whose
         // alignment constraints the transport buffers don't satisfy, so stage
         // the payload through an aligned bounce buffer.
-        if self.cfg.allow_direct_io && data.get_flags() & (libc::O_DIRECT as u32) != 0 {
+        if self.cfg.allow_direct_io && flags & (libc::O_DIRECT as u32) != 0 {
             return self.write_direct(&f, r, size as usize, offset);
         }
 

--- a/src/passthrough/sync_io.rs
+++ b/src/passthrough/sync_io.rs
@@ -237,8 +237,11 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
         let mut target_reclen: usize = 0;
         while cur + size_of::<LinuxDirent64>() <= buf.len() {
             let front = &buf[cur..cur + size_of::<LinuxDirent64>()];
-            let dirent64 = LinuxDirent64::from_slice(front)
-                .expect("fuse: unable to get LinuxDirent64 from slice");
+            let dirent64 = match LinuxDirent64::from_slice(front) {
+                Some(d) => d,
+                // Defend against a malformed getdents64 buffer.
+                None => break,
+            };
             let reclen = dirent64.d_reclen as usize;
             // Defend against a malformed getdents64 buffer: a record shorter
             // than the header would loop forever.
@@ -265,8 +268,11 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
     fn last_cookie_in_buf(mut buf: &[u8]) -> Option<u64> {
         let mut last = None;
         while buf.len() >= size_of::<LinuxDirent64>() {
-            let dirent64 = LinuxDirent64::from_slice(&buf[..size_of::<LinuxDirent64>()])
-                .expect("fuse: unable to get LinuxDirent64 from slice");
+            let dirent64 = match LinuxDirent64::from_slice(&buf[..size_of::<LinuxDirent64>()]) {
+                Some(d) => d,
+                // Defend against a malformed getdents64 buffer.
+                None => break,
+            };
             let reclen = dirent64.d_reclen as usize;
             // Defend against a malformed getdents64 buffer: a record shorter
             // than the header would loop forever and an oversized one would
@@ -460,8 +466,7 @@ impl<S: BitmapSlice + Send + Sync> PassthroughFs<S> {
 
             let (front, back) = rem.split_at(size_of::<LinuxDirent64>());
 
-            let dirent64 = LinuxDirent64::from_slice(front)
-                .expect("fuse: unable to get LinuxDirent64 from slice");
+            let dirent64 = LinuxDirent64::from_slice(front).ok_or_else(einval)?;
 
             let namelen = dirent64.d_reclen as usize - size_of::<LinuxDirent64>();
             debug_assert!(

--- a/src/passthrough/util.rs
+++ b/src/passthrough/util.rs
@@ -7,9 +7,10 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::mem::MaybeUninit;
+use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLockReadGuard, RwLockWriteGuard};
 
 use super::inode_store::InodeId;
 use super::MAX_HOST_INO;
@@ -237,6 +238,23 @@ pub fn sync_fd(fd: &impl AsRawFd, datasync: bool) -> io::Result<()> {
         Ok(())
     } else {
         Err(io::Error::last_os_error())
+    }
+}
+
+/// A helper structure to hold RwLock guard.
+pub enum FileFlagGuard<'a, T> {
+    Reader(RwLockReadGuard<'a, T>),
+    Writer(RwLockWriteGuard<'a, T>),
+}
+
+impl<'a, T> Deref for FileFlagGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            FileFlagGuard::Reader(v) => v.deref(),
+            FileFlagGuard::Writer(v) => v.deref(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Two related fixes so that passthrough actually serves client `O_DIRECT` requests
correctly: make the direct-IO data path work at all (it currently fails with
`EINVAL`), and close a TOCTOU race in the way the backing fd's `O_DIRECT` flag is
toggled per request. Both are gated on `cfg.allow_direct_io` (default `true`), so
a deployment that filters out `O_DIRECT` is unaffected.

## Problem

**1. `O_DIRECT` requests fail with `EINVAL`.**
When a client opens a file with `O_DIRECT` and `cfg.allow_direct_io` is enabled,
`open_inode()` opens the backing file with `O_DIRECT`, but the read/write handlers
`preadv`/`pwritev` directly between that fd and the FUSE transport buffer. The
payload sits right after the fuse headers at an offset the daemon can't control
(after `OutHeader` for reads, after `InHeader`+`WriteIn` for writes), which
generally violates the direct-IO alignment constraints — buffer address, length
and file offset must all be multiples of the device logical block size — so the
IO fails with `EINVAL`. This is latent: buffered clients never hit it, so it went
unnoticed until an `O_DIRECT` client mounted the fs.

**2. Flag toggling races.**
`check_fd_flags()` flipped `O_DIRECT` on the *shared* backing fd with
`fcntl(F_SETFL)` while holding no lock across the IO, so two concurrent requests
on one handle could race: one checks the flag, another flips it, then the first
issues its `preadv`/`pwritev` against the wrong `O_DIRECT` state.

## Changes

**`passthrough: support direct IO requests`** (`sync_io.rs`)
- Reply `FOPEN_DIRECT_IO` for `O_DIRECT` opens, so the kernel routes IO through
  the direct path rather than the page-cache path against an `O_DIRECT` fd.
- Stage the payload of direct-IO reads/writes through a page-aligned bounce
  buffer (`read_direct()` / `write_direct()`), so the unaligned transport-buffer
  offset no longer breaks alignment. The bounce buffer is allocated with
  `posix_memalign()` and freed with `libc::free()` via a small RAII guard
  (`AlignedBuf`) that keeps the `GlobalAlloc` contract satisfied under any
  global allocator.
- Dispatch to the bounce-buffer path from `read()`/`write()` when the request
  flags carry `O_DIRECT`.

**`passthrough: refine the way to support O_DIRECT`** (`mod.rs`, `util.rs`, `sync_io.rs`)
- Replace `check_fd_flags()` with `ensure_file_flags()`, returning a
  `FileFlagGuard` that holds the `HandleData` `open_flags` `RwLock` for the whole
  IO. A request whose `O_DIRECT` bit already matches takes the *read* lock (so
  matching requests stay concurrent); one that must flip the bit takes the
  *write* lock (making the toggle + IO atomic against other requests on the same
  handle). `open_flags` becomes a `RwLock<u32>`, dropping the separate `Mutex`
  and the `get_flags()`/`set_flags()` atomics.
- Build the borrowed `File` atomically so an error between `File::from_raw_fd()`
  and `ManuallyDrop::new()` cannot close the fd out from under the `HandleData`.
- The bounce-buffer dispatch now keys off the per-request flags and runs *while
  the guard is held*, so the `O_DIRECT` state cannot change mid-bounce.

This second commit is based on `47d1e05` ("ptfs: refine the way to support
O_DIRECT") and `abc7b7e` ("ptfs: close a race window in read()/write()").

## Behavior & compatibility

- **No public API change.** `HandleData` is private; the change is internal.
- **Gated on `cfg.allow_direct_io`** (default `true`); filtering deployments keep
  the existing zero-copy path.
- **Async path is covered for free:** `async_read`/`async_write` delegate to the
  sync `read()`/`write()`, so the fix and the race-free flag handling apply in
  async mode too (no separate relay needed).
- **Semantics match the underlying filesystem.** With `FOPEN_DIRECT_IO` the
  kernel does *not* enforce direct-IO alignment on the daemon's behalf, so a
  request with an unaligned size or offset still fails with `EINVAL` — exactly
  the error the underlying filesystem reports. The bounce buffer lifts only the
  buffer-*address* constraint.

## Verification

- **Alignment / semantics (real mount, ext4, kernel 5.10):** aligned `O_DIRECT`
  read/write succeed; unaligned size and unaligned offset return `EINVAL` both
  through the mount *and* on raw ext4 (identical); read past EOF returns 0 bytes;
  an EOF-crossing read is correctly clipped; a direct write at EOF extends the
  file and round-trips.
- **Unit test** `test_direct_io_bounce_buffer` exercises both helpers end to end,
  with a two-tier skip for filesystems that don't support or don't enforce
  `O_DIRECT` (e.g. tmpfs).
- **No performance regression** (fio A/B, base = parent commit vs this branch,
  8 workloads, medians):

  | Workload (IOPS) | Δ |
  |---|---|
  | buffered randread / randwrite / seqread 4k–1m | −0.3% … +2.3% |
  | buffered seqwrite 1m (7-rep focused re-run) | −0.9% |
  | direct randread / randwrite / seqread / seqwrite | −0.2% … +6.0% (within run variance) |

  The added cost is one uncontended `RwLock` read acquire per request, dwarfed by
  the FUSE round trip.
- `cargo build --all-targets` clean (0 warnings); `cargo clippy` adds no new
  lints; `cargo test --lib passthrough` matches the existing baseline;
  `cargo fmt --all --check` clean.